### PR TITLE
feat: implement resource gathering and inventory

### DIFF
--- a/client/src/net/lapidist/colony/client/renderers/MapRendererFactory.java
+++ b/client/src/net/lapidist/colony/client/renderers/MapRendererFactory.java
@@ -10,6 +10,7 @@ import net.lapidist.colony.components.assets.TextureRegionReferenceComponent;
 import net.lapidist.colony.components.entities.BuildingComponent;
 import net.lapidist.colony.components.maps.TileComponent;
 import net.lapidist.colony.components.maps.MapComponent;
+import net.lapidist.colony.components.resources.ResourceComponent;
 
 import java.io.IOException;
 
@@ -44,6 +45,7 @@ public final class MapRendererFactory {
         ComponentMapper<BuildingComponent> buildingMapper = world.getMapper(BuildingComponent.class);
         ComponentMapper<TextureRegionReferenceComponent> textureMapper =
                 world.getMapper(TextureRegionReferenceComponent.class);
+        ComponentMapper<ResourceComponent> resourceMapper = world.getMapper(ResourceComponent.class);
 
         TileRenderer tileRenderer = new TileRenderer(
                 batch,
@@ -59,10 +61,16 @@ public final class MapRendererFactory {
                 buildingMapper,
                 textureMapper
         );
+        ResourceRenderer resourceRenderer = new ResourceRenderer(
+                batch,
+                cameraSystem,
+                tileMapper,
+                resourceMapper
+        );
 
         // trigger map mapper initialization so MapRenderSystem can use it immediately
         world.getMapper(MapComponent.class);
 
-        return new MapRenderers(batch, loader, tileRenderer, buildingRenderer);
+        return new MapRenderers(batch, loader, tileRenderer, buildingRenderer, resourceRenderer);
     }
 }

--- a/client/src/net/lapidist/colony/client/renderers/MapRenderers.java
+++ b/client/src/net/lapidist/colony/client/renderers/MapRenderers.java
@@ -13,17 +13,20 @@ public final class MapRenderers implements Disposable {
     private final ResourceLoader resourceLoader;
     private final TileRenderer tileRenderer;
     private final BuildingRenderer buildingRenderer;
+    private final ResourceRenderer resourceRenderer;
 
     public MapRenderers(
             final SpriteBatch spriteBatchToSet,
             final ResourceLoader resourceLoaderToSet,
             final TileRenderer tileRendererToSet,
-            final BuildingRenderer buildingRendererToSet
+            final BuildingRenderer buildingRendererToSet,
+            final ResourceRenderer resourceRendererToSet
     ) {
         this.spriteBatch = spriteBatchToSet;
         this.resourceLoader = resourceLoaderToSet;
         this.tileRenderer = tileRendererToSet;
         this.buildingRenderer = buildingRendererToSet;
+        this.resourceRenderer = resourceRendererToSet;
     }
 
     public SpriteBatch getSpriteBatch() {
@@ -42,9 +45,14 @@ public final class MapRenderers implements Disposable {
         return buildingRenderer;
     }
 
+    public ResourceRenderer getResourceRenderer() {
+        return resourceRenderer;
+    }
+
     @Override
     public void dispose() {
         resourceLoader.dispose();
+        resourceRenderer.dispose();
         spriteBatch.dispose();
     }
 }

--- a/client/src/net/lapidist/colony/client/renderers/ResourceRenderer.java
+++ b/client/src/net/lapidist/colony/client/renderers/ResourceRenderer.java
@@ -1,0 +1,55 @@
+package net.lapidist.colony.client.renderers;
+
+import com.artemis.ComponentMapper;
+import com.artemis.Entity;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.utils.Array;
+import net.lapidist.colony.client.systems.PlayerCameraSystem;
+import net.lapidist.colony.client.util.CameraUtils;
+import net.lapidist.colony.components.maps.TileComponent;
+import net.lapidist.colony.components.resources.ResourceComponent;
+import com.badlogic.gdx.utils.Disposable;
+
+/** Draws resource amounts on tiles. */
+public final class ResourceRenderer implements EntityRenderer, Disposable {
+    private final SpriteBatch spriteBatch;
+    private final PlayerCameraSystem cameraSystem;
+    private final BitmapFont font = new BitmapFont();
+    private final ComponentMapper<TileComponent> tileMapper;
+    private final ComponentMapper<ResourceComponent> resourceMapper;
+    private static final float OFFSET_Y = 8f;
+
+    public ResourceRenderer(
+            final SpriteBatch spriteBatchToUse,
+            final PlayerCameraSystem cameraSystemToUse,
+            final ComponentMapper<TileComponent> tileMapperToUse,
+            final ComponentMapper<ResourceComponent> resourceMapperToUse
+    ) {
+        this.spriteBatch = spriteBatchToUse;
+        this.cameraSystem = cameraSystemToUse;
+        this.tileMapper = tileMapperToUse;
+        this.resourceMapper = resourceMapperToUse;
+    }
+
+    @Override
+    public void render(final Array<Entity> entities) {
+        for (int i = 0; i < entities.size; i++) {
+            Entity entity = entities.get(i);
+            TileComponent tile = tileMapper.get(entity);
+            Vector2 worldCoords = CameraUtils.tileCoordsToWorldCoords(tile.getX(), tile.getY());
+            if (!CameraUtils.withinCameraView(cameraSystem.getViewport(), worldCoords)) {
+                continue;
+            }
+            ResourceComponent rc = resourceMapper.get(entity);
+            String text = rc.getWood() + "/" + rc.getStone() + "/" + rc.getFood();
+            font.draw(spriteBatch, text, worldCoords.x, worldCoords.y + OFFSET_Y);
+        }
+    }
+
+    @Override
+    public void dispose() {
+        font.dispose();
+    }
+}

--- a/client/src/net/lapidist/colony/client/screens/MapUiBuilder.java
+++ b/client/src/net/lapidist/colony/client/screens/MapUiBuilder.java
@@ -12,6 +12,7 @@ import com.artemis.World;
 import net.lapidist.colony.client.Colony;
 import net.lapidist.colony.client.ui.MinimapActor;
 import net.lapidist.colony.client.ui.ChatBox;
+import net.lapidist.colony.client.ui.PlayerResourcesActor;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.i18n.I18n;
 
@@ -21,6 +22,7 @@ import net.lapidist.colony.i18n.I18n;
 public final class MapUiBuilder {
 
     private static final float PADDING = 10f;
+    private static final int COLUMN_SPAN = 3;
 
     private MapUiBuilder() {
     }
@@ -49,6 +51,7 @@ public final class MapUiBuilder {
         TextButton menuButton = new TextButton(I18n.get("map.menu"), skin);
         MinimapActor minimapActor = new MinimapActor(world);
         ChatBox chatBox = new ChatBox(skin, client);
+        PlayerResourcesActor resourcesActor = new PlayerResourcesActor(skin, world);
 
         menuButton.addListener(new ChangeListener() {
             @Override
@@ -58,10 +61,10 @@ public final class MapUiBuilder {
         });
 
         table.add(menuButton).pad(PADDING).left().top();
-        table.add(minimapActor).pad(PADDING).expandX().right().top();
+        table.add(resourcesActor).pad(PADDING).expandX().left().top();
+        table.add(minimapActor).pad(PADDING).right().top();
         table.row();
-        table.add(chatBox).pad(PADDING).colspan(2).left().bottom().expandX();
-
+        table.add(chatBox).pad(PADDING).colspan(COLUMN_SPAN).left().bottom().expandX();
         return new MapUi(stage, minimapActor, chatBox);
     }
 }

--- a/client/src/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -13,7 +13,9 @@ import net.lapidist.colony.client.systems.PlayerCameraSystem;
 import net.lapidist.colony.client.systems.UISystem;
 import net.lapidist.colony.client.systems.network.TileUpdateSystem;
 import net.lapidist.colony.client.systems.network.BuildingUpdateSystem;
+import net.lapidist.colony.client.systems.network.ResourceUpdateSystem;
 import net.lapidist.colony.client.systems.MapInitSystem;
+import net.lapidist.colony.client.systems.PlayerInitSystem;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.map.MapStateProvider;
 import net.lapidist.colony.map.ProvidedMapStateProvider;
@@ -51,8 +53,10 @@ public final class MapWorldBuilder {
                         new EventSystem(),
                         new ClearScreenSystem(Color.BLACK),
                         inputSystem,
+                        new PlayerInitSystem(),
                         new TileUpdateSystem(client),
                         new BuildingUpdateSystem(client),
+                        new ResourceUpdateSystem(client),
                         new MapRenderSystem(new MapRendererFactory()),
                         new UISystem(stage)
                 );

--- a/client/src/net/lapidist/colony/client/systems/MapRenderSystem.java
+++ b/client/src/net/lapidist/colony/client/systems/MapRenderSystem.java
@@ -6,6 +6,7 @@ import net.lapidist.colony.client.renderers.BuildingRenderer;
 import net.lapidist.colony.client.renderers.MapRendererFactory;
 import net.lapidist.colony.client.renderers.MapRenderers;
 import net.lapidist.colony.client.renderers.TileRenderer;
+import net.lapidist.colony.client.renderers.ResourceRenderer;
 import net.lapidist.colony.components.maps.MapComponent;
 
 public final class MapRenderSystem extends BaseSystem {
@@ -20,6 +21,7 @@ public final class MapRenderSystem extends BaseSystem {
 
     private TileRenderer tileRenderer;
     private BuildingRenderer buildingRenderer;
+    private ResourceRenderer resourceRenderer;
 
     public MapRenderSystem(final MapRendererFactory factoryToUse) {
         this.factory = factoryToUse;
@@ -31,6 +33,7 @@ public final class MapRenderSystem extends BaseSystem {
         renderers = factory.create(world);
         tileRenderer = renderers.getTileRenderer();
         buildingRenderer = renderers.getBuildingRenderer();
+        resourceRenderer = renderers.getResourceRenderer();
 
     }
 
@@ -56,6 +59,7 @@ public final class MapRenderSystem extends BaseSystem {
 
         tileRenderer.render(map.getTiles());
         buildingRenderer.render(map.getEntities());
+        resourceRenderer.render(map.getTiles());
 
         batch.end();
     }

--- a/client/src/net/lapidist/colony/client/systems/PlayerInitSystem.java
+++ b/client/src/net/lapidist/colony/client/systems/PlayerInitSystem.java
@@ -1,0 +1,24 @@
+package net.lapidist.colony.client.systems;
+
+import com.artemis.BaseSystem;
+import com.artemis.Entity;
+import net.lapidist.colony.components.resources.PlayerResourceComponent;
+
+/** Creates a player entity with resource storage. */
+public final class PlayerInitSystem extends BaseSystem {
+    private boolean created;
+
+    @Override
+    public void initialize() {
+        if (!created) {
+            Entity player = world.createEntity();
+            player.edit().add(new PlayerResourceComponent());
+            created = true;
+        }
+    }
+
+    @Override
+    protected void processSystem() {
+        // no-op
+    }
+}

--- a/client/src/net/lapidist/colony/client/systems/network/ResourceUpdateSystem.java
+++ b/client/src/net/lapidist/colony/client/systems/network/ResourceUpdateSystem.java
@@ -6,6 +6,7 @@ import com.artemis.Entity;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.components.maps.MapComponent;
 import net.lapidist.colony.components.resources.ResourceComponent;
+import net.lapidist.colony.components.resources.PlayerResourceComponent;
 import net.lapidist.colony.components.state.ResourceUpdateData;
 import net.lapidist.colony.map.MapUtils;
 
@@ -14,6 +15,8 @@ public final class ResourceUpdateSystem extends BaseSystem {
     private final GameClient client;
     private ComponentMapper<ResourceComponent> resourceMapper;
     private ComponentMapper<MapComponent> mapMapper;
+    private ComponentMapper<PlayerResourceComponent> playerMapper;
+    private Entity player;
     private Entity map;
 
     public ResourceUpdateSystem(final GameClient clientToUse) {
@@ -29,6 +32,14 @@ public final class ResourceUpdateSystem extends BaseSystem {
             }
         }
         MapComponent mapComponent = mapMapper.get(map);
+        if (player == null) {
+            var players = world.getAspectSubscriptionManager()
+                    .get(com.artemis.Aspect.all(PlayerResourceComponent.class))
+                    .getEntities();
+            if (players.size() > 0) {
+                player = world.getEntity(players.get(0));
+            }
+        }
         ResourceUpdateData update;
         while ((update = client.pollResourceUpdate()) != null) {
             for (int i = 0; i < mapComponent.getTiles().size; i++) {
@@ -37,9 +48,24 @@ public final class ResourceUpdateSystem extends BaseSystem {
                 var tcMapper = world.getMapper(net.lapidist.colony.components.maps.TileComponent.class);
                 net.lapidist.colony.components.maps.TileComponent tc = tcMapper.get(tile);
                 if (tc.getX() == update.x() && tc.getY() == update.y()) {
+                    int deltaWood = rc.getWood() - update.wood();
+                    int deltaStone = rc.getStone() - update.stone();
+                    int deltaFood = rc.getFood() - update.food();
                     rc.setWood(update.wood());
                     rc.setStone(update.stone());
                     rc.setFood(update.food());
+                    if (player != null) {
+                        var pr = playerMapper.get(player);
+                        if (deltaWood > 0) {
+                            pr.addWood(deltaWood);
+                        }
+                        if (deltaStone > 0) {
+                            pr.addStone(deltaStone);
+                        }
+                        if (deltaFood > 0) {
+                            pr.addFood(deltaFood);
+                        }
+                    }
                     break;
                 }
             }

--- a/client/src/net/lapidist/colony/client/ui/PlayerResourcesActor.java
+++ b/client/src/net/lapidist/colony/client/ui/PlayerResourcesActor.java
@@ -1,0 +1,44 @@
+package net.lapidist.colony.client.ui;
+
+import com.artemis.Aspect;
+import com.artemis.ComponentMapper;
+import com.artemis.Entity;
+import com.artemis.World;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import net.lapidist.colony.components.resources.PlayerResourceComponent;
+
+/** Displays the player's resource counts. */
+public final class PlayerResourcesActor extends Table {
+    private final World world;
+    private final Label label;
+    private ComponentMapper<PlayerResourceComponent> mapper;
+    private Entity player;
+
+    public PlayerResourcesActor(final Skin skin, final World worldToUse) {
+        this.world = worldToUse;
+        this.label = new Label("", skin);
+        add(label);
+    }
+
+    @Override
+    public void act(final float delta) {
+        super.act(delta);
+        if (mapper == null) {
+            mapper = world.getMapper(PlayerResourceComponent.class);
+        }
+        if (player == null) {
+            var players = world.getAspectSubscriptionManager()
+                    .get(Aspect.all(PlayerResourceComponent.class))
+                    .getEntities();
+            if (players.size() > 0) {
+                player = world.getEntity(players.get(0));
+            }
+        }
+        if (player != null) {
+            PlayerResourceComponent pr = mapper.get(player);
+            label.setText("W:" + pr.getWood() + " S:" + pr.getStone() + " F:" + pr.getFood());
+        }
+    }
+}

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -28,3 +28,4 @@ keybind.moveLeft=Move Left
 keybind.moveRight=Move Right
 keybind.gather=Gather
 common.reset=Reset
+ui.resources=Resources

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -27,3 +27,4 @@ keybind.moveLeft=Nach Links
 keybind.moveRight=Nach Rechts
 keybind.gather=Sammeln
 common.reset=Zurücksetzen
+ui.resources=Rohstoffe

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -27,3 +27,4 @@ keybind.moveLeft=Mover Izquierda
 keybind.moveRight=Mover Derecha
 keybind.gather=Recolectar
 common.reset=Restablecer
+ui.resources=Recursos

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -27,3 +27,4 @@ keybind.moveLeft=Gauche
 keybind.moveRight=Droite
 keybind.gather=Récolter
 common.reset=Réinitialiser
+ui.resources=Ressources

--- a/core/src/net/lapidist/colony/components/resources/PlayerResourceComponent.java
+++ b/core/src/net/lapidist/colony/components/resources/PlayerResourceComponent.java
@@ -1,0 +1,34 @@
+package net.lapidist.colony.components.resources;
+
+import com.artemis.Component;
+
+/** Stores player resource amounts. */
+public final class PlayerResourceComponent extends Component {
+    private int wood;
+    private int stone;
+    private int food;
+
+    public int getWood() {
+        return wood;
+    }
+
+    public void addWood(final int amount) {
+        this.wood += amount;
+    }
+
+    public int getStone() {
+        return stone;
+    }
+
+    public void addStone(final int amount) {
+        this.stone += amount;
+    }
+
+    public int getFood() {
+        return food;
+    }
+
+    public void addFood(final int amount) {
+        this.food += amount;
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/core/resources/PlayerResourceComponentTest.java
+++ b/tests/src/net/lapidist/colony/tests/core/resources/PlayerResourceComponentTest.java
@@ -1,0 +1,24 @@
+package net.lapidist.colony.tests.core.resources;
+
+import net.lapidist.colony.components.resources.PlayerResourceComponent;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/** Unit tests for {@link PlayerResourceComponent}. */
+public class PlayerResourceComponentTest {
+    private static final int WOOD = 3;
+    private static final int STONE = 2;
+    private static final int FOOD = 1;
+
+    @Test
+    public void addMethodsIncreaseCounts() {
+        PlayerResourceComponent pr = new PlayerResourceComponent();
+        pr.addWood(WOOD);
+        pr.addStone(STONE);
+        pr.addFood(FOOD);
+        assertEquals(WOOD, pr.getWood());
+        assertEquals(STONE, pr.getStone());
+        assertEquals(FOOD, pr.getFood());
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/core/resources/package-info.java
+++ b/tests/src/net/lapidist/colony/tests/core/resources/package-info.java
@@ -1,0 +1,1 @@
+package net.lapidist.colony.tests.core.resources;

--- a/tests/src/net/lapidist/colony/tests/scenario/GameSimulation.java
+++ b/tests/src/net/lapidist/colony/tests/scenario/GameSimulation.java
@@ -43,6 +43,7 @@ public final class GameSimulation {
                         new MapLoadSystem(state),
                         new PlayerCameraSystem(),
                         new InputSystem(client, new net.lapidist.colony.settings.KeyBindings()),
+                        new net.lapidist.colony.client.systems.PlayerInitSystem(),
                         new TileUpdateSystem(client),
                         new BuildingUpdateSystem(client),
                         new ResourceUpdateSystem(client)

--- a/tests/src/net/lapidist/colony/tests/scenario/GameSimulationPlayerResourcesTest.java
+++ b/tests/src/net/lapidist/colony/tests/scenario/GameSimulationPlayerResourcesTest.java
@@ -1,0 +1,61 @@
+package net.lapidist.colony.tests.scenario;
+
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.ResourceGatherRequestData;
+import net.lapidist.colony.components.resources.PlayerResourceComponent;
+import net.lapidist.colony.server.GameServer;
+import net.lapidist.colony.server.GameServerConfig;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(GdxTestRunner.class)
+public class GameSimulationPlayerResourcesTest {
+
+    private static final int WAIT_MS = 100;
+
+    @Test
+    public void gatheringIncreasesPlayerInventory() throws Exception {
+        GameServerConfig config = GameServerConfig.builder()
+                .saveName("scenario-player")
+                .build();
+        net.lapidist.colony.io.Paths.deleteAutosave("scenario-player");
+        GameServer server = new GameServer(config);
+        server.start();
+
+        GameClient sender = new GameClient();
+        CountDownLatch latchSender = new CountDownLatch(1);
+        sender.start(state -> latchSender.countDown());
+        GameClient receiver = new GameClient();
+        CountDownLatch latchReceiver = new CountDownLatch(1);
+        receiver.start(state -> latchReceiver.countDown());
+        latchSender.await(1, TimeUnit.SECONDS);
+        latchReceiver.await(1, TimeUnit.SECONDS);
+
+        MapState state = receiver.getMapState();
+        GameSimulation sim = new GameSimulation(state, receiver);
+
+        ResourceGatherRequestData data = new ResourceGatherRequestData(0, 0, "WOOD");
+        sender.sendGatherRequest(data);
+
+        Thread.sleep(WAIT_MS);
+        sim.step();
+
+        var world = sim.getWorld();
+        var players = world.getAspectSubscriptionManager()
+                .get(com.artemis.Aspect.all(PlayerResourceComponent.class))
+                .getEntities();
+        var prc = world.getMapper(PlayerResourceComponent.class).get(world.getEntity(players.get(0)));
+        assertTrue(prc.getWood() > 0);
+
+        sender.stop();
+        receiver.stop();
+        server.stop();
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/systems/InputSystemGatherTest.java
+++ b/tests/src/net/lapidist/colony/tests/systems/InputSystemGatherTest.java
@@ -1,0 +1,59 @@
+package net.lapidist.colony.tests.systems;
+
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import com.badlogic.gdx.math.Vector2;
+import net.lapidist.colony.client.core.Constants;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.client.systems.InputSystem;
+import net.lapidist.colony.client.systems.PlayerCameraSystem;
+import net.lapidist.colony.client.systems.network.MapLoadSystem;
+import net.lapidist.colony.client.util.CameraUtils;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.ResourceData;
+import net.lapidist.colony.components.state.TileData;
+import net.lapidist.colony.components.state.TilePos;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.mockito.Mockito.*;
+
+/** Tests resource gathering via mouse input. */
+@RunWith(GdxTestRunner.class)
+public class InputSystemGatherTest {
+    private static final int INITIAL_WOOD = 5;
+
+    @Test
+    public void tapSendsGatherRequest() {
+        MapState state = new MapState();
+        ResourceData res = new ResourceData(INITIAL_WOOD, 0, 0);
+        TileData tile = TileData.builder()
+                .x(0)
+                .y(0)
+                .tileType("GRASS")
+                .textureRef("grass0")
+                .passable(true)
+                .resources(res)
+                .build();
+        state.tiles().put(new TilePos(0, 0), tile);
+
+        GameClient client = mock(GameClient.class);
+        World world = new World(new WorldConfigurationBuilder()
+                .with(new MapLoadSystem(state), new PlayerCameraSystem(),
+                        new InputSystem(client, new net.lapidist.colony.settings.KeyBindings()))
+                .build());
+
+        world.process();
+
+        PlayerCameraSystem camera = world.getSystem(PlayerCameraSystem.class);
+        camera.getCamera().position.set(Constants.TILE_SIZE / 2f, Constants.TILE_SIZE / 2f, 0);
+        camera.getCamera().update();
+
+        Vector2 screenCoords = CameraUtils.worldToScreenCoords(camera.getViewport(), 0, 0);
+        InputSystem input = world.getSystem(InputSystem.class);
+        input.tap(screenCoords.x, screenCoords.y, 1, 0);
+
+        verify(client).sendGatherRequest(any());
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/systems/MapRenderSystemTest.java
+++ b/tests/src/net/lapidist/colony/tests/systems/MapRenderSystemTest.java
@@ -6,6 +6,7 @@ import net.lapidist.colony.client.renderers.MapRendererFactory;
 import net.lapidist.colony.client.renderers.MapRenderers;
 import net.lapidist.colony.client.renderers.TileRenderer;
 import net.lapidist.colony.client.renderers.BuildingRenderer;
+import net.lapidist.colony.client.renderers.ResourceRenderer;
 import net.lapidist.colony.client.core.io.ResourceLoader;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import net.lapidist.colony.client.systems.MapRenderSystem;
@@ -91,12 +92,19 @@ public class MapRenderSystemTest {
                     buildingMapper,
                     textureMapper
             );
+            ResourceRenderer resourceRenderer = new ResourceRenderer(
+                    batch,
+                    cameraSystem,
+                    tileMapper,
+                    w.getMapper(net.lapidist.colony.components.resources.ResourceComponent.class)
+            );
             w.getMapper(MapComponent.class);
             return new MapRenderers(
                     batch,
                     loader,
                     tileRenderer,
-                    buildingRenderer
+                    buildingRenderer,
+                    resourceRenderer
             );
         });
 

--- a/tests/src/net/lapidist/colony/tests/systems/ResourceUpdateSystemTest.java
+++ b/tests/src/net/lapidist/colony/tests/systems/ResourceUpdateSystemTest.java
@@ -1,0 +1,74 @@
+package net.lapidist.colony.tests.systems;
+
+import com.artemis.Aspect;
+import com.artemis.Entity;
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.client.systems.PlayerInitSystem;
+import net.lapidist.colony.client.systems.network.MapLoadSystem;
+import net.lapidist.colony.client.systems.network.ResourceUpdateSystem;
+import net.lapidist.colony.components.maps.MapComponent;
+import net.lapidist.colony.components.resources.PlayerResourceComponent;
+import net.lapidist.colony.components.resources.ResourceComponent;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.ResourceData;
+import net.lapidist.colony.components.state.ResourceUpdateData;
+import net.lapidist.colony.components.state.TileData;
+import net.lapidist.colony.components.state.TilePos;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+/** Tests for {@link ResourceUpdateSystem}. */
+@RunWith(GdxTestRunner.class)
+public class ResourceUpdateSystemTest {
+    private static final int INITIAL_WOOD = 10;
+    private static final int UPDATED_WOOD = 5;
+
+    @Test
+    public void appliesUpdatesAndAccumulatesResources() {
+        MapState state = new MapState();
+        ResourceData res = new ResourceData(INITIAL_WOOD, 0, 0);
+        TileData tile = TileData.builder()
+                .x(0)
+                .y(0)
+                .tileType("GRASS")
+                .textureRef("grass0")
+                .passable(true)
+                .resources(res)
+                .build();
+        state.tiles().put(new TilePos(0, 0), tile);
+
+        GameClient client = new GameClient();
+        World world = new World(new WorldConfigurationBuilder()
+                .with(new MapLoadSystem(state), new PlayerInitSystem(), new ResourceUpdateSystem(client))
+                .build());
+        world.process();
+
+        client.injectResourceUpdate(new ResourceUpdateData(0, 0, UPDATED_WOOD, 0, 0));
+        world.process();
+
+        com.artemis.utils.IntBag maps = world.getAspectSubscriptionManager()
+                .get(Aspect.all(MapComponent.class))
+                .getEntities();
+        Entity mapEntity = world.getEntity(maps.get(0));
+        Entity tileEntity = world.getMapper(MapComponent.class)
+                .get(mapEntity)
+                .getTiles()
+                .get(0);
+        ResourceComponent rc = world.getMapper(ResourceComponent.class).get(tileEntity);
+        assertEquals(UPDATED_WOOD, rc.getWood());
+
+        com.artemis.utils.IntBag players = world.getAspectSubscriptionManager()
+                .get(Aspect.all(PlayerResourceComponent.class))
+                .getEntities();
+        Entity player = world.getEntity(players.get(0));
+        PlayerResourceComponent pr = world.getMapper(PlayerResourceComponent.class)
+                .get(player);
+        assertEquals(UPDATED_WOOD, pr.getWood());
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/ui/PlayerResourcesActorTest.java
+++ b/tests/src/net/lapidist/colony/tests/ui/PlayerResourcesActorTest.java
@@ -1,0 +1,46 @@
+package net.lapidist.colony.tests.ui;
+
+import com.artemis.Entity;
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import net.lapidist.colony.client.ui.PlayerResourcesActor;
+import net.lapidist.colony.components.resources.PlayerResourceComponent;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link PlayerResourcesActor}. */
+@RunWith(GdxTestRunner.class)
+public class PlayerResourcesActorTest {
+    private static final int WOOD = 5;
+    private static final int STONE = 4;
+    private static final int FOOD = 3;
+
+    @Test
+    public void displaysCurrentResources() throws Exception {
+        World world = new World(new WorldConfigurationBuilder().build());
+        Entity player = world.createEntity();
+        PlayerResourceComponent pr = new PlayerResourceComponent();
+        pr.addWood(WOOD);
+        pr.addStone(STONE);
+        pr.addFood(FOOD);
+        player.edit().add(pr);
+        world.process();
+
+        Skin skin = new Skin(Gdx.files.internal("skin/default.json"));
+        PlayerResourcesActor actor = new PlayerResourcesActor(skin, world);
+        actor.act(0f);
+
+        Field labelField = PlayerResourcesActor.class.getDeclaredField("label");
+        labelField.setAccessible(true);
+        Label label = (Label) labelField.get(actor);
+        assertEquals("W:" + WOOD + " S:" + STONE + " F:" + FOOD, label.getText().toString());
+    }
+}


### PR DESCRIPTION
## Summary
- draw resource values on tiles
- track player resources and show them in the UI
- send gather requests when clicking a tile
- update player inventory when resources broadcast
- include new PlayerInit system and tests

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_6846b4cff60883288420b5827616ff3e