### PR TITLE
ci: set patch coverage threshold to 60%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: 60


### PR DESCRIPTION
## Summary
- configure codecov to require 60% patch coverage

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68476e23e0f083289bf1781b838552b7