### PR TITLE
feat: add asynchronous client handshake

### DIFF
--- a/client/src/net/lapidist/colony/client/Colony.java
+++ b/client/src/net/lapidist/colony/client/Colony.java
@@ -10,7 +10,6 @@ import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.server.GameServerConfig;
 import net.lapidist.colony.config.ColonyConfig;
-import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.core.events.Events;
 import net.lapidist.colony.client.events.GameInitEvent;
 
@@ -35,7 +34,6 @@ public final class Colony extends Game {
     }
 
     public void startGame(final String saveName) {
-        MapState state;
         try {
             if (server != null) {
                 server.stop();
@@ -45,12 +43,10 @@ public final class Colony extends Game {
             );
             server.start();
             client = new GameClient();
-            client.start();
-            state = client.getMapState();
+            client.start(state -> setScreen(new MapScreen(this, state, client)));
         } catch (IOException | InterruptedException e) {
             throw new RuntimeException(e);
         }
-        setScreen(new MapScreen(this, state, client));
     }
 
     public void startGame() {

--- a/client/src/net/lapidist/colony/client/network/GameClient.java
+++ b/client/src/net/lapidist/colony/client/network/GameClient.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Consumer;
 
 
 public final class GameClient extends AbstractMessageEndpoint {
@@ -28,13 +29,16 @@ public final class GameClient extends AbstractMessageEndpoint {
     private final Queue<TileSelectionData> tileUpdates = new ConcurrentLinkedQueue<>();
     private Iterable<MessageHandler<?>> handlers;
     private static final int CONNECT_TIMEOUT = 5000;
-    private static final int WAIT_TIME_MS = 10;
+    private Consumer<MapState> readyCallback;
 
     public GameClient() {
         this.handlers = java.util.List.of(
                 new MapStateMessageHandler(state -> {
                     mapState = state;
                     LOGGER.info("Received map state from server");
+                    if (readyCallback != null) {
+                        readyCallback.accept(state);
+                    }
                 }),
                 new TileSelectionUpdateHandler(tileUpdates)
         );
@@ -44,8 +48,7 @@ public final class GameClient extends AbstractMessageEndpoint {
         this.handlers = handlersToUse;
     }
 
-    @Override
-    public void start() throws IOException, InterruptedException {
+    private void connect() throws IOException {
         KryoRegistry.register(client.getKryo());
         client.start();
         LOGGER.info("Connecting to server...");
@@ -59,10 +62,17 @@ public final class GameClient extends AbstractMessageEndpoint {
             }
         });
         client.connect(CONNECT_TIMEOUT, "localhost", GameServer.TCP_PORT, GameServer.UDP_PORT);
-        while (mapState == null) {
-            Thread.sleep(WAIT_TIME_MS);
-        }
-        LOGGER.info("Map state received, client ready");
+    }
+
+    @Override
+    public void start() throws IOException, InterruptedException {
+        start(ms -> {
+        });
+    }
+
+    public void start(final Consumer<MapState> callback) throws IOException, InterruptedException {
+        this.readyCallback = callback;
+        connect();
     }
 
     public MapState getMapState() {

--- a/tests/src/net/lapidist/colony/tests/network/GameClientServerTest.java
+++ b/tests/src/net/lapidist/colony/tests/network/GameClientServerTest.java
@@ -4,6 +4,8 @@ import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.server.GameServerConfig;
 import org.junit.Test;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -15,7 +17,9 @@ public class GameClientServerTest {
         server.start();
 
         GameClient client = new GameClient();
-        client.start();
+        CountDownLatch latch = new CountDownLatch(1);
+        client.start(state -> latch.countDown());
+        latch.await(1, TimeUnit.SECONDS);
 
         assertNotNull(client.getMapState());
         assertNotNull(server.getMapState());

--- a/tests/src/net/lapidist/colony/tests/network/GameClientServerTest.java
+++ b/tests/src/net/lapidist/colony/tests/network/GameClientServerTest.java
@@ -27,4 +27,26 @@ public class GameClientServerTest {
         client.stop();
         server.stop();
     }
+
+    @Test
+    public void clientReceivesMapUsingDefaultStart() throws Exception {
+        GameServer server = new GameServer(GameServerConfig.builder().build());
+        server.start();
+
+        GameClient client = new GameClient();
+        client.start();
+
+        final int maxAttempts = 20;
+        final int delayMs = 50;
+        int attempts = 0;
+        while (client.getMapState() == null && attempts < maxAttempts) {
+            Thread.sleep(delayMs);
+            attempts++;
+        }
+
+        assertNotNull(client.getMapState());
+
+        client.stop();
+        server.stop();
+    }
 }

--- a/tests/src/net/lapidist/colony/tests/network/GameServerBroadcastTest.java
+++ b/tests/src/net/lapidist/colony/tests/network/GameServerBroadcastTest.java
@@ -5,6 +5,8 @@ import net.lapidist.colony.components.state.TileSelectionData;
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.server.GameServerConfig;
 import org.junit.Test;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -19,9 +21,13 @@ public class GameServerBroadcastTest {
         server.start();
 
         GameClient clientA = new GameClient();
-        clientA.start();
+        CountDownLatch latchA = new CountDownLatch(1);
+        clientA.start(state -> latchA.countDown());
         GameClient clientB = new GameClient();
-        clientB.start();
+        CountDownLatch latchB = new CountDownLatch(1);
+        clientB.start(state -> latchB.countDown());
+        latchA.await(1, TimeUnit.SECONDS);
+        latchB.await(1, TimeUnit.SECONDS);
 
         TileSelectionData data = new TileSelectionData(0, 0, true);
         clientA.sendTileSelectionRequest(data);

--- a/tests/src/net/lapidist/colony/tests/scenario/GameSimulationDelayedTileUpdateTest.java
+++ b/tests/src/net/lapidist/colony/tests/scenario/GameSimulationDelayedTileUpdateTest.java
@@ -15,6 +15,8 @@ import net.lapidist.colony.io.Paths;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -37,7 +39,9 @@ public class GameSimulationDelayedTileUpdateTest {
         server.start();
 
         GameClient client = new GameClient();
-        client.start();
+        CountDownLatch latch = new CountDownLatch(1);
+        client.start(state -> latch.countDown());
+        latch.await(1, TimeUnit.SECONDS);
 
         try {
             MapState state = client.getMapState();

--- a/tests/src/net/lapidist/colony/tests/scenario/GameSimulationInputSelectionTest.java
+++ b/tests/src/net/lapidist/colony/tests/scenario/GameSimulationInputSelectionTest.java
@@ -15,6 +15,8 @@ import net.lapidist.colony.io.Paths;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertTrue;
 
@@ -37,7 +39,9 @@ public class GameSimulationInputSelectionTest {
         server.start();
 
         GameClient client = new GameClient();
-        client.start();
+        CountDownLatch latch = new CountDownLatch(1);
+        client.start(state -> latch.countDown());
+        latch.await(1, TimeUnit.SECONDS);
 
         try {
             MapState state = client.getMapState();

--- a/tests/src/net/lapidist/colony/tests/scenario/GameSimulationTileUpdateTest.java
+++ b/tests/src/net/lapidist/colony/tests/scenario/GameSimulationTileUpdateTest.java
@@ -8,6 +8,8 @@ import net.lapidist.colony.server.GameServerConfig;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertTrue;
 
@@ -22,9 +24,13 @@ public class GameSimulationTileUpdateTest {
         server.start();
 
         GameClient sender = new GameClient();
-        sender.start();
+        CountDownLatch latchSender = new CountDownLatch(1);
+        sender.start(state -> latchSender.countDown());
         GameClient receiver = new GameClient();
-        receiver.start();
+        CountDownLatch latchReceiver = new CountDownLatch(1);
+        receiver.start(state -> latchReceiver.countDown());
+        latchSender.await(1, TimeUnit.SECONDS);
+        latchReceiver.await(1, TimeUnit.SECONDS);
 
         MapState state = receiver.getMapState();
         GameSimulation sim = new GameSimulation(state, receiver);

--- a/tests/src/net/lapidist/colony/tests/server/GameServerSelectionTest.java
+++ b/tests/src/net/lapidist/colony/tests/server/GameServerSelectionTest.java
@@ -9,6 +9,8 @@ import net.lapidist.colony.core.events.Events;
 import net.lapidist.colony.server.events.TileSelectionEvent;
 import net.mostlyoriginal.api.event.common.Subscribe;
 import org.junit.Test;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertTrue;
 
@@ -29,7 +31,9 @@ public class GameServerSelectionTest {
         Events.getInstance().registerEvents(this);
 
         GameClient client = new GameClient();
-        client.start();
+        CountDownLatch latch = new CountDownLatch(1);
+        client.start(state -> latch.countDown());
+        latch.await(1, TimeUnit.SECONDS);
 
         TileSelectionData data = new TileSelectionData(0, 0, true);
 


### PR DESCRIPTION
## Summary
- handle map state reception with a callback in `GameClient`
- update `Colony` to set the map screen after the handshake
- adjust networking tests for the asynchronous behaviour

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_68460eae1f9c83289e74f0e0365acef9