### PR TITLE
feat: persist player resources across saves

### DIFF
--- a/client/src/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -17,6 +17,7 @@ import net.lapidist.colony.client.systems.network.ResourceUpdateSystem;
 import net.lapidist.colony.client.systems.MapInitSystem;
 import net.lapidist.colony.client.systems.PlayerInitSystem;
 import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.ResourceData;
 import net.lapidist.colony.map.MapStateProvider;
 import net.lapidist.colony.map.ProvidedMapStateProvider;
 import net.lapidist.colony.core.events.Events;
@@ -45,6 +46,15 @@ public final class MapWorldBuilder {
             final Stage stage,
             final KeyBindings keyBindings
     ) {
+        return baseBuilder(client, stage, keyBindings, new ResourceData());
+    }
+
+    public static WorldConfigurationBuilder baseBuilder(
+            final GameClient client,
+            final Stage stage,
+            final KeyBindings keyBindings,
+            final ResourceData playerResources
+    ) {
         InputSystem inputSystem = new InputSystem(client, keyBindings);
         inputSystem.addProcessor(stage);
 
@@ -53,7 +63,7 @@ public final class MapWorldBuilder {
                         new EventSystem(),
                         new ClearScreenSystem(Color.BLACK),
                         inputSystem,
-                        new PlayerInitSystem(),
+                        new PlayerInitSystem(playerResources),
                         new TileUpdateSystem(client),
                         new BuildingUpdateSystem(client),
                         new ResourceUpdateSystem(client),
@@ -77,7 +87,7 @@ public final class MapWorldBuilder {
             final Stage stage,
             final KeyBindings keyBindings
     ) {
-        return baseBuilder(client, stage, keyBindings)
+        return baseBuilder(client, stage, keyBindings, new ResourceData())
                 .with(
                         new MapInitSystem(provider),
                         new PlayerCameraSystem()
@@ -93,7 +103,11 @@ public final class MapWorldBuilder {
             final Stage stage,
             final KeyBindings keyBindings
     ) {
-        return builder(new ProvidedMapStateProvider(state), client, stage, keyBindings);
+        return baseBuilder(client, stage, keyBindings, state.playerResources())
+                .with(
+                        new MapInitSystem(new ProvidedMapStateProvider(state)),
+                        new PlayerCameraSystem()
+                );
     }
 
     /**

--- a/client/src/net/lapidist/colony/client/systems/PlayerInitSystem.java
+++ b/client/src/net/lapidist/colony/client/systems/PlayerInitSystem.java
@@ -3,16 +3,30 @@ package net.lapidist.colony.client.systems;
 import com.artemis.BaseSystem;
 import com.artemis.Entity;
 import net.lapidist.colony.components.resources.PlayerResourceComponent;
+import net.lapidist.colony.components.state.ResourceData;
 
 /** Creates a player entity with resource storage. */
 public final class PlayerInitSystem extends BaseSystem {
     private boolean created;
+    private final ResourceData initialResources;
+
+    public PlayerInitSystem() {
+        this(new ResourceData());
+    }
+
+    public PlayerInitSystem(final ResourceData resources) {
+        this.initialResources = resources;
+    }
 
     @Override
     public void initialize() {
         if (!created) {
             Entity player = world.createEntity();
-            player.edit().add(new PlayerResourceComponent());
+            PlayerResourceComponent pr = new PlayerResourceComponent();
+            pr.setWood(initialResources.wood());
+            pr.setStone(initialResources.stone());
+            pr.setFood(initialResources.food());
+            player.edit().add(pr);
             created = true;
         }
     }

--- a/core/src/net/lapidist/colony/components/resources/PlayerResourceComponent.java
+++ b/core/src/net/lapidist/colony/components/resources/PlayerResourceComponent.java
@@ -12,6 +12,10 @@ public final class PlayerResourceComponent extends Component {
         return wood;
     }
 
+    public void setWood(final int amount) {
+        this.wood = amount;
+    }
+
     public void addWood(final int amount) {
         this.wood += amount;
     }
@@ -20,12 +24,20 @@ public final class PlayerResourceComponent extends Component {
         return stone;
     }
 
+    public void setStone(final int amount) {
+        this.stone = amount;
+    }
+
     public void addStone(final int amount) {
         this.stone += amount;
     }
 
     public int getFood() {
         return food;
+    }
+
+    public void setFood(final int amount) {
+        this.food = amount;
     }
 
     public void addFood(final int amount) {

--- a/core/src/net/lapidist/colony/components/state/MapState.java
+++ b/core/src/net/lapidist/colony/components/state/MapState.java
@@ -17,7 +17,8 @@ public record MapState(
         String autosaveName,
         String description,
         Map<TilePos, TileData> tiles,
-        List<BuildingData> buildings
+        List<BuildingData> buildings,
+        ResourceData playerResources
 ) {
     public static final int CURRENT_VERSION = SaveVersion.CURRENT.number();
 
@@ -29,7 +30,8 @@ public record MapState(
                 null,
                 null,
                 new HashMap<>(),
-                new ArrayList<>()
+                new ArrayList<>(),
+                new ResourceData()
         );
     }
 
@@ -49,6 +51,7 @@ public record MapState(
         private String description;
         private Map<TilePos, TileData> tiles;
         private List<BuildingData> buildings;
+        private ResourceData playerResources;
 
         private Builder() {
             this.version = CURRENT_VERSION;
@@ -58,6 +61,7 @@ public record MapState(
             this.description = null;
             this.tiles = new HashMap<>();
             this.buildings = new ArrayList<>();
+            this.playerResources = new ResourceData();
         }
 
         private Builder(final MapState state) {
@@ -68,6 +72,7 @@ public record MapState(
             this.description = state.description;
             this.tiles = state.tiles;
             this.buildings = state.buildings;
+            this.playerResources = state.playerResources;
         }
 
         public Builder version(final int newVersion) {
@@ -105,8 +110,13 @@ public record MapState(
             return this;
         }
 
+        public Builder playerResources(final ResourceData newResources) {
+            this.playerResources = newResources;
+            return this;
+        }
+
         public MapState build() {
-            return new MapState(version, name, saveName, autosaveName, description, tiles, buildings);
+            return new MapState(version, name, saveName, autosaveName, description, tiles, buildings, playerResources);
         }
     }
 }

--- a/core/src/net/lapidist/colony/map/DefaultMapGenerator.java
+++ b/core/src/net/lapidist/colony/map/DefaultMapGenerator.java
@@ -38,6 +38,10 @@ public final class DefaultMapGenerator implements MapGenerator {
         BuildingData building = new BuildingData(width / 2, height / 2, "HOUSE", "house0");
         state.buildings().add(building);
 
+        state = state.toBuilder()
+                .playerResources(new ResourceData())
+                .build();
+
         return state;
     }
 

--- a/core/src/net/lapidist/colony/save/SaveMigrator.java
+++ b/core/src/net/lapidist/colony/save/SaveMigrator.java
@@ -16,6 +16,7 @@ public final class SaveMigrator {
         register(new V1ToV2Migration());
         register(new V2ToV3Migration());
         register(new V3ToV4Migration());
+        register(new V4ToV5Migration());
     }
 
     private SaveMigrator() {

--- a/core/src/net/lapidist/colony/save/SaveVersion.java
+++ b/core/src/net/lapidist/colony/save/SaveVersion.java
@@ -7,9 +7,10 @@ public enum SaveVersion {
     V1(1),
     V2(2),
     V3(3),
-    V4(4);
+    V4(4),
+    V5(5);
 
-    public static final SaveVersion CURRENT = V4;
+    public static final SaveVersion CURRENT = V5;
 
     private final int number;
 

--- a/core/src/net/lapidist/colony/save/V4ToV5Migration.java
+++ b/core/src/net/lapidist/colony/save/V4ToV5Migration.java
@@ -1,0 +1,25 @@
+package net.lapidist.colony.save;
+
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.ResourceData;
+
+/** Migration from save version 4 to version 5 adding player resources. */
+public final class V4ToV5Migration implements MapStateMigration {
+    @Override
+    public int fromVersion() {
+        return SaveVersion.V4.number();
+    }
+
+    @Override
+    public int toVersion() {
+        return SaveVersion.V5.number();
+    }
+
+    @Override
+    public MapState apply(final MapState state) {
+        return state.toBuilder()
+                .playerResources(new ResourceData())
+                .version(toVersion())
+                .build();
+    }
+}

--- a/server/src/net/lapidist/colony/server/GameServer.java
+++ b/server/src/net/lapidist/colony/server/GameServer.java
@@ -85,7 +85,7 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
             commandHandlers = java.util.List.of(
                     new TileSelectionCommandHandler(() -> mapState, networkService),
                     new BuildCommandHandler(() -> mapState, networkService),
-                    new GatherCommandHandler(() -> mapState, networkService)
+                    new GatherCommandHandler(() -> mapState, s -> mapState = s, networkService)
             );
         }
         commandBus.registerHandlers(commandHandlers);

--- a/tests/src/net/lapidist/colony/tests/server/GameServerPlayerResourceSaveTest.java
+++ b/tests/src/net/lapidist/colony/tests/server/GameServerPlayerResourceSaveTest.java
@@ -1,0 +1,47 @@
+package net.lapidist.colony.tests.server;
+
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.components.state.ResourceGatherRequestData;
+import net.lapidist.colony.server.GameServer;
+import net.lapidist.colony.server.GameServerConfig;
+import net.lapidist.colony.io.Paths;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertTrue;
+
+public class GameServerPlayerResourceSaveTest {
+
+    private static final int WAIT_MS = 200;
+
+    @Test
+    public void playerResourcesPersistAcrossSaves() throws Exception {
+        GameServerConfig config = GameServerConfig.builder()
+                .saveName("resource-save")
+                .autosaveInterval(WAIT_MS)
+                .build();
+        Paths.deleteAutosave("resource-save");
+        GameServer server = new GameServer(config);
+        server.start();
+
+        GameClient client = new GameClient();
+        CountDownLatch latch = new CountDownLatch(1);
+        client.start(state -> latch.countDown());
+        latch.await(1, TimeUnit.SECONDS);
+
+        client.sendGatherRequest(new ResourceGatherRequestData(0, 0, "WOOD"));
+        Thread.sleep(WAIT_MS);
+
+        client.stop();
+        server.stop();
+
+        GameServer server2 = new GameServer(config);
+        server2.start();
+        int wood = server2.getMapState().playerResources().wood();
+        server2.stop();
+
+        assertTrue(wood > 0);
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/server/GameStateIOMigrationV4Test.java
+++ b/tests/src/net/lapidist/colony/tests/server/GameStateIOMigrationV4Test.java
@@ -1,0 +1,43 @@
+package net.lapidist.colony.tests.server;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Output;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.core.serialization.KryoRegistry;
+import net.lapidist.colony.save.SaveData;
+import net.lapidist.colony.save.SaveVersion;
+import net.lapidist.colony.serialization.SerializationRegistrar;
+import net.lapidist.colony.server.io.GameStateIO;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+
+public class GameStateIOMigrationV4Test {
+
+    @Test
+    public void migratesV4ToCurrent() throws Exception {
+        Path file = Files.createTempFile("state", ".dat");
+        MapState state = new MapState()
+                .toBuilder()
+                .version(SaveVersion.V4.number())
+                .build();
+        Kryo kryo = new Kryo();
+        KryoRegistry.register(kryo);
+        try (Output output = new Output(Files.newOutputStream(file))) {
+            SaveData data = new SaveData(
+                    SaveVersion.V4.number(),
+                    SerializationRegistrar.registrationHash(),
+                    state
+            );
+            kryo.writeObject(output, data);
+        }
+
+        MapState loaded = GameStateIO.load(file);
+        Files.deleteIfExists(file);
+        assertEquals(SaveVersion.CURRENT.number(), loaded.version());
+        assertEquals(0, loaded.playerResources().wood());
+    }
+}


### PR DESCRIPTION
## Summary
- add player resources to `MapState`
- bump save version to v5 and migrate old saves
- update gather logic to store resources
- initialise player resources from save data
- verify persistence with new tests

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6846e9698cac8328abecc685809b0893