### PR TITLE
fix: switch map screen creation to main thread

### DIFF
--- a/client/src/net/lapidist/colony/client/Colony.java
+++ b/client/src/net/lapidist/colony/client/Colony.java
@@ -1,6 +1,7 @@
 package net.lapidist.colony.client;
 
 import com.badlogic.gdx.Game;
+import com.badlogic.gdx.Gdx;
 import net.lapidist.colony.io.Paths;
 import net.lapidist.colony.client.screens.MapScreen;
 import net.lapidist.colony.client.screens.MainMenuScreen;
@@ -43,7 +44,8 @@ public final class Colony extends Game {
             );
             server.start();
             client = new GameClient();
-            client.start(state -> setScreen(new MapScreen(this, state, client)));
+            client.start(state ->
+                    Gdx.app.postRunnable(() -> setScreen(new MapScreen(this, state, client))));
         } catch (IOException | InterruptedException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
## Summary
- ensure the client map screen is created on the LibGDX main thread

## Testing
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_6846968211a48328a06044699f616473