### PR TITLE
feat: show chat dialog and save versions

### DIFF
--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -31,3 +31,8 @@ keybind.gather=Gather
 keybind.chat=Chat
 common.reset=Reset
 ui.resources=Resources
+
+chat.dialogTitle=Chat
+chat.send=Send
+common.cancel=Cancel
+loadGame.migrate=Migrate

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -30,3 +30,8 @@ keybind.gather=Sammeln
 keybind.chat=Chat
 common.reset=Zurücksetzen
 ui.resources=Rohstoffe
+
+chat.dialogTitle=Chat
+chat.send=Senden
+common.cancel=Abbrechen
+loadGame.migrate=Migrieren

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -30,3 +30,8 @@ keybind.gather=Recolectar
 keybind.chat=Chat
 common.reset=Restablecer
 ui.resources=Recursos
+
+chat.dialogTitle=Chat
+chat.send=Enviar
+common.cancel=Cancelar
+loadGame.migrate=Migrar

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -30,3 +30,8 @@ keybind.gather=Récolter
 keybind.chat=Chat
 common.reset=Réinitialiser
 ui.resources=Ressources
+
+chat.dialogTitle=Chat
+chat.send=Envoyer
+common.cancel=Annuler
+loadGame.migrate=Migration

--- a/server/src/net/lapidist/colony/server/io/GameStateIO.java
+++ b/server/src/net/lapidist/colony/server/io/GameStateIO.java
@@ -43,5 +43,14 @@ public final class GameStateIO {
         }
     }
 
+    public static int readVersion(final Path file) throws IOException {
+        Kryo kryo = new Kryo();
+        KryoRegistry.register(kryo);
+        try (Input input = new Input(new FileInputStream(file.toFile()))) {
+            SaveData data = kryo.readObject(input, SaveData.class);
+            return data.version();
+        }
+    }
+
     // Class registration handled by KryoRegistry
 }


### PR DESCRIPTION
## Summary
- open a dialog for chat when pressing the chat key
- display autosave versions and migration button
- expose save version reader for autosaves
- add localization for chat dialog and migration action

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684704b7ac888328a80dfaa64c2cb03c