### PR TITLE
refactor: make Paths instantiable

### DIFF
--- a/client/src/net/lapidist/colony/client/Colony.java
+++ b/client/src/net/lapidist/colony/client/Colony.java
@@ -63,7 +63,7 @@ public final class Colony extends Game {
     public void create() {
         // Do global initialisation
         try {
-            Paths.createGameFoldersIfNotExists();
+            Paths.get().createGameFoldersIfNotExists();
             settings = Settings.load();
             I18n.setLocale(settings.getLocale());
         } catch (IOException e) {

--- a/client/src/net/lapidist/colony/client/screens/LoadGameScreen.java
+++ b/client/src/net/lapidist/colony/client/screens/LoadGameScreen.java
@@ -44,7 +44,7 @@ public final class LoadGameScreen extends BaseScreen {
                         protected void result(final Object obj) {
                             if (Boolean.TRUE.equals(obj)) {
                                 try {
-                                    Paths.deleteAutosave(save);
+                                    Paths.get().deleteAutosave(save);
                                 } catch (IOException e) {
                                     // ignore
                                 }
@@ -72,7 +72,7 @@ public final class LoadGameScreen extends BaseScreen {
 
     private List<String> listSaves() {
         try {
-            return Paths.listAutosaves();
+            return Paths.get().listAutosaves();
         } catch (IOException e) {
             return new ArrayList<>();
         }

--- a/client/src/net/lapidist/colony/client/screens/MainMenuScreen.java
+++ b/client/src/net/lapidist/colony/client/screens/MainMenuScreen.java
@@ -27,10 +27,10 @@ public final class MainMenuScreen extends BaseScreen {
         String lastSave = null;
         boolean canContinue = false;
         try {
-            Path marker = Paths.getLastAutosaveMarker();
+            Path marker = Paths.get().getLastAutosaveMarker();
             if (Files.exists(marker)) {
                 lastSave = Files.readString(marker).trim();
-                canContinue = Files.exists(Paths.getAutosave(lastSave));
+                canContinue = Files.exists(Paths.get().getAutosave(lastSave));
             }
         } catch (IOException e) {
             // ignore missing last autosave marker

--- a/core/src/net/lapidist/colony/io/Paths.java
+++ b/core/src/net/lapidist/colony/io/Paths.java
@@ -15,9 +15,17 @@ public final class Paths {
 
     public static final String AUTOSAVE_SUFFIX = "-autosave.dat";
 
-    private static PathService service = createDefaultService();
+    private static final Paths INSTANCE = new Paths(createDefaultService());
 
-    private Paths() { }
+    private final PathService service;
+
+    public static Paths get() {
+        return INSTANCE;
+    }
+
+    public Paths(final PathService serviceToUse) {
+        this.service = serviceToUse;
+    }
 
     /**
      * Creates the default {@link PathService} for the current operating system.
@@ -30,45 +38,35 @@ public final class Paths {
         return new UnixPathService();
     }
 
-    /**
-     * Replace the underlying {@link PathService} implementation.
-     * Primarily used for testing.
-     *
-     * @param newService service to use
-     */
-    public static void setService(final PathService newService) {
-        service = newService;
-    }
-
-    public static void createGameFoldersIfNotExists() throws IOException {
+    public void createGameFoldersIfNotExists() throws IOException {
         service.createGameFoldersIfNotExists();
     }
 
-    public static Path getSettingsFile() throws IOException {
+    public Path getSettingsFile() throws IOException {
         return service.getSettingsFile();
     }
 
-    public static Path getSaveFile(final String fileName) throws IOException {
+    public Path getSaveFile(final String fileName) throws IOException {
         return service.getSaveFile(fileName);
     }
 
-    public static Path getSave(final String saveName) throws IOException {
+    public Path getSave(final String saveName) throws IOException {
         return service.getSave(saveName);
     }
 
-    public static Path getAutosave(final String saveName) throws IOException {
+    public Path getAutosave(final String saveName) throws IOException {
         return service.getAutosave(saveName);
     }
 
-    public static Path getLastAutosaveMarker() throws IOException {
+    public Path getLastAutosaveMarker() throws IOException {
         return service.getLastAutosaveMarker();
     }
 
-    public static List<String> listAutosaves() throws IOException {
+    public List<String> listAutosaves() throws IOException {
         return service.listAutosaves();
     }
 
-    public static void deleteAutosave(final String saveName) throws IOException {
+    public void deleteAutosave(final String saveName) throws IOException {
         service.deleteAutosave(saveName);
     }
 }

--- a/server/src/net/lapidist/colony/server/GameServer.java
+++ b/server/src/net/lapidist/colony/server/GameServer.java
@@ -76,7 +76,7 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
     public void start() throws IOException, InterruptedException {
         KryoRegistry.register(server.getKryo());
         Events.init(new EventSystem());
-        Paths.createGameFoldersIfNotExists();
+        Paths.get().createGameFoldersIfNotExists();
 
         mapState = mapService.load();
         networkService.start(mapState, this::dispatch);

--- a/server/src/net/lapidist/colony/server/services/AutosaveService.java
+++ b/server/src/net/lapidist/colony/server/services/AutosaveService.java
@@ -73,7 +73,7 @@ public final class AutosaveService {
     private void saveGameState(final java.util.function.BiFunction<Path, Long, SaveEvent> creator, final String log) {
         MapState mapState = supplier.get();
         try {
-            Path file = Paths.getAutosave(saveName);
+            Path file = Paths.get().getAutosave(saveName);
             GameStateIO.save(mapState, file);
             long size = Files.size(file);
             Events.dispatch(creator.apply(file, size));

--- a/server/src/net/lapidist/colony/server/services/MapService.java
+++ b/server/src/net/lapidist/colony/server/services/MapService.java
@@ -28,7 +28,7 @@ public final class MapService {
     }
 
     public MapState load() throws IOException {
-        Path saveFile = Paths.getAutosave(saveName);
+        Path saveFile = Paths.get().getAutosave(saveName);
         MapState state;
         if (Files.exists(saveFile)) {
             state = GameStateIO.load(saveFile);
@@ -42,7 +42,7 @@ public final class MapService {
                 .saveName(saveName)
                 .autosaveName(saveName + Paths.AUTOSAVE_SUFFIX)
                 .build();
-        Files.writeString(Paths.getLastAutosaveMarker(), saveName);
+        Files.writeString(Paths.get().getLastAutosaveMarker(), saveName);
         return state;
     }
 

--- a/tests/src/net/lapidist/colony/tests/core/io/AutosaveDeleteTest.java
+++ b/tests/src/net/lapidist/colony/tests/core/io/AutosaveDeleteTest.java
@@ -13,11 +13,11 @@ public class AutosaveDeleteTest {
 
     @Test
     public void deleteAutosaveRemovesFile() throws Exception {
-        Paths.createGameFoldersIfNotExists();
-        Path file = Paths.getAutosave("delete-test");
+        Paths.get().createGameFoldersIfNotExists();
+        Path file = Paths.get().getAutosave("delete-test");
         Files.writeString(file, "dummy");
         assertTrue(Files.exists(file));
-        Paths.deleteAutosave("delete-test");
+        Paths.get().deleteAutosave("delete-test");
         assertFalse(Files.exists(file));
     }
 }

--- a/tests/src/net/lapidist/colony/tests/core/io/PathServiceResolutionTest.java
+++ b/tests/src/net/lapidist/colony/tests/core/io/PathServiceResolutionTest.java
@@ -34,7 +34,6 @@ public class PathServiceResolutionTest {
         System.setProperty("user.home", oldUserHome);
         System.setProperty("os.name", oldOsName);
         Gdx.files = oldFiles;
-        Paths.setService(Paths.createDefaultService());
     }
 
     @Test
@@ -54,9 +53,9 @@ public class PathServiceResolutionTest {
         Path tmp = java.nio.file.Files.createTempDirectory("unix");
         System.setProperty("user.home", tmp.toString());
         PathService service = new UnixPathService();
-        Paths.setService(service);
+        Paths paths = new Paths(service);
 
-        Path save = Paths.getSave("foo");
+        Path save = paths.getSave("foo");
         Path expected = java.nio.file.Paths.get(tmp.toString(), ".colony", "saves", "foo.dat");
         assertEquals(expected, save);
     }
@@ -66,9 +65,9 @@ public class PathServiceResolutionTest {
         Path tmp = java.nio.file.Files.createTempDirectory("win");
         System.setProperty("user.home", tmp.toString());
         PathService service = new WindowsPathService();
-        Paths.setService(service);
+        Paths paths = new Paths(service);
 
-        Path save = Paths.getSave("bar");
+        Path save = paths.getSave("bar");
         Path expected = java.nio.file.Paths.get(tmp.toString(), ".colony", "saves", "bar.dat");
         assertEquals(expected, save);
     }

--- a/tests/src/net/lapidist/colony/tests/core/io/PathsTest.java
+++ b/tests/src/net/lapidist/colony/tests/core/io/PathsTest.java
@@ -2,7 +2,6 @@ package net.lapidist.colony.tests.core.io;
 
 import net.lapidist.colony.io.PathService;
 import net.lapidist.colony.io.Paths;
-import org.junit.After;
 import org.junit.Test;
 
 import java.nio.file.Path;
@@ -14,19 +13,15 @@ import static org.mockito.Mockito.*;
 
 public class PathsTest {
 
-    @After
-    public void tearDown() {
-        Paths.setService(Paths.createDefaultService());
-    }
 
     @Test
     public void delegatesGetSave() throws Exception {
         PathService service = mock(PathService.class);
         Path expected = java.nio.file.Paths.get("save.dat");
         when(service.getSave("save")).thenReturn(expected);
-        Paths.setService(service);
+        Paths paths = new Paths(service);
 
-        Path actual = Paths.getSave("save");
+        Path actual = paths.getSave("save");
         assertEquals(expected, actual);
         verify(service).getSave("save");
     }
@@ -36,9 +31,9 @@ public class PathsTest {
         PathService service = mock(PathService.class);
         Path expected = java.nio.file.Paths.get("save" + Paths.AUTOSAVE_SUFFIX);
         when(service.getAutosave("save")).thenReturn(expected);
-        Paths.setService(service);
+        Paths paths = new Paths(service);
 
-        Path actual = Paths.getAutosave("save");
+        Path actual = paths.getAutosave("save");
         assertEquals(expected, actual);
         verify(service).getAutosave("save");
     }
@@ -48,9 +43,9 @@ public class PathsTest {
         PathService service = mock(PathService.class);
         List<String> expected = Arrays.asList("a", "b");
         when(service.listAutosaves()).thenReturn(expected);
-        Paths.setService(service);
+        Paths paths = new Paths(service);
 
-        List<String> actual = Paths.listAutosaves();
+        List<String> actual = paths.listAutosaves();
         assertEquals(expected, actual);
         verify(service).listAutosaves();
     }
@@ -58,18 +53,18 @@ public class PathsTest {
     @Test
     public void delegatesDeleteAutosave() throws Exception {
         PathService service = mock(PathService.class);
-        Paths.setService(service);
+        Paths paths = new Paths(service);
 
-        Paths.deleteAutosave("temp");
+        paths.deleteAutosave("temp");
         verify(service).deleteAutosave("temp");
     }
 
     @Test
     public void delegatesCreateGameFoldersIfNotExists() throws Exception {
         PathService service = mock(PathService.class);
-        Paths.setService(service);
+        Paths paths = new Paths(service);
 
-        Paths.createGameFoldersIfNotExists();
+        paths.createGameFoldersIfNotExists();
         verify(service).createGameFoldersIfNotExists();
     }
 
@@ -78,9 +73,9 @@ public class PathsTest {
         PathService service = mock(PathService.class);
         Path expected = java.nio.file.Paths.get("settings.properties");
         when(service.getSettingsFile()).thenReturn(expected);
-        Paths.setService(service);
+        Paths paths = new Paths(service);
 
-        Path actual = Paths.getSettingsFile();
+        Path actual = paths.getSettingsFile();
         assertEquals(expected, actual);
         verify(service).getSettingsFile();
     }

--- a/tests/src/net/lapidist/colony/tests/network/GameServerBroadcastTest.java
+++ b/tests/src/net/lapidist/colony/tests/network/GameServerBroadcastTest.java
@@ -20,7 +20,7 @@ public class GameServerBroadcastTest {
         GameServerConfig config = GameServerConfig.builder()
                 .saveName("broadcast")
                 .build();
-        net.lapidist.colony.io.Paths.deleteAutosave("broadcast");
+        net.lapidist.colony.io.Paths.get().deleteAutosave("broadcast");
         GameServer server = new GameServer(config);
         server.start();
 

--- a/tests/src/net/lapidist/colony/tests/network/GameServerBuildBroadcastTest.java
+++ b/tests/src/net/lapidist/colony/tests/network/GameServerBuildBroadcastTest.java
@@ -22,7 +22,7 @@ public class GameServerBuildBroadcastTest {
         GameServerConfig config = GameServerConfig.builder()
                 .saveName("build-broadcast")
                 .build();
-        net.lapidist.colony.io.Paths.deleteAutosave("build-broadcast");
+        net.lapidist.colony.io.Paths.get().deleteAutosave("build-broadcast");
         GameServer server = new GameServer(config);
         server.start();
 

--- a/tests/src/net/lapidist/colony/tests/network/GameServerChatBroadcastTest.java
+++ b/tests/src/net/lapidist/colony/tests/network/GameServerChatBroadcastTest.java
@@ -21,7 +21,7 @@ public class GameServerChatBroadcastTest {
         GameServerConfig config = GameServerConfig.builder()
                 .saveName("chat-broadcast")
                 .build();
-        net.lapidist.colony.io.Paths.deleteAutosave("chat-broadcast");
+        net.lapidist.colony.io.Paths.get().deleteAutosave("chat-broadcast");
         GameServer server = new GameServer(config);
         server.start();
 

--- a/tests/src/net/lapidist/colony/tests/network/GameServerGatherBroadcastTest.java
+++ b/tests/src/net/lapidist/colony/tests/network/GameServerGatherBroadcastTest.java
@@ -22,7 +22,7 @@ public class GameServerGatherBroadcastTest {
         GameServerConfig config = GameServerConfig.builder()
                 .saveName("gather-broadcast")
                 .build();
-        net.lapidist.colony.io.Paths.deleteAutosave("gather-broadcast");
+        net.lapidist.colony.io.Paths.get().deleteAutosave("gather-broadcast");
         GameServer server = new GameServer(config);
         server.start();
 

--- a/tests/src/net/lapidist/colony/tests/scenario/GameSimulationBuildingUpdateTest.java
+++ b/tests/src/net/lapidist/colony/tests/scenario/GameSimulationBuildingUpdateTest.java
@@ -25,7 +25,7 @@ public class GameSimulationBuildingUpdateTest {
         GameServerConfig config = GameServerConfig.builder()
                 .saveName("scenario-build")
                 .build();
-        net.lapidist.colony.io.Paths.deleteAutosave("scenario-build");
+        net.lapidist.colony.io.Paths.get().deleteAutosave("scenario-build");
         GameServer server = new GameServer(config);
         server.start();
 

--- a/tests/src/net/lapidist/colony/tests/scenario/GameSimulationDelayedTileUpdateTest.java
+++ b/tests/src/net/lapidist/colony/tests/scenario/GameSimulationDelayedTileUpdateTest.java
@@ -35,7 +35,7 @@ public class GameSimulationDelayedTileUpdateTest {
         GameServerConfig config = GameServerConfig.builder()
                 .saveName("scenario")
                 .build();
-        Paths.deleteAutosave("scenario");
+        Paths.get().deleteAutosave("scenario");
         GameServer server = new GameServer(config);
         server.start();
 

--- a/tests/src/net/lapidist/colony/tests/scenario/GameSimulationInputSelectionTest.java
+++ b/tests/src/net/lapidist/colony/tests/scenario/GameSimulationInputSelectionTest.java
@@ -35,7 +35,7 @@ public class GameSimulationInputSelectionTest {
         GameServerConfig config = GameServerConfig.builder()
                 .saveName("scenario")
                 .build();
-        Paths.deleteAutosave("scenario");
+        Paths.get().deleteAutosave("scenario");
         GameServer server = new GameServer(config);
         server.start();
 

--- a/tests/src/net/lapidist/colony/tests/scenario/GameSimulationPlayerResourcesTest.java
+++ b/tests/src/net/lapidist/colony/tests/scenario/GameSimulationPlayerResourcesTest.java
@@ -25,7 +25,7 @@ public class GameSimulationPlayerResourcesTest {
         GameServerConfig config = GameServerConfig.builder()
                 .saveName("scenario-player")
                 .build();
-        net.lapidist.colony.io.Paths.deleteAutosave("scenario-player");
+        net.lapidist.colony.io.Paths.get().deleteAutosave("scenario-player");
         GameServer server = new GameServer(config);
         server.start();
 

--- a/tests/src/net/lapidist/colony/tests/scenario/GameSimulationResourceUpdateTest.java
+++ b/tests/src/net/lapidist/colony/tests/scenario/GameSimulationResourceUpdateTest.java
@@ -26,7 +26,7 @@ public class GameSimulationResourceUpdateTest {
         GameServerConfig config = GameServerConfig.builder()
                 .saveName("scenario-gather")
                 .build();
-        net.lapidist.colony.io.Paths.deleteAutosave("scenario-gather");
+        net.lapidist.colony.io.Paths.get().deleteAutosave("scenario-gather");
         GameServer server = new GameServer(config);
         server.start();
 

--- a/tests/src/net/lapidist/colony/tests/server/GameServerBuildTest.java
+++ b/tests/src/net/lapidist/colony/tests/server/GameServerBuildTest.java
@@ -29,7 +29,7 @@ public class GameServerBuildTest {
         GameServerConfig config = GameServerConfig.builder()
                 .saveName("build-test")
                 .build();
-        net.lapidist.colony.io.Paths.deleteAutosave("build-test");
+        net.lapidist.colony.io.Paths.get().deleteAutosave("build-test");
         GameServer server = new GameServer(config);
         server.start();
         Events.getInstance().registerEvents(this);

--- a/tests/src/net/lapidist/colony/tests/server/GameServerChatCommandTest.java
+++ b/tests/src/net/lapidist/colony/tests/server/GameServerChatCommandTest.java
@@ -30,7 +30,7 @@ public class GameServerChatCommandTest {
         GameServerConfig config = GameServerConfig.builder()
                 .saveName("chat-command")
                 .build();
-        net.lapidist.colony.io.Paths.deleteAutosave("chat-command");
+        net.lapidist.colony.io.Paths.get().deleteAutosave("chat-command");
         GameServer server = new GameServer(config);
         server.start();
         Events.getInstance().registerEvents(this);

--- a/tests/src/net/lapidist/colony/tests/server/GameServerHandlerRegistrationTest.java
+++ b/tests/src/net/lapidist/colony/tests/server/GameServerHandlerRegistrationTest.java
@@ -73,7 +73,7 @@ public class GameServerHandlerRegistrationTest {
         GameServerConfig config = GameServerConfig.builder()
                 .saveName("handler-test")
                 .build();
-        net.lapidist.colony.io.Paths.deleteAutosave("handler-test");
+        net.lapidist.colony.io.Paths.get().deleteAutosave("handler-test");
         GameServer server = new GameServer(
                 config,
                 java.util.List.of(messageHandler),

--- a/tests/src/net/lapidist/colony/tests/server/GameServerPlayerResourceSaveTest.java
+++ b/tests/src/net/lapidist/colony/tests/server/GameServerPlayerResourceSaveTest.java
@@ -22,7 +22,7 @@ public class GameServerPlayerResourceSaveTest {
                 .saveName("resource-save")
                 .autosaveInterval(WAIT_MS)
                 .build();
-        Paths.deleteAutosave("resource-save");
+        Paths.get().deleteAutosave("resource-save");
         GameServer server = new GameServer(config);
         server.start();
 

--- a/tests/src/net/lapidist/colony/tests/server/GameServerSaveTest.java
+++ b/tests/src/net/lapidist/colony/tests/server/GameServerSaveTest.java
@@ -28,9 +28,9 @@ public class GameServerSaveTest {
 
     @Before
     public void setUp() throws IOException {
-        Path saveFile = Paths.getAutosave("autosave");
+        Path saveFile = Paths.get().getAutosave("autosave");
         Files.deleteIfExists(saveFile);
-        Paths.createGameFoldersIfNotExists();
+        Paths.get().createGameFoldersIfNotExists();
     }
 
     @Subscribe
@@ -49,7 +49,7 @@ public class GameServerSaveTest {
                 .saveName("save-test")
                 .autosaveInterval(TEST_INTERVAL_MS)
                 .build();
-        net.lapidist.colony.io.Paths.deleteAutosave("save-test");
+        net.lapidist.colony.io.Paths.get().deleteAutosave("save-test");
         GameServer server = new GameServer(config);
         server.start();
         Events.getInstance().registerEvents(this);
@@ -57,7 +57,7 @@ public class GameServerSaveTest {
         Thread.sleep(WAIT_MS);
         Events.update();
 
-        Path saveFile = Paths.getAutosave("save-test");
+        Path saveFile = Paths.get().getAutosave("save-test");
         assertTrue(Files.exists(saveFile));
         assertTrue(lastEvent != null);
         assertTrue(saveFile.equals(lastEvent.getLocation()));
@@ -78,7 +78,7 @@ public class GameServerSaveTest {
 
         server.stop();
 
-        Path saveFile = Paths.getAutosave("save-test");
+        Path saveFile = Paths.get().getAutosave("save-test");
         assertTrue(Files.exists(saveFile));
         assertTrue(shutdownEvent != null);
         assertTrue(saveFile.equals(shutdownEvent.getLocation()));
@@ -99,7 +99,7 @@ public class GameServerSaveTest {
                 .textureRef("changed")
                 .build();
         first.getMapState().tiles().put(pos, modified);
-        GameStateIO.save(first.getMapState(), Paths.getAutosave("save-test"));
+        GameStateIO.save(first.getMapState(), Paths.get().getAutosave("save-test"));
         first.stop();
 
         GameServer second = new GameServer(cfg);

--- a/tests/src/net/lapidist/colony/tests/server/GameServerSelectionTest.java
+++ b/tests/src/net/lapidist/colony/tests/server/GameServerSelectionTest.java
@@ -29,7 +29,7 @@ public class GameServerSelectionTest {
         GameServerConfig config = GameServerConfig.builder()
                 .saveName("selection-test")
                 .build();
-        net.lapidist.colony.io.Paths.deleteAutosave("selection-test");
+        net.lapidist.colony.io.Paths.get().deleteAutosave("selection-test");
         GameServer server = new GameServer(config);
         server.start();
         Events.getInstance().registerEvents(this);


### PR DESCRIPTION
## Summary
- convert `Paths` to a class with a default singleton instance
- update client and server code to use `Paths.get()`
- adjust tests to instantiate `Paths` where needed

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_68476a279df083289ea9467c16290d6e