### PR TITLE
refactor(core): reuse default MapState in builder

### DIFF
--- a/core/src/net/lapidist/colony/components/state/MapState.java
+++ b/core/src/net/lapidist/colony/components/state/MapState.java
@@ -54,14 +54,7 @@ public record MapState(
         private ResourceData playerResources;
 
         private Builder() {
-            this.version = CURRENT_VERSION;
-            this.name = "map-" + UUID.randomUUID();
-            this.saveName = "save-" + UUID.randomUUID();
-            this.autosaveName = null;
-            this.description = null;
-            this.tiles = new HashMap<>();
-            this.buildings = new ArrayList<>();
-            this.playerResources = new ResourceData();
+            this(new MapState());
         }
 
         private Builder(final MapState state) {


### PR DESCRIPTION
## Summary
- avoid duplicating MapState defaults in the builder

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`

------
https://chatgpt.com/codex/tasks/task_e_68476a43225083288083a47cfcbd895f