### PR TITLE
feat(docs): publish javadocs to GitHub Pages

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -62,3 +62,37 @@ jobs:
         run: |
           npm i -g semantic-release @semantic-release/changelog @semantic-release/git
           semantic-release
+
+  pages:
+    runs-on: ubuntu-latest
+    needs: [release]
+    if: github.ref == 'refs/heads/master'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    name: Deploy Docs
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Generate Javadoc
+        run: |
+          ./gradlew tests:copyAssets
+          ./gradlew aggregateJavadocs
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/docs/javadoc
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Colony is a small simulation/strategy prototype built with LibGDX and the Artemi
 - [Development Guidelines](#development-guidelines)
   - [Code Style](#code-style)
   - [Contributing](#contributing)
+  - [Documentation](#documentation)
 
 ## Quick Start
 ### Building and Testing
@@ -75,6 +76,9 @@ New classes should be placed under the `net.lapidist.colony` package in the appr
 
 
 For more details see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Documentation
+The latest Java API reference is published to [GitHub Pages](https://bylapidist.github.io/colony/) on every release.
 
 ## License
 This project is licensed under the [MIT License](LICENSE).

--- a/build.gradle
+++ b/build.gradle
@@ -163,3 +163,12 @@ tasks.register('codeCoverageReport', JacocoReport) {
         html.required.set(true)
     }
 }
+
+tasks.register('aggregateJavadocs', Javadoc) {
+    dependsOn subprojects.collect { it.tasks.javadoc }
+    destinationDir = file("${buildDir}/docs/javadoc")
+    source subprojects.collect { it.sourceSets.main.allJava }
+    classpath = files(subprojects.collect { it.sourceSets.main.compileClasspath })
+    options.encoding = 'UTF-8'
+    options.addBooleanOption('Xdoclint:none', true)
+}


### PR DESCRIPTION
## Summary
- aggregate javadocs across modules
- link to generated documentation
- deploy documentation to GitHub Pages on release

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew aggregateJavadocs`


------
https://chatgpt.com/codex/tasks/task_e_6845dbaa1f848328b3203eb2e83ead53