### PR TITLE
fix: add configurable chat hotkey

### DIFF
--- a/client/src/net/lapidist/colony/client/screens/MapUiBuilder.java
+++ b/client/src/net/lapidist/colony/client/screens/MapUiBuilder.java
@@ -17,6 +17,8 @@ import net.lapidist.colony.client.ui.ChatBox;
 import net.lapidist.colony.client.ui.PlayerResourcesActor;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.i18n.I18n;
+import net.lapidist.colony.settings.KeyBindings;
+import net.lapidist.colony.settings.KeyAction;
 
 /**
  * Builds the UI for {@link MapScreen}.
@@ -44,6 +46,7 @@ public final class MapUiBuilder {
             final Colony colony
     ) {
         Skin skin = new Skin(Gdx.files.internal("skin/default.json"));
+        KeyBindings keyBindings = colony.getSettings().getKeyBindings();
 
         Table table = new Table();
         table.setFillParent(true);
@@ -76,7 +79,7 @@ public final class MapUiBuilder {
         stage.addListener(new InputListener() {
             @Override
             public boolean keyDown(final InputEvent event, final int keycode) {
-                if (keycode == com.badlogic.gdx.Input.Keys.ENTER && !chatBox.isInputVisible()) {
+                if (keycode == keyBindings.getKey(KeyAction.CHAT) && !chatBox.isInputVisible()) {
                     chatBox.showInput();
                     return true;
                 }

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -28,5 +28,6 @@ keybind.moveDown=Move Down
 keybind.moveLeft=Move Left
 keybind.moveRight=Move Right
 keybind.gather=Gather
+keybind.chat=Chat
 common.reset=Reset
 ui.resources=Resources

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -27,5 +27,6 @@ keybind.moveDown=Nach Unten
 keybind.moveLeft=Nach Links
 keybind.moveRight=Nach Rechts
 keybind.gather=Sammeln
+keybind.chat=Chat
 common.reset=Zurücksetzen
 ui.resources=Rohstoffe

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -27,5 +27,6 @@ keybind.moveDown=Mover Abajo
 keybind.moveLeft=Mover Izquierda
 keybind.moveRight=Mover Derecha
 keybind.gather=Recolectar
+keybind.chat=Chat
 common.reset=Restablecer
 ui.resources=Recursos

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -27,5 +27,6 @@ keybind.moveDown=Bas
 keybind.moveLeft=Gauche
 keybind.moveRight=Droite
 keybind.gather=Récolter
+keybind.chat=Chat
 common.reset=Réinitialiser
 ui.resources=Ressources

--- a/core/src/net/lapidist/colony/settings/KeyAction.java
+++ b/core/src/net/lapidist/colony/settings/KeyAction.java
@@ -8,7 +8,8 @@ public enum KeyAction {
     MOVE_DOWN("moveDown"),
     MOVE_LEFT("moveLeft"),
     MOVE_RIGHT("moveRight"),
-    GATHER("gather");
+    GATHER("gather"),
+    CHAT("chat");
 
     private final String i18nKey;
 

--- a/core/src/net/lapidist/colony/settings/KeyBindings.java
+++ b/core/src/net/lapidist/colony/settings/KeyBindings.java
@@ -17,7 +17,8 @@ public final class KeyBindings {
             KeyAction.MOVE_DOWN, Input.Keys.S,
             KeyAction.MOVE_LEFT, Input.Keys.A,
             KeyAction.MOVE_RIGHT, Input.Keys.D,
-            KeyAction.GATHER, Input.Keys.H
+            KeyAction.GATHER, Input.Keys.H,
+            KeyAction.CHAT, Input.Keys.ENTER
     );
 
     private final EnumMap<KeyAction, Integer> bindings = new EnumMap<>(KeyAction.class);

--- a/tests/src/net/lapidist/colony/tests/screens/MapUiBuilderTest.java
+++ b/tests/src/net/lapidist/colony/tests/screens/MapUiBuilderTest.java
@@ -1,6 +1,5 @@
 package net.lapidist.colony.tests.screens;
 
-import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.utils.viewport.ScreenViewport;
@@ -10,12 +9,14 @@ import net.lapidist.colony.client.Colony;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.client.screens.MapUi;
 import net.lapidist.colony.client.screens.MapUiBuilder;
+import net.lapidist.colony.settings.KeyAction;
+import net.lapidist.colony.settings.Settings;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 @RunWith(GdxTestRunner.class)
 public class MapUiBuilderTest {
@@ -26,9 +27,11 @@ public class MapUiBuilderTest {
         World world = new World(new WorldConfigurationBuilder().build());
         GameClient client = mock(GameClient.class);
         Colony colony = mock(Colony.class);
+        Settings settings = new Settings();
+        when(colony.getSettings()).thenReturn(settings);
         MapUi ui = MapUiBuilder.build(stage, world, client, colony);
 
-        stage.keyDown(Input.Keys.ENTER);
+        stage.keyDown(settings.getKeyBindings().getKey(KeyAction.CHAT));
 
         assertTrue(ui.getChatBox().isInputVisible());
     }


### PR DESCRIPTION
## Summary
- add CHAT action to KeyAction enum
- map ENTER key to the new CHAT action by default
- use key binding for opening chat input
- support chat key in all locale files
- adjust MapUiBuilder tests for configurable chat key

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_6846e71eda008328894011a96e53c3a0