### PR TITLE
feat: add in-game chat system

### DIFF
--- a/client/src/net/lapidist/colony/client/network/handlers/ChatMessageHandler.java
+++ b/client/src/net/lapidist/colony/client/network/handlers/ChatMessageHandler.java
@@ -1,0 +1,23 @@
+package net.lapidist.colony.client.network.handlers;
+
+import net.lapidist.colony.chat.ChatMessage;
+import net.lapidist.colony.network.AbstractMessageHandler;
+
+import java.util.Queue;
+
+/**
+ * Queues chat messages received from the server.
+ */
+public final class ChatMessageHandler extends AbstractMessageHandler<ChatMessage> {
+    private final Queue<ChatMessage> queue;
+
+    public ChatMessageHandler(final Queue<ChatMessage> queueToUse) {
+        super(ChatMessage.class);
+        this.queue = queueToUse;
+    }
+
+    @Override
+    public void handle(final ChatMessage message) {
+        queue.add(message);
+    }
+}

--- a/client/src/net/lapidist/colony/client/screens/MapScreen.java
+++ b/client/src/net/lapidist/colony/client/screens/MapScreen.java
@@ -25,7 +25,7 @@ public final class MapScreen implements Screen {
         this.colony = colonyToSet;
         stage = new Stage(new ScreenViewport());
         world = MapWorldBuilder.build(MapWorldBuilder.builder(state, client, stage));
-        MapUi ui = MapUiBuilder.build(stage, world, colony);
+        MapUi ui = MapUiBuilder.build(stage, world, client, colony);
         minimapActor = ui.getMinimapActor();
         events = new MapScreenEventHandler();
     }

--- a/client/src/net/lapidist/colony/client/screens/MapUi.java
+++ b/client/src/net/lapidist/colony/client/screens/MapUi.java
@@ -2,6 +2,7 @@ package net.lapidist.colony.client.screens;
 
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import net.lapidist.colony.client.ui.MinimapActor;
+import net.lapidist.colony.client.ui.ChatBox;
 
 /**
  * Container for UI elements of the map screen.
@@ -10,10 +11,12 @@ public final class MapUi {
 
     private final Stage stage;
     private final MinimapActor minimapActor;
+    private final ChatBox chatBox;
 
-    public MapUi(final Stage uiStage, final MinimapActor minimap) {
+    public MapUi(final Stage uiStage, final MinimapActor minimap, final ChatBox chat) {
         this.stage = uiStage;
         this.minimapActor = minimap;
+        this.chatBox = chat;
     }
 
     public Stage getStage() {
@@ -22,5 +25,9 @@ public final class MapUi {
 
     public MinimapActor getMinimapActor() {
         return minimapActor;
+    }
+
+    public ChatBox getChatBox() {
+        return chatBox;
     }
 }

--- a/client/src/net/lapidist/colony/client/screens/MapUiBuilder.java
+++ b/client/src/net/lapidist/colony/client/screens/MapUiBuilder.java
@@ -11,6 +11,8 @@ import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener.ChangeEvent;
 import com.artemis.World;
 import net.lapidist.colony.client.Colony;
 import net.lapidist.colony.client.ui.MinimapActor;
+import net.lapidist.colony.client.ui.ChatBox;
+import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.i18n.I18n;
 
 /**
@@ -34,6 +36,7 @@ public final class MapUiBuilder {
     public static MapUi build(
             final Stage stage,
             final World world,
+            final GameClient client,
             final Colony colony
     ) {
         Skin skin = new Skin(Gdx.files.internal("skin/default.json"));
@@ -45,6 +48,7 @@ public final class MapUiBuilder {
 
         TextButton menuButton = new TextButton(I18n.get("map.menu"), skin);
         MinimapActor minimapActor = new MinimapActor(world);
+        ChatBox chatBox = new ChatBox(skin, client);
 
         menuButton.addListener(new ChangeListener() {
             @Override
@@ -55,7 +59,9 @@ public final class MapUiBuilder {
 
         table.add(menuButton).pad(PADDING).left().top();
         table.add(minimapActor).pad(PADDING).expandX().right().top();
+        table.row();
+        table.add(chatBox).pad(PADDING).colspan(2).left().bottom().expandX();
 
-        return new MapUi(stage, minimapActor);
+        return new MapUi(stage, minimapActor, chatBox);
     }
 }

--- a/client/src/net/lapidist/colony/client/ui/ChatBox.java
+++ b/client/src/net/lapidist/colony/client/ui/ChatBox.java
@@ -1,0 +1,64 @@
+package net.lapidist.colony.client.ui;
+
+import com.badlogic.gdx.scenes.scene2d.InputEvent;
+import com.badlogic.gdx.scenes.scene2d.InputListener;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.ui.TextArea;
+import com.badlogic.gdx.scenes.scene2d.ui.TextField;
+import net.lapidist.colony.chat.ChatMessage;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.i18n.I18n;
+
+/**
+ * Simple chat UI widget containing a log and input field.
+ */
+public final class ChatBox extends Table {
+    private static final int PREF_ROWS = 6;
+    private static final float LOG_HEIGHT = 100f;
+    private final TextArea log;
+    private final TextField input;
+    private final GameClient client;
+
+    public ChatBox(final Skin skin, final GameClient clientToUse) {
+        this.client = clientToUse;
+        log = new TextArea("", skin);
+        log.setDisabled(true);
+        log.setPrefRows(PREF_ROWS);
+        input = new TextField("", skin);
+        input.setMessageText(I18n.get("chat.placeholder"));
+        input.addListener(new InputListener() {
+            @Override
+            public boolean keyTyped(final InputEvent event, final char character) {
+                if (character == '\n' || character == '\r') {
+                    submit();
+                    return true;
+                }
+                return false;
+            }
+        });
+        add(log).growX().height(LOG_HEIGHT).row();
+        add(input).growX();
+    }
+
+    private void submit() {
+        String text = input.getText().trim();
+        if (!text.isEmpty()) {
+            client.sendChatMessage(new ChatMessage(text));
+            input.setText("");
+        }
+    }
+
+    public void addMessage(final ChatMessage msg) {
+        log.appendText(msg.text() + "\n");
+    }
+
+    @Override
+    public void act(final float delta) {
+        super.act(delta);
+        ChatMessage msg;
+        while ((msg = client.pollChatMessage()) != null) {
+            addMessage(msg);
+        }
+    }
+}

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -20,3 +20,4 @@ language.es=Español
 language.de=Deutsch
 ui.fpsSuffix= FPS
 error.preferencesUnavailable=Preferences unavailable
+chat.placeholder=Type a message

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -19,3 +19,4 @@ language.es=Spanisch
 language.de=Deutsch
 ui.fpsSuffix= FPS
 error.preferencesUnavailable=Einstellungen nicht verfügbar
+chat.placeholder=Nachricht eingeben

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -19,3 +19,4 @@ language.es=Español
 language.de=Alemán
 ui.fpsSuffix= FPS
 error.preferencesUnavailable=Preferencias no disponibles
+chat.placeholder=Escribe un mensaje

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -19,3 +19,4 @@ language.es=Espagnol
 language.de=Allemand
 ui.fpsSuffix= FPS
 error.preferencesUnavailable=Préférences indisponibles
+chat.placeholder=Entrez un message

--- a/core/src/net/lapidist/colony/chat/ChatMessage.java
+++ b/core/src/net/lapidist/colony/chat/ChatMessage.java
@@ -1,0 +1,7 @@
+package net.lapidist.colony.chat;
+
+/**
+ * Simple chat message exchanged between clients via the server.
+ */
+public record ChatMessage(String text) {
+}

--- a/core/src/net/lapidist/colony/chat/package-info.java
+++ b/core/src/net/lapidist/colony/chat/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains chat related classes.
+ */
+package net.lapidist.colony.chat;

--- a/core/src/net/lapidist/colony/serialization/SerializationRegistrar.java
+++ b/core/src/net/lapidist/colony/serialization/SerializationRegistrar.java
@@ -52,6 +52,7 @@ public final class SerializationRegistrar {
             MapState.class,
             BuildingData.class,
             TilePos.class,
+            net.lapidist.colony.chat.ChatMessage.class,
             SaveData.class
     };
 }

--- a/server/src/net/lapidist/colony/server/GameServer.java
+++ b/server/src/net/lapidist/colony/server/GameServer.java
@@ -10,6 +10,7 @@ import net.lapidist.colony.network.MessageHandler;
 import net.lapidist.colony.io.Paths;
 import net.lapidist.colony.map.MapGenerator;
 import net.lapidist.colony.server.handlers.TileSelectionRequestHandler;
+import net.lapidist.colony.server.handlers.ChatMessageHandler;
 import net.lapidist.colony.server.commands.CommandBus;
 import net.lapidist.colony.server.commands.CommandHandler;
 import net.lapidist.colony.server.commands.TileSelectionCommandHandler;
@@ -85,7 +86,8 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
 
         if (handlers == null) {
             handlers = java.util.List.of(
-                    new TileSelectionRequestHandler(commandBus)
+                    new TileSelectionRequestHandler(commandBus),
+                    new ChatMessageHandler(networkService, commandBus)
             );
         }
         registerHandlers(handlers);

--- a/server/src/net/lapidist/colony/server/handlers/ChatMessageHandler.java
+++ b/server/src/net/lapidist/colony/server/handlers/ChatMessageHandler.java
@@ -1,0 +1,50 @@
+package net.lapidist.colony.server.handlers;
+
+import net.lapidist.colony.chat.ChatMessage;
+import net.lapidist.colony.network.AbstractMessageHandler;
+import net.lapidist.colony.server.commands.CommandBus;
+import net.lapidist.colony.server.commands.TileSelectionCommand;
+import net.lapidist.colony.server.services.NetworkService;
+
+/**
+ * Handles incoming chat messages and broadcasts them to all clients.
+ * Messages starting with a slash are treated as commands.
+ */
+public final class ChatMessageHandler extends AbstractMessageHandler<ChatMessage> {
+    private static final int SELECT_PARTS = 4;
+    private static final int ARG_X = 1;
+    private static final int ARG_Y = 2;
+    private static final int ARG_SELECTED = 3;
+    private final NetworkService networkService;
+    private final CommandBus commandBus;
+
+    public ChatMessageHandler(final NetworkService service, final CommandBus bus) {
+        super(ChatMessage.class);
+        this.networkService = service;
+        this.commandBus = bus;
+    }
+
+    @Override
+    public void handle(final ChatMessage message) {
+        String text = message.text();
+        if (text.startsWith("/")) {
+            processCommand(text.substring(1));
+        } else {
+            networkService.broadcast(message);
+        }
+    }
+
+    private void processCommand(final String commandLine) {
+        String[] parts = commandLine.split("\\s+");
+        if (parts.length == SELECT_PARTS && "select".equals(parts[0])) {
+            try {
+                int x = Integer.parseInt(parts[ARG_X]);
+                int y = Integer.parseInt(parts[ARG_Y]);
+                boolean selected = Boolean.parseBoolean(parts[ARG_SELECTED]);
+                commandBus.dispatch(new TileSelectionCommand(x, y, selected));
+            } catch (NumberFormatException ignore) {
+                // silently ignore malformed commands
+            }
+        }
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/network/GameServerChatBroadcastTest.java
+++ b/tests/src/net/lapidist/colony/tests/network/GameServerChatBroadcastTest.java
@@ -1,0 +1,45 @@
+package net.lapidist.colony.tests.network;
+
+import net.lapidist.colony.chat.ChatMessage;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.server.GameServer;
+import net.lapidist.colony.server.GameServerConfig;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class GameServerChatBroadcastTest {
+
+    private static final int WAIT_MS = 100;
+
+    @Test
+    public void serverBroadcastsChatMessages() throws Exception {
+        GameServer server = new GameServer(GameServerConfig.builder().build());
+        server.start();
+
+        GameClient clientA = new GameClient();
+        CountDownLatch latchA = new CountDownLatch(1);
+        clientA.start(state -> latchA.countDown());
+        GameClient clientB = new GameClient();
+        CountDownLatch latchB = new CountDownLatch(1);
+        clientB.start(state -> latchB.countDown());
+        latchA.await(1, TimeUnit.SECONDS);
+        latchB.await(1, TimeUnit.SECONDS);
+
+        ChatMessage msg = new ChatMessage("hello");
+        clientA.sendChatMessage(msg);
+        Thread.sleep(WAIT_MS);
+
+        ChatMessage received = clientB.pollChatMessage();
+        assertNotNull(received);
+        assertEquals(msg.text(), received.text());
+
+        clientA.stop();
+        clientB.stop();
+        server.stop();
+    }
+}


### PR DESCRIPTION
## Summary
- implement ChatMessage network record and register with Kryo
- add ChatMessageHandler for client and server
- broadcast chat messages and parse chat commands
- provide ChatBox UI and integrate into Map UI
- support sending chat messages from GameClient
- add scenario tests for chat broadcast and command handling

## Testing
- `./gradlew spotlessApply`
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68461923ae448328bc0103bf6e0a7fcb