### PR TITLE
build: run javadocs during check

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,8 +34,6 @@ jobs:
     - name: Run style checks
       run: ./gradlew check
 
-    - name: Generate Javadoc
-      run: ./gradlew aggregateJavadocs
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5

--- a/build.gradle
+++ b/build.gradle
@@ -172,3 +172,7 @@ tasks.register('aggregateJavadocs', Javadoc) {
     options.encoding = 'UTF-8'
     options.addBooleanOption('Xdoclint:none', true)
 }
+
+tasks.named('check') {
+    dependsOn 'aggregateJavadocs'
+}

--- a/core/src/net/lapidist/colony/chat/ChatMessage.java
+++ b/core/src/net/lapidist/colony/chat/ChatMessage.java
@@ -11,7 +11,7 @@ public record ChatMessage(int playerId, String text) {
     /**
      * Convenience constructor without a player id. Primarily used by tests.
      *
-     * @param text chat text
+     * @param message chat text
      */
     public ChatMessage(final String message) {
         this(-1, message);


### PR DESCRIPTION
## Summary
- ensure ChatMessage constructor javadoc matches parameter name
- run aggregateJavadocs as part of the `check` task
- remove redundant javadoc step from CI

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew aggregateJavadocs`


------
https://chatgpt.com/codex/tasks/task_e_6846f1ad646c83289fbe246c2fc32825