### PR TITLE
fix: handle missing resource textures

### DIFF
--- a/client/src/net/lapidist/colony/client/ui/MinimapActor.java
+++ b/client/src/net/lapidist/colony/client/ui/MinimapActor.java
@@ -96,7 +96,7 @@ public final class MinimapActor extends Actor implements Disposable {
         setSize(DEFAULT_SIZE, DEFAULT_SIZE);
         try {
             resourceLoader.load(FileLocation.INTERNAL, "textures/textures.atlas");
-        } catch (IOException e) {
+        } catch (IOException | com.badlogic.gdx.utils.GdxRuntimeException e) {
             // ignore loading errors in headless tests
         }
         mapWidthWorld = -1;

--- a/core/src/net/lapidist/colony/map/DefaultMapGenerator.java
+++ b/core/src/net/lapidist/colony/map/DefaultMapGenerator.java
@@ -14,11 +14,12 @@ import java.util.Random;
  */
 public final class DefaultMapGenerator implements MapGenerator {
 
-    private static final String[] TEXTURES = {"grass0", "dirt0"};
+    private static final String[] TERRAIN_TEXTURES = {"grass0", "dirt0"};
     private static final int NAME_RANGE = 100000;
-    private static final int DEFAULT_WOOD = 10;
-    private static final int DEFAULT_STONE = 5;
-    private static final int DEFAULT_FOOD = 3;
+    private static final int RESOURCE_AMOUNT = 10;
+    private static final int RESOURCE_CHANCE = 10; // percent
+    private static final int RANDOM_MAX = 100;
+    private static final int RESOURCE_TYPES = 3;
 
     @Override
     public MapState generate(final int width, final int height) {
@@ -46,14 +47,31 @@ public final class DefaultMapGenerator implements MapGenerator {
     }
 
     private static TileData createTile(final int x, final int y, final Random random) {
+        int chance = random.nextInt(RANDOM_MAX);
+        String texture;
+        ResourceData resources = new ResourceData();
+
+        if (chance < RESOURCE_CHANCE) {
+            texture = "wood0";
+            resources = new ResourceData(RESOURCE_AMOUNT, 0, 0);
+        } else if (chance < RESOURCE_CHANCE * 2) {
+            texture = "stone0";
+            resources = new ResourceData(0, RESOURCE_AMOUNT, 0);
+        } else if (chance < RESOURCE_CHANCE * RESOURCE_TYPES) {
+            texture = "food0";
+            resources = new ResourceData(0, 0, RESOURCE_AMOUNT);
+        } else {
+            texture = TERRAIN_TEXTURES[random.nextInt(TERRAIN_TEXTURES.length)];
+        }
+
         return TileData.builder()
                 .x(x)
                 .y(y)
                 .tileType("GRASS")
-                .textureRef(TEXTURES[random.nextInt(TEXTURES.length)])
+                .textureRef(texture)
                 .passable(true)
                 .selected(false)
-                .resources(new ResourceData(DEFAULT_WOOD, DEFAULT_STONE, DEFAULT_FOOD))
+                .resources(resources)
                 .build();
     }
 }

--- a/tests/src/net/lapidist/colony/tests/map/DefaultMapGeneratorTest.java
+++ b/tests/src/net/lapidist/colony/tests/map/DefaultMapGeneratorTest.java
@@ -5,6 +5,7 @@ import net.lapidist.colony.map.DefaultMapGenerator;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class DefaultMapGeneratorTest {
 
@@ -15,5 +16,29 @@ public class DefaultMapGeneratorTest {
         final int height = 3;
         MapState state = generator.generate(width, height);
         assertEquals(width * height, state.tiles().size());
+    }
+
+    @Test
+    public void placesRandomResourceTiles() {
+        DefaultMapGenerator generator = new DefaultMapGenerator();
+        final int size = 10;
+        MapState state = generator.generate(size, size);
+        long resourceTiles = state.tiles().values().stream()
+                .filter(t -> t.resources().wood() > 0 || t.resources().stone() > 0 || t.resources().food() > 0)
+                .count();
+        // ensure some but not all tiles contain resources
+        assertTrue(resourceTiles > 0 && resourceTiles < size * size);
+    }
+
+    @Test
+    public void generatesAllResourceTypes() {
+        DefaultMapGenerator generator = new DefaultMapGenerator();
+        final int size = 20;
+        MapState state = generator.generate(size, size);
+        boolean hasWood = state.tiles().values().stream().anyMatch(t -> t.resources().wood() > 0);
+        boolean hasStone = state.tiles().values().stream().anyMatch(t -> t.resources().stone() > 0);
+        boolean hasFood = state.tiles().values().stream().anyMatch(t -> t.resources().food() > 0);
+
+        assertTrue(hasWood && hasStone && hasFood);
     }
 }

--- a/tests/src/net/lapidist/colony/tests/scenario/GameSimulationPlayerResourcesTest.java
+++ b/tests/src/net/lapidist/colony/tests/scenario/GameSimulationPlayerResourcesTest.java
@@ -41,7 +41,12 @@ public class GameSimulationPlayerResourcesTest {
         MapState state = receiver.getMapState();
         GameSimulation sim = new GameSimulation(state, receiver);
 
-        ResourceGatherRequestData data = new ResourceGatherRequestData(0, 0, "WOOD");
+        var woodPos = state.tiles().entrySet().stream()
+                .filter(e -> e.getValue().resources().wood() > 0)
+                .map(java.util.Map.Entry::getKey)
+                .findFirst()
+                .orElse(new net.lapidist.colony.components.state.TilePos(0, 0));
+        ResourceGatherRequestData data = new ResourceGatherRequestData(woodPos.x(), woodPos.y(), "WOOD");
         sender.sendGatherRequest(data);
 
         Thread.sleep(WAIT_MS);

--- a/tests/src/net/lapidist/colony/tests/scenario/GameSimulationResourceUpdateTest.java
+++ b/tests/src/net/lapidist/colony/tests/scenario/GameSimulationResourceUpdateTest.java
@@ -42,7 +42,12 @@ public class GameSimulationResourceUpdateTest {
         MapState state = receiver.getMapState();
         GameSimulation sim = new GameSimulation(state, receiver);
 
-        ResourceGatherRequestData data = new ResourceGatherRequestData(0, 0, "WOOD");
+        var woodPos = state.tiles().entrySet().stream()
+                .filter(e -> e.getValue().resources().wood() > 0)
+                .map(java.util.Map.Entry::getKey)
+                .findFirst()
+                .orElse(new net.lapidist.colony.components.state.TilePos(0, 0));
+        ResourceGatherRequestData data = new ResourceGatherRequestData(woodPos.x(), woodPos.y(), "WOOD");
         sender.sendGatherRequest(data);
 
         Thread.sleep(WAIT_MS);

--- a/tests/src/net/lapidist/colony/tests/server/GameServerPlayerResourceSaveTest.java
+++ b/tests/src/net/lapidist/colony/tests/server/GameServerPlayerResourceSaveTest.java
@@ -31,7 +31,12 @@ public class GameServerPlayerResourceSaveTest {
         client.start(state -> latch.countDown());
         latch.await(1, TimeUnit.SECONDS);
 
-        client.sendGatherRequest(new ResourceGatherRequestData(0, 0, "WOOD"));
+        var woodPos = server.getMapState().tiles().entrySet().stream()
+                .filter(e -> e.getValue().resources().wood() > 0)
+                .map(java.util.Map.Entry::getKey)
+                .findFirst()
+                .orElse(new net.lapidist.colony.components.state.TilePos(0, 0));
+        client.sendGatherRequest(new ResourceGatherRequestData(woodPos.x(), woodPos.y(), "WOOD"));
         Thread.sleep(WAIT_MS);
 
         client.stop();


### PR DESCRIPTION
## Summary
- revert atlas to exclude resource textures
- handle missing textures in `MinimapActor`
- verify all resource types are generated
- remove placeholder texture images

## Testing
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_6846fe7977508328815da2c6e0d345d2