### PR TITLE
refactor(client): use GameConstants for map settings

### DIFF
--- a/client/src/net/lapidist/colony/client/core/Constants.java
+++ b/client/src/net/lapidist/colony/client/core/Constants.java
@@ -11,10 +11,6 @@ public final class Constants {
     public static final int WIDTH = 1080;
     public static final int HEIGHT = 720;
     public static final int TARGET_FPS = 60;
-    public static final int TILE_SIZE = net.lapidist.colony.components.GameConstants.TILE_SIZE;
-    public static final int MAP_WIDTH = net.lapidist.colony.components.GameConstants.MAP_WIDTH;
-    public static final int MAP_HEIGHT = net.lapidist.colony.components.GameConstants.MAP_HEIGHT;
-
     public static final int MAP_GUTTER = 4;
 
     private static final class Version {

--- a/client/src/net/lapidist/colony/client/entities/factories/SpriteFactoryUtil.java
+++ b/client/src/net/lapidist/colony/client/entities/factories/SpriteFactoryUtil.java
@@ -3,7 +3,7 @@ package net.lapidist.colony.client.entities.factories;
 import com.artemis.Entity;
 import com.artemis.World;
 import com.badlogic.gdx.math.Vector2;
-import net.lapidist.colony.client.core.Constants;
+import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.components.BoundedComponent;
 import net.lapidist.colony.components.assets.TextureRegionReferenceComponent;
 
@@ -30,8 +30,8 @@ public final class SpriteFactoryUtil {
             final Vector2 coords
     ) {
         Entity entity = createEntity(world, resourceRef);
-        component.setHeight(Constants.TILE_SIZE);
-        component.setWidth(Constants.TILE_SIZE);
+        component.setHeight(GameConstants.TILE_SIZE);
+        component.setWidth(GameConstants.TILE_SIZE);
         component.setX((int) coords.x);
         component.setY((int) coords.y);
         entity.edit().add(component);

--- a/client/src/net/lapidist/colony/client/systems/input/KeyboardInputHandler.java
+++ b/client/src/net/lapidist/colony/client/systems/input/KeyboardInputHandler.java
@@ -3,7 +3,7 @@ package net.lapidist.colony.client.systems.input;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Vector3;
-import net.lapidist.colony.client.core.Constants;
+import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
 import net.lapidist.colony.settings.KeyAction;
 import net.lapidist.colony.settings.KeyBindings;
@@ -46,8 +46,8 @@ public final class KeyboardInputHandler {
 
     public void clampCameraPosition() {
         final Vector3 position = cameraSystem.getCamera().position;
-        final float mapWidth = Constants.MAP_WIDTH * Constants.TILE_SIZE;
-        final float mapHeight = Constants.MAP_HEIGHT * Constants.TILE_SIZE;
+        final float mapWidth = GameConstants.MAP_WIDTH * GameConstants.TILE_SIZE;
+        final float mapHeight = GameConstants.MAP_HEIGHT * GameConstants.TILE_SIZE;
 
         position.x = MathUtils.clamp(position.x, 0, mapWidth);
         position.y = MathUtils.clamp(position.y, 0, mapHeight);

--- a/client/src/net/lapidist/colony/client/ui/MinimapActor.java
+++ b/client/src/net/lapidist/colony/client/ui/MinimapActor.java
@@ -8,7 +8,7 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
-import net.lapidist.colony.client.core.Constants;
+import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.client.core.io.FileLocation;
 import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
@@ -56,16 +56,16 @@ public final class MinimapActor extends Actor implements Disposable {
         for (int i = 0; i < tiles.size; i++) {
             TileComponent tileComponent = tileMapper.get(tiles.get(i));
             mapWidthWorld = Math.max(mapWidthWorld,
-                    (tileComponent.getX() + 1) * Constants.TILE_SIZE);
+                    (tileComponent.getX() + 1) * GameConstants.TILE_SIZE);
             mapHeightWorld = Math.max(mapHeightWorld,
-                    (tileComponent.getY() + 1) * Constants.TILE_SIZE);
+                    (tileComponent.getY() + 1) * GameConstants.TILE_SIZE);
         }
 
         if (mapWidthWorld == 0) {
-            mapWidthWorld = Constants.MAP_WIDTH * Constants.TILE_SIZE;
+            mapWidthWorld = GameConstants.MAP_WIDTH * GameConstants.TILE_SIZE;
         }
         if (mapHeightWorld == 0) {
-            mapHeightWorld = Constants.MAP_HEIGHT * Constants.TILE_SIZE;
+            mapHeightWorld = GameConstants.MAP_HEIGHT * GameConstants.TILE_SIZE;
         }
     }
 

--- a/client/src/net/lapidist/colony/client/ui/MinimapCache.java
+++ b/client/src/net/lapidist/colony/client/ui/MinimapCache.java
@@ -8,7 +8,7 @@ import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
-import net.lapidist.colony.client.core.Constants;
+import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.components.assets.TextureRegionReferenceComponent;
 import net.lapidist.colony.components.maps.MapComponent;
@@ -66,10 +66,10 @@ final class MinimapCache implements Disposable {
             if (region != null) {
                 spriteCache.add(
                         region,
-                        tileComponent.getX() * Constants.TILE_SIZE * scaleX,
-                        tileComponent.getY() * Constants.TILE_SIZE * scaleY,
-                        Constants.TILE_SIZE * scaleX,
-                        Constants.TILE_SIZE * scaleY
+                        tileComponent.getX() * GameConstants.TILE_SIZE * scaleX,
+                        tileComponent.getY() * GameConstants.TILE_SIZE * scaleY,
+                        GameConstants.TILE_SIZE * scaleX,
+                        GameConstants.TILE_SIZE * scaleY
                 );
             }
         }

--- a/client/src/net/lapidist/colony/client/util/CameraUtils.java
+++ b/client/src/net/lapidist/colony/client/util/CameraUtils.java
@@ -6,7 +6,7 @@ import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.viewport.ExtendViewport;
-import net.lapidist.colony.client.core.Constants;
+import net.lapidist.colony.components.GameConstants;
 
 /**
  * Utility methods for converting between tile, world and screen coordinates.
@@ -17,7 +17,7 @@ public final class CameraUtils {
     }
 
     public static Vector2 tileCoordsToWorldCoords(final int x, final int y) {
-        return new Vector2(x * Constants.TILE_SIZE, y * Constants.TILE_SIZE);
+        return new Vector2(x * GameConstants.TILE_SIZE, y * GameConstants.TILE_SIZE);
     }
 
     public static Vector2 tileCoordsToWorldCoords(final Vector2 coords) {
@@ -26,8 +26,8 @@ public final class CameraUtils {
 
     public static Vector2 worldCoordsToTileCoords(final int x, final int y) {
         return new Vector2(
-                Math.floorDiv(x, Constants.TILE_SIZE),
-                Math.floorDiv(y, Constants.TILE_SIZE)
+                Math.floorDiv(x, GameConstants.TILE_SIZE),
+                Math.floorDiv(y, GameConstants.TILE_SIZE)
         );
     }
 
@@ -62,8 +62,8 @@ public final class CameraUtils {
 
     public static Vector2 getWorldCenter() {
         return new Vector2(
-                (Constants.TILE_SIZE * Constants.MAP_WIDTH + Constants.TILE_SIZE) / 2f,
-                (Constants.TILE_SIZE * Constants.MAP_HEIGHT + Constants.TILE_SIZE) / 2f
+                (GameConstants.TILE_SIZE * GameConstants.MAP_WIDTH + GameConstants.TILE_SIZE) / 2f,
+                (GameConstants.TILE_SIZE * GameConstants.MAP_HEIGHT + GameConstants.TILE_SIZE) / 2f
         );
     }
 

--- a/tests/src/net/lapidist/colony/tests/scenario/GameSimulationCameraTest.java
+++ b/tests/src/net/lapidist/colony/tests/scenario/GameSimulationCameraTest.java
@@ -1,6 +1,6 @@
 package net.lapidist.colony.tests.scenario;
 
-import net.lapidist.colony.client.core.Constants;
+import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.TilePos;
@@ -40,8 +40,8 @@ public class GameSimulationCameraTest {
         sim.step();
 
         final float epsilon = 0.01f;
-        float expectedX = max(0, min(Constants.MAP_WIDTH * Constants.TILE_SIZE, startX - deltaX));
-        float expectedY = max(0, min(Constants.MAP_HEIGHT * Constants.TILE_SIZE, startY + deltaY));
+        float expectedX = max(0, min(GameConstants.MAP_WIDTH * GameConstants.TILE_SIZE, startX - deltaX));
+        float expectedY = max(0, min(GameConstants.MAP_HEIGHT * GameConstants.TILE_SIZE, startY + deltaY));
 
         assertEquals(expectedX, sim.getCamera().getCamera().position.x, epsilon);
         assertEquals(expectedY, sim.getCamera().getCamera().position.y, epsilon);

--- a/tests/src/net/lapidist/colony/tests/systems/InputSystemGatherTest.java
+++ b/tests/src/net/lapidist/colony/tests/systems/InputSystemGatherTest.java
@@ -3,7 +3,7 @@ package net.lapidist.colony.tests.systems;
 import com.artemis.World;
 import com.artemis.WorldConfigurationBuilder;
 import com.badlogic.gdx.math.Vector2;
-import net.lapidist.colony.client.core.Constants;
+import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.client.systems.InputSystem;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
@@ -47,7 +47,7 @@ public class InputSystemGatherTest {
         world.process();
 
         PlayerCameraSystem camera = world.getSystem(PlayerCameraSystem.class);
-        camera.getCamera().position.set(Constants.TILE_SIZE / 2f, Constants.TILE_SIZE / 2f, 0);
+        camera.getCamera().position.set(GameConstants.TILE_SIZE / 2f, GameConstants.TILE_SIZE / 2f, 0);
         camera.getCamera().update();
 
         Vector2 screenCoords = CameraUtils.worldToScreenCoords(camera.getViewport(), 0, 0);

--- a/tests/src/net/lapidist/colony/tests/systems/InputSystemInitOrderTest.java
+++ b/tests/src/net/lapidist/colony/tests/systems/InputSystemInitOrderTest.java
@@ -3,7 +3,7 @@ package net.lapidist.colony.tests.systems;
 import com.artemis.World;
 import com.artemis.WorldConfigurationBuilder;
 import com.badlogic.gdx.math.Vector2;
-import net.lapidist.colony.client.core.Constants;
+import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.client.systems.InputSystem;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
@@ -45,7 +45,7 @@ public class InputSystemInitOrderTest {
         world.process();
 
         PlayerCameraSystem camera = world.getSystem(PlayerCameraSystem.class);
-        camera.getCamera().position.set(Constants.TILE_SIZE / 2f, Constants.TILE_SIZE / 2f, 0);
+        camera.getCamera().position.set(GameConstants.TILE_SIZE / 2f, GameConstants.TILE_SIZE / 2f, 0);
         camera.getCamera().update();
 
         Vector2 screenCoords = CameraUtils.worldToScreenCoords(camera.getViewport(), 0, 0);

--- a/tests/src/net/lapidist/colony/tests/systems/InputSystemTest.java
+++ b/tests/src/net/lapidist/colony/tests/systems/InputSystemTest.java
@@ -6,7 +6,7 @@ import com.artemis.World;
 import com.artemis.WorldConfigurationBuilder;
 import com.artemis.utils.IntBag;
 import com.badlogic.gdx.math.Vector2;
-import net.lapidist.colony.client.core.Constants;
+import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
 import net.lapidist.colony.client.util.CameraUtils;
@@ -48,7 +48,7 @@ public class InputSystemTest {
         world.process();
 
         PlayerCameraSystem camera = world.getSystem(PlayerCameraSystem.class);
-        camera.getCamera().position.set(Constants.TILE_SIZE / 2f, Constants.TILE_SIZE / 2f, 0);
+        camera.getCamera().position.set(GameConstants.TILE_SIZE / 2f, GameConstants.TILE_SIZE / 2f, 0);
         camera.getCamera().update();
 
         Vector2 screenCoords = CameraUtils.worldToScreenCoords(camera.getViewport(), 0, 0);


### PR DESCRIPTION
## Summary
- expose map width/height/tile size only through `GameConstants`
- remove duplicated fields from `client.core.Constants`
- update client and tests to import `GameConstants`

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_68476a3d67848328be1e97df91b9f7de