### PR TITLE
feat: add tile lookup helper

### DIFF
--- a/client/src/net/lapidist/colony/client/systems/InputSystem.java
+++ b/client/src/net/lapidist/colony/client/systems/InputSystem.java
@@ -18,6 +18,7 @@ import net.lapidist.colony.components.maps.TileComponent;
 import net.lapidist.colony.components.state.ResourceGatherRequestData;
 import net.lapidist.colony.components.resources.ResourceType;
 import net.lapidist.colony.client.util.CameraUtils;
+import net.lapidist.colony.map.MapUtils;
 import com.artemis.ComponentMapper;
 import net.lapidist.colony.settings.KeyAction;
 import net.lapidist.colony.settings.KeyBindings;
@@ -115,19 +116,16 @@ public final class InputSystem extends BaseSystem {
             Vector2 worldCoords = CameraUtils.screenToWorldCoords(
                     cameraSystem.getViewport(), x, y);
             Vector2 tileCoords = CameraUtils.worldCoordsToTileCoords(worldCoords);
-            for (int i = 0; i < map.getTiles().size; i++) {
-                var tile = map.getTiles().get(i);
-                TileComponent tc = tileMapper.get(tile);
-                if (tc.getX() == (int) tileCoords.x && tc.getY() == (int) tileCoords.y) {
-                    var rc = resourceMapper.get(tile);
-                    if (rc.getWood() > 0) {
-                        ResourceGatherRequestData msg = new ResourceGatherRequestData(
-                                tc.getX(), tc.getY(), ResourceType.WOOD.name());
-                        client.sendGatherRequest(msg);
-                    }
-                    break;
-                }
-            }
+            MapUtils.findTile(map, (int) tileCoords.x, (int) tileCoords.y, tileMapper)
+                    .ifPresent(tile -> {
+                        TileComponent tc = tileMapper.get(tile);
+                        var rc = resourceMapper.get(tile);
+                        if (rc.getWood() > 0) {
+                            ResourceGatherRequestData msg = new ResourceGatherRequestData(
+                                    tc.getX(), tc.getY(), ResourceType.WOOD.name());
+                            client.sendGatherRequest(msg);
+                        }
+                    });
         }
         return result;
     }

--- a/client/src/net/lapidist/colony/client/systems/input/BuildingPlacementHandler.java
+++ b/client/src/net/lapidist/colony/client/systems/input/BuildingPlacementHandler.java
@@ -1,9 +1,8 @@
 package net.lapidist.colony.client.systems.input;
 
 import com.artemis.ComponentMapper;
-import com.artemis.Entity;
 import com.badlogic.gdx.math.Vector2;
-import com.badlogic.gdx.utils.Array;
+import net.lapidist.colony.map.MapUtils;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
 import net.lapidist.colony.client.util.CameraUtils;
@@ -38,20 +37,17 @@ public final class BuildingPlacementHandler {
         Vector2 worldCoords = CameraUtils.screenToWorldCoords(cameraSystem.getViewport(), x, y);
         Vector2 tileCoords = CameraUtils.worldCoordsToTileCoords(worldCoords);
 
-        Array<Entity> tiles = map.getTiles();
-        for (int i = 0; i < tiles.size; i++) {
-            Entity tile = tiles.get(i);
-            TileComponent tc = tileMapper.get(tile);
-            if (tc.getX() == (int) tileCoords.x && tc.getY() == (int) tileCoords.y) {
-                BuildingPlacementData msg = new BuildingPlacementData(
-                        tc.getX(),
-                        tc.getY(),
-                        BuildingComponent.BuildingType.HOUSE.name()
-                );
-                client.sendBuildRequest(msg);
-                return true;
-            }
-        }
-        return false;
+        return MapUtils.findTile(map, (int) tileCoords.x, (int) tileCoords.y, tileMapper)
+                .map(tile -> {
+                    TileComponent tc = tileMapper.get(tile);
+                    BuildingPlacementData msg = new BuildingPlacementData(
+                            tc.getX(),
+                            tc.getY(),
+                            BuildingComponent.BuildingType.HOUSE.name()
+                    );
+                    client.sendBuildRequest(msg);
+                    return true;
+                })
+                .orElse(false);
     }
 }

--- a/client/src/net/lapidist/colony/client/systems/input/TileSelectionHandler.java
+++ b/client/src/net/lapidist/colony/client/systems/input/TileSelectionHandler.java
@@ -1,9 +1,8 @@
 package net.lapidist.colony.client.systems.input;
 
 import com.artemis.ComponentMapper;
-import com.artemis.Entity;
 import com.badlogic.gdx.math.Vector2;
-import com.badlogic.gdx.utils.Array;
+import net.lapidist.colony.map.MapUtils;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
 import net.lapidist.colony.client.util.CameraUtils;
@@ -42,23 +41,19 @@ public final class TileSelectionHandler {
         Vector2 worldCoords = CameraUtils.screenToWorldCoords(cameraSystem.getViewport(), x, y);
         Vector2 tileCoords = CameraUtils.worldCoordsToTileCoords(worldCoords);
 
-        Array<Entity> tiles = map.getTiles();
-        for (int i = 0; i < tiles.size; i++) {
-            Entity tile = tiles.get(i);
-            TileComponent tileComponent = tileMapper.get(tile);
-            if (tileComponent.getX() == (int) tileCoords.x && tileComponent.getY() == (int) tileCoords.y) {
-                boolean newState = !tileComponent.isSelected();
+        return MapUtils.findTile(map, (int) tileCoords.x, (int) tileCoords.y, tileMapper)
+                .map(tile -> {
+                    TileComponent tileComponent = tileMapper.get(tile);
+                    boolean newState = !tileComponent.isSelected();
 
-                TileSelectionData msg = new TileSelectionData(
-                        tileComponent.getX(),
-                        tileComponent.getY(),
-                        newState
-                );
-                client.sendTileSelectionRequest(msg);
-                return true;
-            }
-        }
-
-        return false;
+                    TileSelectionData msg = new TileSelectionData(
+                            tileComponent.getX(),
+                            tileComponent.getY(),
+                            newState
+                    );
+                    client.sendTileSelectionRequest(msg);
+                    return true;
+                })
+                .orElse(false);
     }
 }

--- a/core/src/net/lapidist/colony/map/MapUtils.java
+++ b/core/src/net/lapidist/colony/map/MapUtils.java
@@ -5,6 +5,8 @@ import com.artemis.Entity;
 import com.artemis.World;
 import com.artemis.utils.IntBag;
 import net.lapidist.colony.components.maps.MapComponent;
+import net.lapidist.colony.components.maps.TileComponent;
+import com.artemis.ComponentMapper;
 import java.util.Optional;
 
 /**
@@ -45,6 +47,36 @@ public final class MapUtils {
                     world.getMapper(MapComponent.class).get(maps.get(0))
             );
         }
+        return Optional.empty();
+    }
+
+    /**
+     * Finds a tile entity at the given map coordinates.
+     *
+     * @param map    the map component containing tiles
+     * @param x      the tile x coordinate
+     * @param y      the tile y coordinate
+     * @param mapper mapper for {@link TileComponent} instances
+     * @return an {@link Optional} containing the tile entity if present
+     */
+    public static Optional<Entity> findTile(
+            final MapComponent map,
+            final int x,
+            final int y,
+            final ComponentMapper<TileComponent> mapper
+    ) {
+        if (map == null) {
+            return Optional.empty();
+        }
+
+        for (int i = 0; i < map.getTiles().size; i++) {
+            Entity tile = map.getTiles().get(i);
+            TileComponent tc = mapper.get(tile);
+            if (tc.getX() == x && tc.getY() == y) {
+                return Optional.of(tile);
+            }
+        }
+
         return Optional.empty();
     }
 }

--- a/tests/src/net/lapidist/colony/tests/map/MapUtilsTest.java
+++ b/tests/src/net/lapidist/colony/tests/map/MapUtilsTest.java
@@ -8,6 +8,8 @@ import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.map.MapUtils;
+import net.lapidist.colony.components.maps.TileComponent;
+import com.artemis.ComponentMapper;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -42,5 +44,30 @@ public class MapUtilsTest {
         MapComponent map = MapUtils.findMap(world).orElse(null);
         assertNotNull(map);
         assertEquals(1, map.getTiles().size);
+    }
+
+    @Test
+    public void findsTileByCoordinates() {
+        MapState state = new MapState();
+        TileData tile = TileData.builder()
+                .x(1)
+                .y(2)
+                .tileType("GRASS")
+                .textureRef("grass0")
+                .passable(true)
+                .build();
+        state.tiles().put(new TilePos(1, 2), tile);
+
+        World world = new World(new WorldConfigurationBuilder()
+                .with(new MapLoadSystem(state))
+                .build());
+        world.process();
+
+        MapComponent map = MapUtils.findMap(world).orElse(null);
+        assertNotNull(map);
+        ComponentMapper<TileComponent> mapper = world.getMapper(TileComponent.class);
+
+        assertTrue(MapUtils.findTile(map, 1, 2, mapper).isPresent());
+        assertTrue(MapUtils.findTile(map, 0, 0, mapper).isEmpty());
     }
 }

--- a/tests/src/net/lapidist/colony/tests/scenario/GameSimulationDelayedTileUpdateTest.java
+++ b/tests/src/net/lapidist/colony/tests/scenario/GameSimulationDelayedTileUpdateTest.java
@@ -8,6 +8,7 @@ import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.client.util.CameraUtils;
 import net.lapidist.colony.components.maps.MapComponent;
 import net.lapidist.colony.components.maps.TileComponent;
+import net.lapidist.colony.map.MapUtils;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.server.GameServerConfig;
@@ -75,14 +76,12 @@ public class GameSimulationDelayedTileUpdateTest {
         Entity map = sim.getWorld().getEntity(maps.get(0));
         MapComponent mapComponent = sim.getWorld().getMapper(MapComponent.class)
                 .get(map);
-        for (int i = 0; i < mapComponent.getTiles().size; i++) {
-            TileComponent tc = sim.getWorld()
-                    .getMapper(TileComponent.class)
-                    .get(mapComponent.getTiles().get(i));
-            if (tc.getX() == 0 && tc.getY() == 0) {
-                return tc;
-            }
-        }
-        return null;
+        return MapUtils.findTile(
+                mapComponent,
+                0,
+                0,
+                sim.getWorld().getMapper(TileComponent.class)
+        ).map(t -> sim.getWorld().getMapper(TileComponent.class).get(t))
+                .orElse(null);
     }
 }

--- a/tests/src/net/lapidist/colony/tests/scenario/GameSimulationInputSelectionTest.java
+++ b/tests/src/net/lapidist/colony/tests/scenario/GameSimulationInputSelectionTest.java
@@ -8,6 +8,7 @@ import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.client.util.CameraUtils;
 import net.lapidist.colony.components.maps.MapComponent;
 import net.lapidist.colony.components.maps.TileComponent;
+import net.lapidist.colony.map.MapUtils;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.server.GameServerConfig;
@@ -62,16 +63,15 @@ public class GameSimulationInputSelectionTest {
             Entity map = sim.getWorld().getEntity(maps.get(0));
             MapComponent mapComponent =
                     sim.getWorld().getMapper(MapComponent.class).get(map);
-            TileComponent tile = null;
-            for (int i = 0; i < mapComponent.getTiles().size; i++) {
-                TileComponent tc = sim.getWorld()
-                        .getMapper(TileComponent.class)
-                        .get(mapComponent.getTiles().get(i));
-                if (tc.getX() == 0 && tc.getY() == 0) {
-                    tile = tc;
-                    break;
-                }
-            }
+            var tileOpt = MapUtils.findTile(
+                    mapComponent,
+                    0,
+                    0,
+                    sim.getWorld().getMapper(TileComponent.class)
+            );
+            TileComponent tile = tileOpt.map(
+                    t -> sim.getWorld().getMapper(TileComponent.class).get(t)
+            ).orElse(null);
             assertTrue(tile != null && tile.isSelected());
         } finally {
             client.stop();


### PR DESCRIPTION
## Summary
- add `MapUtils.findTile` helper for locating tiles by coordinates
- leverage helper in building placement, tile selection and tap gather logic
- update tests to cover the new method

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684765cb4df88328beb1afdafec661aa