### PR TITLE
feat: add building construction mechanic

### DIFF
--- a/client/src/net/lapidist/colony/client/network/GameClient.java
+++ b/client/src/net/lapidist/colony/client/network/GameClient.java
@@ -4,6 +4,8 @@ import com.esotericsoftware.kryonet.Client;
 import com.esotericsoftware.kryonet.Connection;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileSelectionData;
+import net.lapidist.colony.components.state.BuildingData;
+import net.lapidist.colony.components.state.BuildingPlacementData;
 import net.lapidist.colony.chat.ChatMessage;
 import net.lapidist.colony.core.serialization.KryoRegistry;
 import net.lapidist.colony.network.AbstractMessageEndpoint;
@@ -12,6 +14,7 @@ import net.lapidist.colony.network.MessageHandler;
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.client.network.handlers.MapStateMessageHandler;
 import net.lapidist.colony.client.network.handlers.TileSelectionUpdateHandler;
+import net.lapidist.colony.client.network.handlers.BuildingUpdateHandler;
 import net.lapidist.colony.client.network.handlers.ChatMessageHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +32,7 @@ public final class GameClient extends AbstractMessageEndpoint {
     private final Client client = new Client(BUFFER_SIZE, BUFFER_SIZE);
     private MapState mapState;
     private final Queue<TileSelectionData> tileUpdates = new ConcurrentLinkedQueue<>();
+    private final Queue<BuildingData> buildingUpdates = new ConcurrentLinkedQueue<>();
     private final Queue<ChatMessage> chatMessages = new ConcurrentLinkedQueue<>();
     private Iterable<MessageHandler<?>> handlers;
     private static final int CONNECT_TIMEOUT = 5000;
@@ -44,6 +48,7 @@ public final class GameClient extends AbstractMessageEndpoint {
                     }
                 }),
                 new TileSelectionUpdateHandler(tileUpdates),
+                new BuildingUpdateHandler(buildingUpdates),
                 new ChatMessageHandler(chatMessages)
         );
     }
@@ -87,6 +92,10 @@ public final class GameClient extends AbstractMessageEndpoint {
         return tileUpdates.poll();
     }
 
+    public BuildingData pollBuildingUpdate() {
+        return buildingUpdates.poll();
+    }
+
     public ChatMessage pollChatMessage() {
         return chatMessages.poll();
     }
@@ -95,8 +104,16 @@ public final class GameClient extends AbstractMessageEndpoint {
         tileUpdates.add(data);
     }
 
+    public void injectBuildingUpdate(final BuildingData data) {
+        buildingUpdates.add(data);
+    }
+
 
     public void sendTileSelectionRequest(final TileSelectionData data) {
+        send(data);
+    }
+
+    public void sendBuildRequest(final BuildingPlacementData data) {
         send(data);
     }
 

--- a/client/src/net/lapidist/colony/client/network/handlers/BuildingUpdateHandler.java
+++ b/client/src/net/lapidist/colony/client/network/handlers/BuildingUpdateHandler.java
@@ -1,0 +1,23 @@
+package net.lapidist.colony.client.network.handlers;
+
+import net.lapidist.colony.components.state.BuildingData;
+import net.lapidist.colony.network.AbstractMessageHandler;
+
+import java.util.Queue;
+
+/**
+ * Queues building updates received from the server.
+ */
+public final class BuildingUpdateHandler extends AbstractMessageHandler<BuildingData> {
+    private final Queue<BuildingData> queue;
+
+    public BuildingUpdateHandler(final Queue<BuildingData> queueToUse) {
+        super(BuildingData.class);
+        this.queue = queueToUse;
+    }
+
+    @Override
+    public void handle(final BuildingData message) {
+        queue.add(message);
+    }
+}

--- a/client/src/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -12,6 +12,7 @@ import net.lapidist.colony.client.renderers.MapRendererFactory;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
 import net.lapidist.colony.client.systems.UISystem;
 import net.lapidist.colony.client.systems.network.TileUpdateSystem;
+import net.lapidist.colony.client.systems.network.BuildingUpdateSystem;
 import net.lapidist.colony.client.systems.MapInitSystem;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.map.MapStateProvider;
@@ -49,6 +50,7 @@ public final class MapWorldBuilder {
                         new ClearScreenSystem(Color.BLACK),
                         inputSystem,
                         new TileUpdateSystem(client),
+                        new BuildingUpdateSystem(client),
                         new MapRenderSystem(new MapRendererFactory()),
                         new UISystem(stage)
                 );

--- a/client/src/net/lapidist/colony/client/systems/InputSystem.java
+++ b/client/src/net/lapidist/colony/client/systems/InputSystem.java
@@ -9,6 +9,7 @@ import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.client.systems.input.GestureInputHandler;
 import net.lapidist.colony.client.systems.input.KeyboardInputHandler;
 import net.lapidist.colony.client.systems.input.TileSelectionHandler;
+import net.lapidist.colony.client.systems.input.BuildingPlacementHandler;
 import net.lapidist.colony.client.systems.input.InputGestureListener;
 import net.lapidist.colony.client.systems.input.ScrollInputProcessor;
 import net.lapidist.colony.components.maps.MapComponent;
@@ -29,7 +30,9 @@ public final class InputSystem extends BaseSystem {
     private KeyboardInputHandler keyboardHandler;
     private GestureInputHandler gestureHandler;
     private TileSelectionHandler tileSelectionHandler;
+    private BuildingPlacementHandler buildingPlacementHandler;
     private InputGestureListener gestureListener;
+    private boolean buildMode;
 
     public InputSystem(final GameClient clientToSet) {
         this.client = clientToSet;
@@ -47,6 +50,7 @@ public final class InputSystem extends BaseSystem {
         keyboardHandler = new KeyboardInputHandler(cameraSystem);
         gestureHandler = new GestureInputHandler(cameraSystem);
         tileSelectionHandler = new TileSelectionHandler(client, cameraSystem);
+        buildingPlacementHandler = new BuildingPlacementHandler(client, cameraSystem);
         gestureListener = new InputGestureListener(
                 gestureHandler,
                 keyboardHandler,
@@ -79,6 +83,9 @@ public final class InputSystem extends BaseSystem {
     }
 
     public boolean tap(final float x, final float y, final int count, final int button) {
+        if (buildMode) {
+            return buildingPlacementHandler.handleTap(x, y, map, tileMapper);
+        }
         return tileSelectionHandler.handleTap(x, y, map, tileMapper);
     }
 
@@ -90,5 +97,9 @@ public final class InputSystem extends BaseSystem {
 
     public boolean zoom(final float initialDistance, final float distance) {
         return gestureHandler.zoom(initialDistance, distance);
+    }
+
+    public void setBuildMode(final boolean mode) {
+        this.buildMode = mode;
     }
 }

--- a/client/src/net/lapidist/colony/client/systems/input/BuildingPlacementHandler.java
+++ b/client/src/net/lapidist/colony/client/systems/input/BuildingPlacementHandler.java
@@ -1,0 +1,57 @@
+package net.lapidist.colony.client.systems.input;
+
+import com.artemis.ComponentMapper;
+import com.artemis.Entity;
+import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.utils.Array;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.client.systems.PlayerCameraSystem;
+import net.lapidist.colony.client.util.CameraUtils;
+import net.lapidist.colony.components.entities.BuildingComponent;
+import net.lapidist.colony.components.maps.MapComponent;
+import net.lapidist.colony.components.maps.TileComponent;
+import net.lapidist.colony.components.state.BuildingPlacementData;
+
+/**
+ * Handles player building placement input.
+ */
+public final class BuildingPlacementHandler {
+    private final GameClient client;
+    private final PlayerCameraSystem cameraSystem;
+
+    public BuildingPlacementHandler(final GameClient clientToSet, final PlayerCameraSystem cameraSystemToSet) {
+        this.client = clientToSet;
+        this.cameraSystem = cameraSystemToSet;
+    }
+
+    public boolean handleTap(
+            final float x,
+            final float y,
+            final MapComponent map,
+            final ComponentMapper<TileComponent> tileMapper
+    ) {
+        if (map == null) {
+            return false;
+        }
+
+        cameraSystem.getCamera().update();
+        Vector2 worldCoords = CameraUtils.screenToWorldCoords(cameraSystem.getViewport(), x, y);
+        Vector2 tileCoords = CameraUtils.worldCoordsToTileCoords(worldCoords);
+
+        Array<Entity> tiles = map.getTiles();
+        for (int i = 0; i < tiles.size; i++) {
+            Entity tile = tiles.get(i);
+            TileComponent tc = tileMapper.get(tile);
+            if (tc.getX() == (int) tileCoords.x && tc.getY() == (int) tileCoords.y) {
+                BuildingPlacementData msg = new BuildingPlacementData(
+                        tc.getX(),
+                        tc.getY(),
+                        BuildingComponent.BuildingType.HOUSE.name()
+                );
+                client.sendBuildRequest(msg);
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/client/src/net/lapidist/colony/client/systems/network/BuildingUpdateSystem.java
+++ b/client/src/net/lapidist/colony/client/systems/network/BuildingUpdateSystem.java
@@ -1,0 +1,43 @@
+package net.lapidist.colony.client.systems.network;
+
+import com.artemis.BaseSystem;
+import com.badlogic.gdx.math.Vector2;
+import net.lapidist.colony.client.entities.factories.BuildingFactory;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.components.entities.BuildingComponent;
+import net.lapidist.colony.components.maps.MapComponent;
+import net.lapidist.colony.components.state.BuildingData;
+import net.lapidist.colony.map.MapUtils;
+
+/**
+ * Applies building placement updates received from the server.
+ */
+public final class BuildingUpdateSystem extends BaseSystem {
+    private final GameClient client;
+    private MapComponent map;
+
+    public BuildingUpdateSystem(final GameClient clientToSet) {
+        this.client = clientToSet;
+    }
+
+    @Override
+    protected void processSystem() {
+        if (map == null) {
+            map = MapUtils.findMap(world).orElse(null);
+            if (map == null) {
+                return;
+            }
+        }
+
+        BuildingData update;
+        while ((update = client.pollBuildingUpdate()) != null) {
+            world.createEntity();
+            map.addEntity(BuildingFactory.create(
+                    world,
+                    BuildingComponent.BuildingType.valueOf(update.buildingType()),
+                    update.textureRef(),
+                    new Vector2(update.x(), update.y())
+            ));
+        }
+    }
+}

--- a/core/src/net/lapidist/colony/components/state/BuildingPlacementData.java
+++ b/core/src/net/lapidist/colony/components/state/BuildingPlacementData.java
@@ -1,0 +1,10 @@
+package net.lapidist.colony.components.state;
+
+import net.lapidist.colony.serialization.KryoType;
+
+/**
+ * Request message sent by clients when placing a building.
+ */
+@KryoType
+public record BuildingPlacementData(int x, int y, String buildingType) {
+}

--- a/core/src/net/lapidist/colony/serialization/SerializationRegistrar.java
+++ b/core/src/net/lapidist/colony/serialization/SerializationRegistrar.java
@@ -7,6 +7,7 @@ import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.TileSelectionData;
 import net.lapidist.colony.components.state.TilePos;
+import net.lapidist.colony.components.state.BuildingPlacementData;
 import net.lapidist.colony.save.SaveData;
 
 /**
@@ -51,6 +52,7 @@ public final class SerializationRegistrar {
             TileSelectionData.class,
             MapState.class,
             BuildingData.class,
+            BuildingPlacementData.class,
             TilePos.class,
             net.lapidist.colony.chat.ChatMessage.class,
             SaveData.class

--- a/server/src/net/lapidist/colony/server/GameServer.java
+++ b/server/src/net/lapidist/colony/server/GameServer.java
@@ -10,10 +10,12 @@ import net.lapidist.colony.network.MessageHandler;
 import net.lapidist.colony.io.Paths;
 import net.lapidist.colony.map.MapGenerator;
 import net.lapidist.colony.server.handlers.TileSelectionRequestHandler;
+import net.lapidist.colony.server.handlers.BuildingPlacementRequestHandler;
 import net.lapidist.colony.server.handlers.ChatMessageHandler;
 import net.lapidist.colony.server.commands.CommandBus;
 import net.lapidist.colony.server.commands.CommandHandler;
 import net.lapidist.colony.server.commands.TileSelectionCommandHandler;
+import net.lapidist.colony.server.commands.BuildCommandHandler;
 import net.lapidist.colony.server.services.AutosaveService;
 import net.lapidist.colony.server.services.MapService;
 import net.lapidist.colony.server.services.NetworkService;
@@ -79,7 +81,8 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
 
         if (commandHandlers == null) {
             commandHandlers = java.util.List.of(
-                    new TileSelectionCommandHandler(() -> mapState, networkService)
+                    new TileSelectionCommandHandler(() -> mapState, networkService),
+                    new BuildCommandHandler(() -> mapState, networkService)
             );
         }
         commandBus.registerHandlers(commandHandlers);
@@ -87,6 +90,7 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
         if (handlers == null) {
             handlers = java.util.List.of(
                     new TileSelectionRequestHandler(commandBus),
+                    new BuildingPlacementRequestHandler(commandBus),
                     new ChatMessageHandler(networkService, commandBus)
             );
         }

--- a/server/src/net/lapidist/colony/server/commands/BuildCommand.java
+++ b/server/src/net/lapidist/colony/server/commands/BuildCommand.java
@@ -1,0 +1,9 @@
+package net.lapidist.colony.server.commands;
+
+import net.lapidist.colony.components.entities.BuildingComponent;
+
+/**
+ * Command representing a building placement request.
+ */
+public record BuildCommand(int x, int y, BuildingComponent.BuildingType type) implements ServerCommand {
+}

--- a/server/src/net/lapidist/colony/server/commands/BuildCommandHandler.java
+++ b/server/src/net/lapidist/colony/server/commands/BuildCommandHandler.java
@@ -1,0 +1,55 @@
+package net.lapidist.colony.server.commands;
+
+import net.lapidist.colony.components.entities.BuildingComponent;
+import net.lapidist.colony.components.state.BuildingData;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.TileData;
+import net.lapidist.colony.components.state.TilePos;
+import net.lapidist.colony.core.events.Events;
+import net.lapidist.colony.server.events.BuildingPlacedEvent;
+import net.lapidist.colony.server.services.NetworkService;
+
+import java.util.function.Supplier;
+
+/**
+ * Applies a {@link BuildCommand} to the game state and broadcasts the change.
+ */
+public final class BuildCommandHandler implements CommandHandler<BuildCommand> {
+    private final Supplier<MapState> stateSupplier;
+    private final NetworkService networkService;
+
+    public BuildCommandHandler(final Supplier<MapState> stateSupplierToUse,
+                               final NetworkService networkServiceToUse) {
+        this.stateSupplier = stateSupplierToUse;
+        this.networkService = networkServiceToUse;
+    }
+
+    @Override
+    public Class<BuildCommand> type() {
+        return BuildCommand.class;
+    }
+
+    @Override
+    public void handle(final BuildCommand command) {
+        MapState state = stateSupplier.get();
+        TileData tile = state.tiles().get(new TilePos(command.x(), command.y()));
+        boolean occupied = state.buildings().stream()
+                .anyMatch(b -> b.x() == command.x() && b.y() == command.y());
+        if (tile == null || occupied) {
+            return;
+        }
+        String texture = defaultTexture(command.type());
+        BuildingData building = new BuildingData(command.x(), command.y(), command.type().name(), texture);
+        state.buildings().add(building);
+        Events.dispatch(new BuildingPlacedEvent(command.x(), command.y(), command.type().name()));
+        networkService.broadcast(building);
+    }
+
+    private static String defaultTexture(final BuildingComponent.BuildingType type) {
+        return switch (type) {
+            case HOUSE -> "house0";
+            case MARKET -> "house0";
+            case FACTORY -> "house0";
+        };
+    }
+}

--- a/server/src/net/lapidist/colony/server/events/BuildingPlacedEvent.java
+++ b/server/src/net/lapidist/colony/server/events/BuildingPlacedEvent.java
@@ -1,0 +1,35 @@
+package net.lapidist.colony.server.events;
+
+import net.lapidist.colony.core.events.AbstractDataEvent;
+
+/**
+ * Event fired when a building is placed on the map.
+ */
+public final class BuildingPlacedEvent extends AbstractDataEvent {
+    private final int x;
+    private final int y;
+    private final String buildingType;
+
+    public BuildingPlacedEvent(final int xToSet, final int yToSet, final String typeToSet) {
+        this.x = xToSet;
+        this.y = yToSet;
+        this.buildingType = typeToSet;
+    }
+
+    public int getX() {
+        return x;
+    }
+
+    public int getY() {
+        return y;
+    }
+
+    public String getBuildingType() {
+        return buildingType;
+    }
+
+    @Override
+    public String toString() {
+        return format("x", x, "y", y, "buildingType", buildingType);
+    }
+}

--- a/server/src/net/lapidist/colony/server/handlers/BuildingPlacementRequestHandler.java
+++ b/server/src/net/lapidist/colony/server/handlers/BuildingPlacementRequestHandler.java
@@ -1,0 +1,28 @@
+package net.lapidist.colony.server.handlers;
+
+import net.lapidist.colony.components.entities.BuildingComponent;
+import net.lapidist.colony.components.state.BuildingPlacementData;
+import net.lapidist.colony.server.commands.BuildCommand;
+import net.lapidist.colony.server.commands.CommandBus;
+import net.lapidist.colony.network.AbstractMessageHandler;
+
+/**
+ * Converts incoming {@link BuildingPlacementData} messages into {@link BuildCommand} instances.
+ */
+public final class BuildingPlacementRequestHandler extends AbstractMessageHandler<BuildingPlacementData> {
+    private final CommandBus commandBus;
+
+    public BuildingPlacementRequestHandler(final CommandBus bus) {
+        super(BuildingPlacementData.class);
+        this.commandBus = bus;
+    }
+
+    @Override
+    public void handle(final BuildingPlacementData data) {
+        commandBus.dispatch(new BuildCommand(
+                data.x(),
+                data.y(),
+                BuildingComponent.BuildingType.valueOf(data.buildingType())
+        ));
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/network/GameServerBroadcastTest.java
+++ b/tests/src/net/lapidist/colony/tests/network/GameServerBroadcastTest.java
@@ -17,7 +17,11 @@ public class GameServerBroadcastTest {
 
     @Test
     public void serverBroadcastsTileSelection() throws Exception {
-        GameServer server = new GameServer(GameServerConfig.builder().build());
+        GameServerConfig config = GameServerConfig.builder()
+                .saveName("broadcast")
+                .build();
+        net.lapidist.colony.io.Paths.deleteAutosave("broadcast");
+        GameServer server = new GameServer(config);
         server.start();
 
         GameClient clientA = new GameClient();

--- a/tests/src/net/lapidist/colony/tests/scenario/GameSimulation.java
+++ b/tests/src/net/lapidist/colony/tests/scenario/GameSimulation.java
@@ -7,6 +7,7 @@ import net.lapidist.colony.client.systems.PlayerCameraSystem;
 import net.lapidist.colony.client.systems.InputSystem;
 import net.lapidist.colony.client.systems.network.MapLoadSystem;
 import net.lapidist.colony.client.systems.network.TileUpdateSystem;
+import net.lapidist.colony.client.systems.network.BuildingUpdateSystem;
 import net.lapidist.colony.components.state.MapState;
 
 import static org.mockito.Mockito.mock;
@@ -41,7 +42,8 @@ public final class GameSimulation {
                         new MapLoadSystem(state),
                         new PlayerCameraSystem(),
                         new InputSystem(client),
-                        new TileUpdateSystem(client)
+                        new TileUpdateSystem(client),
+                        new BuildingUpdateSystem(client)
                 )
                 .build());
         // run once so systems initialise

--- a/tests/src/net/lapidist/colony/tests/scenario/GameSimulationBuildingUpdateTest.java
+++ b/tests/src/net/lapidist/colony/tests/scenario/GameSimulationBuildingUpdateTest.java
@@ -1,0 +1,72 @@
+package net.lapidist.colony.tests.scenario;
+
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.BuildingPlacementData;
+import net.lapidist.colony.components.entities.BuildingComponent;
+import net.lapidist.colony.server.GameServer;
+import net.lapidist.colony.server.GameServerConfig;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(GdxTestRunner.class)
+public class GameSimulationBuildingUpdateTest {
+
+    private static final int WAIT_MS = 200;
+
+    @Test
+    public void serverUpdatesAppliedToClientWorld() throws Exception {
+        GameServerConfig config = GameServerConfig.builder()
+                .saveName("scenario-build")
+                .build();
+        net.lapidist.colony.io.Paths.deleteAutosave("scenario-build");
+        GameServer server = new GameServer(config);
+        server.start();
+
+        GameClient sender = new GameClient();
+        CountDownLatch latchSender = new CountDownLatch(1);
+        sender.start(state -> latchSender.countDown());
+        GameClient receiver = new GameClient();
+        CountDownLatch latchReceiver = new CountDownLatch(1);
+        receiver.start(state -> latchReceiver.countDown());
+        latchSender.await(1, TimeUnit.SECONDS);
+        latchReceiver.await(1, TimeUnit.SECONDS);
+
+        MapState state = receiver.getMapState();
+        GameSimulation sim = new GameSimulation(state, receiver);
+
+        BuildingPlacementData data = new BuildingPlacementData(0, 0, "HOUSE");
+        sender.sendBuildRequest(data);
+
+        Thread.sleep(WAIT_MS);
+        sim.step();
+
+        var world = sim.getWorld();
+        var maps = world.getAspectSubscriptionManager()
+                .get(com.artemis.Aspect.all(net.lapidist.colony.components.maps.MapComponent.class))
+                .getEntities();
+        var map = world.getEntity(maps.get(0));
+        var mapComponent = world.getMapper(net.lapidist.colony.components.maps.MapComponent.class).get(map);
+        boolean found = false;
+        for (int i = 0; i < mapComponent.getEntities().size; i++) {
+            var building = mapComponent.getEntities().get(i);
+            var bc = world.getMapper(BuildingComponent.class).get(building);
+            if (bc.getX() == 0 && bc.getY() == 0) {
+                found = true;
+                break;
+            }
+        }
+        assertTrue(found);
+
+        sender.stop();
+        receiver.stop();
+        server.stop();
+        Thread.sleep(WAIT_MS);
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/server/GameServerBuildTest.java
+++ b/tests/src/net/lapidist/colony/tests/server/GameServerBuildTest.java
@@ -1,35 +1,35 @@
 package net.lapidist.colony.tests.server;
 
 import net.lapidist.colony.client.network.GameClient;
-import net.lapidist.colony.components.state.TileSelectionData;
-import net.lapidist.colony.components.state.TilePos;
+import net.lapidist.colony.components.state.BuildingPlacementData;
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.server.GameServerConfig;
 import net.lapidist.colony.core.events.Events;
-import net.lapidist.colony.server.events.TileSelectionEvent;
+import net.lapidist.colony.server.events.BuildingPlacedEvent;
 import net.mostlyoriginal.api.event.common.Subscribe;
 import org.junit.Test;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertTrue;
 
-public class GameServerSelectionTest {
+public class GameServerBuildTest {
 
     private boolean handled;
-    private static final int WAIT_MS = 100;
+    private static final int WAIT_MS = 200;
 
     @Subscribe
-    private void onTileSelection(final TileSelectionEvent event) {
+    private void onBuildingPlaced(final BuildingPlacedEvent event) {
         handled = true;
     }
 
     @Test
-    public void selectingTileUpdatesServerState() throws Exception {
+    public void buildingPlacementUpdatesServerState() throws Exception {
         GameServerConfig config = GameServerConfig.builder()
-                .saveName("selection-test")
+                .saveName("build-test")
                 .build();
-        net.lapidist.colony.io.Paths.deleteAutosave("selection-test");
+        net.lapidist.colony.io.Paths.deleteAutosave("build-test");
         GameServer server = new GameServer(config);
         server.start();
         Events.getInstance().registerEvents(this);
@@ -39,16 +39,17 @@ public class GameServerSelectionTest {
         client.start(state -> latch.countDown());
         latch.await(1, TimeUnit.SECONDS);
 
-        TileSelectionData data = new TileSelectionData(0, 0, true);
-
-        client.sendTileSelectionRequest(data);
+        BuildingPlacementData data = new BuildingPlacementData(0, 0, "HOUSE");
+        client.sendBuildRequest(data);
         Thread.sleep(WAIT_MS);
         Events.update();
 
-        assertTrue(server.getMapState().tiles().get(new TilePos(0, 0)).selected());
+        assertTrue(server.getMapState().buildings().stream()
+                .anyMatch(b -> b.x() == 0 && b.y() == 0));
         assertTrue(handled);
 
         client.stop();
         server.stop();
+        Thread.sleep(WAIT_MS);
     }
 }

--- a/tests/src/net/lapidist/colony/tests/server/GameServerChatCommandTest.java
+++ b/tests/src/net/lapidist/colony/tests/server/GameServerChatCommandTest.java
@@ -27,7 +27,11 @@ public class GameServerChatCommandTest {
 
     @Test
     public void chatCommandSelectsTile() throws Exception {
-        GameServer server = new GameServer(GameServerConfig.builder().build());
+        GameServerConfig config = GameServerConfig.builder()
+                .saveName("chat-command")
+                .build();
+        net.lapidist.colony.io.Paths.deleteAutosave("chat-command");
+        GameServer server = new GameServer(config);
         server.start();
         Events.getInstance().registerEvents(this);
 

--- a/tests/src/net/lapidist/colony/tests/server/GameServerHandlerRegistrationTest.java
+++ b/tests/src/net/lapidist/colony/tests/server/GameServerHandlerRegistrationTest.java
@@ -70,8 +70,12 @@ public class GameServerHandlerRegistrationTest {
     public void registersAndDispatchesCustomHandlers() throws Exception {
         DummyMessageHandler messageHandler = new DummyMessageHandler();
         DummyCommandHandler commandHandler = new DummyCommandHandler();
+        GameServerConfig config = GameServerConfig.builder()
+                .saveName("handler-test")
+                .build();
+        net.lapidist.colony.io.Paths.deleteAutosave("handler-test");
         GameServer server = new GameServer(
-                GameServerConfig.builder().build(),
+                config,
                 java.util.List.of(messageHandler),
                 java.util.List.of(commandHandler)
         );

--- a/tests/src/net/lapidist/colony/tests/server/GameServerSaveTest.java
+++ b/tests/src/net/lapidist/colony/tests/server/GameServerSaveTest.java
@@ -45,16 +45,19 @@ public class GameServerSaveTest {
 
     @Test
     public void autosaveCreatesSaveFileAndFiresEvent() throws Exception {
-        GameServer server = new GameServer(
-                GameServerConfig.builder().autosaveInterval(TEST_INTERVAL_MS).build()
-        );
+        GameServerConfig config = GameServerConfig.builder()
+                .saveName("save-test")
+                .autosaveInterval(TEST_INTERVAL_MS)
+                .build();
+        net.lapidist.colony.io.Paths.deleteAutosave("save-test");
+        GameServer server = new GameServer(config);
         server.start();
         Events.getInstance().registerEvents(this);
 
         Thread.sleep(WAIT_MS);
         Events.update();
 
-        Path saveFile = Paths.getAutosave("autosave");
+        Path saveFile = Paths.getAutosave("save-test");
         assertTrue(Files.exists(saveFile));
         assertTrue(lastEvent != null);
         assertTrue(saveFile.equals(lastEvent.getLocation()));
@@ -65,15 +68,17 @@ public class GameServerSaveTest {
 
     @Test
     public void stoppingSavesFileAndFiresEvent() throws Exception {
-        GameServer server = new GameServer(
-                GameServerConfig.builder().autosaveInterval(TEST_INTERVAL_MS).build()
-        );
+        GameServerConfig config = GameServerConfig.builder()
+                .saveName("save-test")
+                .autosaveInterval(TEST_INTERVAL_MS)
+                .build();
+        GameServer server = new GameServer(config);
         server.start();
         Events.getInstance().registerEvents(this);
 
         server.stop();
 
-        Path saveFile = Paths.getAutosave("autosave");
+        Path saveFile = Paths.getAutosave("save-test");
         assertTrue(Files.exists(saveFile));
         assertTrue(shutdownEvent != null);
         assertTrue(saveFile.equals(shutdownEvent.getLocation()));
@@ -82,9 +87,11 @@ public class GameServerSaveTest {
 
     @Test
     public void loadsExistingSave() throws Exception {
-        GameServer first = new GameServer(
-                GameServerConfig.builder().autosaveInterval(TEST_INTERVAL_MS).build()
-        );
+        GameServerConfig cfg = GameServerConfig.builder()
+                .saveName("save-test")
+                .autosaveInterval(TEST_INTERVAL_MS)
+                .build();
+        GameServer first = new GameServer(cfg);
         first.start();
         TilePos pos = new TilePos(0, 0);
         TileData modified = first.getMapState().tiles().get(pos)
@@ -92,12 +99,10 @@ public class GameServerSaveTest {
                 .textureRef("changed")
                 .build();
         first.getMapState().tiles().put(pos, modified);
-        GameStateIO.save(first.getMapState(), Paths.getAutosave("autosave"));
+        GameStateIO.save(first.getMapState(), Paths.getAutosave("save-test"));
         first.stop();
 
-        GameServer second = new GameServer(
-                GameServerConfig.builder().autosaveInterval(TEST_INTERVAL_MS).build()
-        );
+        GameServer second = new GameServer(cfg);
         second.start();
         String loaded = second.getMapState().tiles().get(new TilePos(0, 0)).textureRef();
         second.stop();

--- a/tests/src/net/lapidist/colony/tests/server/events/ServerEventsTest.java
+++ b/tests/src/net/lapidist/colony/tests/server/events/ServerEventsTest.java
@@ -4,6 +4,7 @@ import net.lapidist.colony.server.events.AutosaveEvent;
 import net.lapidist.colony.core.events.Events;
 import net.lapidist.colony.server.events.ShutdownSaveEvent;
 import net.lapidist.colony.server.events.TileSelectionEvent;
+import net.lapidist.colony.server.events.BuildingPlacedEvent;
 import net.mostlyoriginal.api.event.common.EventSystem;
 import net.mostlyoriginal.api.event.common.Subscribe;
 import org.junit.Before;
@@ -93,6 +94,17 @@ public class ServerEventsTest {
         TileSelectionEvent event = new TileSelectionEvent(x, y, true);
         assertEquals(
                 String.format("TileSelectionEvent(x=%d, y=%d, selected=true)", x, y),
+                event.toString()
+        );
+    }
+
+    @Test
+    public void testBuildingPlacedEventToString() {
+        final int x = 1;
+        final int y = 2;
+        BuildingPlacedEvent event = new BuildingPlacedEvent(x, y, "HOUSE");
+        assertEquals(
+                String.format("BuildingPlacedEvent(x=%d, y=%d, buildingType=HOUSE)", x, y),
                 event.toString()
         );
     }

--- a/tests/src/net/lapidist/colony/tests/systems/BuildingUpdateSystemTest.java
+++ b/tests/src/net/lapidist/colony/tests/systems/BuildingUpdateSystemTest.java
@@ -1,0 +1,61 @@
+package net.lapidist.colony.tests.systems;
+
+import com.artemis.Aspect;
+import com.artemis.Entity;
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import com.artemis.utils.IntBag;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.client.systems.network.MapLoadSystem;
+import net.lapidist.colony.client.systems.network.BuildingUpdateSystem;
+import net.lapidist.colony.components.maps.MapComponent;
+import net.lapidist.colony.components.entities.BuildingComponent;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.TileData;
+import net.lapidist.colony.components.state.TilePos;
+import net.lapidist.colony.components.state.BuildingData;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(GdxTestRunner.class)
+public class BuildingUpdateSystemTest {
+
+    @Test
+    public void appliesServerBuildingPlacement() {
+        MapState state = new MapState();
+        TileData tile = TileData.builder()
+                .x(0)
+                .y(0)
+                .tileType("GRASS")
+                .textureRef("grass0")
+                .passable(true)
+                .build();
+        state.tiles().put(new TilePos(0, 0), tile);
+
+        GameClient client = new GameClient();
+        World world = new World(new WorldConfigurationBuilder()
+                .with(new MapLoadSystem(state), new BuildingUpdateSystem(client))
+                .build());
+
+        world.process();
+
+        BuildingData data = new BuildingData(0, 0, "HOUSE", "house0");
+        client.injectBuildingUpdate(data);
+
+        world.process();
+
+        IntBag maps = world.getAspectSubscriptionManager()
+                .get(Aspect.all(MapComponent.class))
+                .getEntities();
+        Entity map = world.getEntity(maps.get(0));
+        MapComponent mapComponent = world.getMapper(MapComponent.class).get(map);
+        Entity building = mapComponent.getEntities().get(0);
+        BuildingComponent bc = world.getMapper(BuildingComponent.class).get(building);
+
+        assertEquals(0, bc.getX());
+        assertEquals(0, bc.getY());
+    }
+}


### PR DESCRIPTION
## Summary
- add data class for building placement requests
- handle building placement on client and server
- broadcast new buildings to connected clients
- update InputSystem with build mode
- include building update system and handler
- add scenario and server tests for building placement
- use unique save names for server tests

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68462187bc608328bc48ae26b2bd7be4