### PR TITLE
chore(ci): stop pushing release commit

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -13,10 +13,6 @@
     ["@semantic-release/changelog", {
       "changelogFile": "CHANGELOG.md"
     }],
-    "@semantic-release/github",
-    ["@semantic-release/git", {
-      "assets": ["CHANGELOG.md"],
-      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-    }]
+    "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Summary
- prevent semantic release from pushing to the protected `master` branch

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_6845dfc5803c8328842eb24b80ff151b