### PR TITLE
ci: generate javadoc during tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,6 +34,9 @@ jobs:
     - name: Run style checks
       run: ./gradlew check
 
+    - name: Generate Javadoc
+      run: ./gradlew aggregateJavadocs
+
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5
       with:


### PR DESCRIPTION
## Summary
- ensure javadoc generation happens during CI tests

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_6846e8dc81708328b14993d37c16cec7