### PR TITLE
feat: split input handling into separate systems

### DIFF
--- a/client/src/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -6,7 +6,9 @@ import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.client.systems.ClearScreenSystem;
-import net.lapidist.colony.client.systems.InputSystem;
+import net.lapidist.colony.client.systems.CameraInputSystem;
+import net.lapidist.colony.client.systems.SelectionSystem;
+import net.lapidist.colony.client.systems.BuildPlacementSystem;
 import net.lapidist.colony.client.systems.MapRenderSystem;
 import net.lapidist.colony.client.renderers.MapRendererFactory;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
@@ -55,14 +57,18 @@ public final class MapWorldBuilder {
             final KeyBindings keyBindings,
             final ResourceData playerResources
     ) {
-        InputSystem inputSystem = new InputSystem(client, keyBindings);
-        inputSystem.addProcessor(stage);
+        CameraInputSystem cameraInput = new CameraInputSystem(keyBindings);
+        cameraInput.addProcessor(stage);
+        SelectionSystem selection = new SelectionSystem(client, keyBindings);
+        BuildPlacementSystem buildPlacement = new BuildPlacementSystem(client);
 
         return new WorldConfigurationBuilder()
                 .with(
                         new EventSystem(),
                         new ClearScreenSystem(Color.BLACK),
-                        inputSystem,
+                        cameraInput,
+                        selection,
+                        buildPlacement,
                         new PlayerInitSystem(playerResources),
                         new TileUpdateSystem(client),
                         new BuildingUpdateSystem(client),

--- a/client/src/net/lapidist/colony/client/systems/BuildPlacementSystem.java
+++ b/client/src/net/lapidist/colony/client/systems/BuildPlacementSystem.java
@@ -1,0 +1,52 @@
+package net.lapidist.colony.client.systems;
+
+import com.artemis.BaseSystem;
+import com.artemis.ComponentMapper;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.client.systems.input.BuildingPlacementHandler;
+import net.lapidist.colony.components.maps.MapComponent;
+import net.lapidist.colony.components.maps.TileComponent;
+import net.lapidist.colony.map.MapUtils;
+
+/**
+ * Handles player building placement input.
+ */
+public final class BuildPlacementSystem extends BaseSystem {
+
+    private final GameClient client;
+    private PlayerCameraSystem cameraSystem;
+    private MapComponent map;
+    private ComponentMapper<TileComponent> tileMapper;
+    private BuildingPlacementHandler handler;
+    private boolean buildMode;
+
+    public BuildPlacementSystem(final GameClient clientToSet) {
+        this.client = clientToSet;
+    }
+
+    @Override
+    public void initialize() {
+        cameraSystem = world.getSystem(PlayerCameraSystem.class);
+        tileMapper = world.getMapper(TileComponent.class);
+        map = MapUtils.findMap(world).orElse(null);
+        handler = new BuildingPlacementHandler(client, cameraSystem);
+    }
+
+    @Override
+    protected void processSystem() {
+        if (map == null) {
+            map = MapUtils.findMap(world).orElse(null);
+        }
+    }
+
+    public void setBuildMode(final boolean mode) {
+        this.buildMode = mode;
+    }
+
+    public boolean tap(final float x, final float y, final int count, final int button) {
+        if (!buildMode) {
+            return false;
+        }
+        return handler.handleTap(x, y, map, tileMapper);
+    }
+}

--- a/client/src/net/lapidist/colony/client/systems/CameraInputSystem.java
+++ b/client/src/net/lapidist/colony/client/systems/CameraInputSystem.java
@@ -1,0 +1,77 @@
+package net.lapidist.colony.client.systems;
+
+import com.artemis.BaseSystem;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.InputMultiplexer;
+import com.badlogic.gdx.InputProcessor;
+import com.badlogic.gdx.input.GestureDetector;
+import com.badlogic.gdx.input.GestureDetector.GestureAdapter;
+import net.lapidist.colony.client.systems.input.GestureInputHandler;
+import net.lapidist.colony.client.systems.input.KeyboardInputHandler;
+import net.lapidist.colony.client.systems.input.ScrollInputProcessor;
+import net.lapidist.colony.settings.KeyBindings;
+
+/**
+ * Handles camera movement via gestures and keyboard input.
+ */
+public final class CameraInputSystem extends BaseSystem {
+
+    private final KeyBindings keyBindings;
+    private final InputMultiplexer multiplexer = new InputMultiplexer();
+
+    private PlayerCameraSystem cameraSystem;
+    private KeyboardInputHandler keyboardHandler;
+    private GestureInputHandler gestureHandler;
+
+    public CameraInputSystem(final KeyBindings bindings) {
+        this.keyBindings = bindings;
+    }
+
+    public void addProcessor(final InputProcessor processor) {
+        multiplexer.addProcessor(0, processor);
+    }
+
+    @Override
+    public void initialize() {
+        cameraSystem = world.getSystem(PlayerCameraSystem.class);
+        keyboardHandler = new KeyboardInputHandler(cameraSystem, keyBindings);
+        gestureHandler = new GestureInputHandler(cameraSystem);
+
+        multiplexer.addProcessor(new GestureDetector(new CameraGestureListener()));
+        multiplexer.addProcessor(new ScrollInputProcessor(gestureHandler));
+        Gdx.input.setInputProcessor(multiplexer);
+    }
+
+    @Override
+    protected void processSystem() {
+        keyboardHandler.handleKeyboardInput(world.getDelta());
+        keyboardHandler.clampCameraPosition();
+        cameraSystem.getCamera().update();
+    }
+
+    public boolean scrolled(final float amountX, final float amountY) {
+        return gestureHandler.scrolled(amountX, amountY);
+    }
+
+    public boolean pan(final float x, final float y, final float deltaX, final float deltaY) {
+        boolean result = gestureHandler.pan(deltaX, deltaY);
+        keyboardHandler.clampCameraPosition();
+        return result;
+    }
+
+    public boolean zoom(final float initialDistance, final float distance) {
+        return gestureHandler.zoom(initialDistance, distance);
+    }
+
+    private final class CameraGestureListener extends GestureAdapter {
+        @Override
+        public boolean pan(final float x, final float y, final float deltaX, final float deltaY) {
+            return CameraInputSystem.this.pan(x, y, deltaX, deltaY);
+        }
+
+        @Override
+        public boolean zoom(final float initialDistance, final float distance) {
+            return CameraInputSystem.this.zoom(initialDistance, distance);
+        }
+    }
+}

--- a/client/src/net/lapidist/colony/client/systems/SelectionSystem.java
+++ b/client/src/net/lapidist/colony/client/systems/SelectionSystem.java
@@ -1,0 +1,84 @@
+package net.lapidist.colony.client.systems;
+
+import com.artemis.BaseSystem;
+import com.artemis.ComponentMapper;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.math.Vector2;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.client.systems.input.TileSelectionHandler;
+import net.lapidist.colony.client.util.CameraUtils;
+import net.lapidist.colony.components.maps.MapComponent;
+import net.lapidist.colony.components.maps.TileComponent;
+import net.lapidist.colony.components.resources.ResourceComponent;
+import net.lapidist.colony.components.state.ResourceGatherRequestData;
+import net.lapidist.colony.components.resources.ResourceType;
+import net.lapidist.colony.map.MapUtils;
+import net.lapidist.colony.settings.KeyAction;
+import net.lapidist.colony.settings.KeyBindings;
+
+/**
+ * Processes tile selection and gather commands.
+ */
+public final class SelectionSystem extends BaseSystem {
+
+    private final GameClient client;
+    private final KeyBindings keyBindings;
+
+    private PlayerCameraSystem cameraSystem;
+    private MapComponent map;
+    private ComponentMapper<TileComponent> tileMapper;
+    private ComponentMapper<ResourceComponent> resourceMapper;
+    private TileSelectionHandler selectionHandler;
+
+    public SelectionSystem(final GameClient clientToSet, final KeyBindings bindings) {
+        this.client = clientToSet;
+        this.keyBindings = bindings;
+    }
+
+    @Override
+    public void initialize() {
+        cameraSystem = world.getSystem(PlayerCameraSystem.class);
+        tileMapper = world.getMapper(TileComponent.class);
+        resourceMapper = world.getMapper(ResourceComponent.class);
+        map = MapUtils.findMap(world).orElse(null);
+        selectionHandler = new TileSelectionHandler(client, cameraSystem);
+    }
+
+    @Override
+    protected void processSystem() {
+        if (map == null) {
+            map = MapUtils.findMap(world).orElse(null);
+        }
+        if (Gdx.input.isKeyJustPressed(keyBindings.getKey(KeyAction.GATHER)) && map != null) {
+            for (int i = 0; i < map.getTiles().size; i++) {
+                var tile = map.getTiles().get(i);
+                TileComponent tc = tileMapper.get(tile);
+                if (tc.isSelected()) {
+                    ResourceGatherRequestData msg = new ResourceGatherRequestData(
+                            tc.getX(), tc.getY(), ResourceType.WOOD.name());
+                    client.sendGatherRequest(msg);
+                }
+            }
+        }
+    }
+
+    public boolean tap(final float x, final float y, final int count, final int button) {
+        boolean result = selectionHandler.handleTap(x, y, map, tileMapper);
+        if (map != null) {
+            cameraSystem.getCamera().update();
+            Vector2 worldCoords = CameraUtils.screenToWorldCoords(cameraSystem.getViewport(), x, y);
+            Vector2 tileCoords = CameraUtils.worldCoordsToTileCoords(worldCoords);
+            MapUtils.findTile(map, (int) tileCoords.x, (int) tileCoords.y, tileMapper)
+                    .ifPresent(tile -> {
+                        TileComponent tc = tileMapper.get(tile);
+                        var rc = resourceMapper.get(tile);
+                        if (rc.getWood() > 0) {
+                            ResourceGatherRequestData msg = new ResourceGatherRequestData(
+                                    tc.getX(), tc.getY(), ResourceType.WOOD.name());
+                            client.sendGatherRequest(msg);
+                        }
+                    });
+        }
+        return result;
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/scenario/GameSimulation.java
+++ b/tests/src/net/lapidist/colony/tests/scenario/GameSimulation.java
@@ -4,7 +4,9 @@ import com.artemis.World;
 import com.artemis.WorldConfigurationBuilder;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
-import net.lapidist.colony.client.systems.InputSystem;
+import net.lapidist.colony.client.systems.CameraInputSystem;
+import net.lapidist.colony.client.systems.SelectionSystem;
+import net.lapidist.colony.client.systems.BuildPlacementSystem;
 import net.lapidist.colony.client.systems.network.MapLoadSystem;
 import net.lapidist.colony.client.systems.network.TileUpdateSystem;
 import net.lapidist.colony.client.systems.network.BuildingUpdateSystem;
@@ -19,7 +21,9 @@ import static org.mockito.Mockito.mock;
  */
 public final class GameSimulation {
     private final World world;
-    private final InputSystem inputSystem;
+    private final CameraInputSystem cameraInput;
+    private final SelectionSystem selectionSystem;
+    private final BuildPlacementSystem buildPlacementSystem;
     private final PlayerCameraSystem cameraSystem;
     private final GameClient client;
 
@@ -42,7 +46,9 @@ public final class GameSimulation {
                 .with(
                         new MapLoadSystem(state),
                         new PlayerCameraSystem(),
-                        new InputSystem(client, new net.lapidist.colony.settings.KeyBindings()),
+                        new CameraInputSystem(new net.lapidist.colony.settings.KeyBindings()),
+                        new SelectionSystem(client, new net.lapidist.colony.settings.KeyBindings()),
+                        new BuildPlacementSystem(client),
                         new net.lapidist.colony.client.systems.PlayerInitSystem(),
                         new TileUpdateSystem(client),
                         new BuildingUpdateSystem(client),
@@ -51,7 +57,9 @@ public final class GameSimulation {
                 .build());
         // run once so systems initialise
         world.process();
-        inputSystem = world.getSystem(InputSystem.class);
+        cameraInput = world.getSystem(CameraInputSystem.class);
+        selectionSystem = world.getSystem(SelectionSystem.class);
+        buildPlacementSystem = world.getSystem(BuildPlacementSystem.class);
         cameraSystem = world.getSystem(PlayerCameraSystem.class);
     }
 
@@ -65,8 +73,16 @@ public final class GameSimulation {
         return world;
     }
 
-    public InputSystem getInput() {
-        return inputSystem;
+    public CameraInputSystem getCameraInput() {
+        return cameraInput;
+    }
+
+    public SelectionSystem getSelection() {
+        return selectionSystem;
+    }
+
+    public BuildPlacementSystem getBuildPlacement() {
+        return buildPlacementSystem;
     }
 
     public PlayerCameraSystem getCamera() {

--- a/tests/src/net/lapidist/colony/tests/scenario/GameSimulationCameraTest.java
+++ b/tests/src/net/lapidist/colony/tests/scenario/GameSimulationCameraTest.java
@@ -36,7 +36,7 @@ public class GameSimulationCameraTest {
 
         final float deltaX = -20f;
         final float deltaY = 15f;
-        sim.getInput().pan(0, 0, deltaX, deltaY);
+        sim.getCameraInput().pan(0, 0, deltaX, deltaY);
         sim.step();
 
         final float epsilon = 0.01f;

--- a/tests/src/net/lapidist/colony/tests/scenario/GameSimulationDelayedTileUpdateTest.java
+++ b/tests/src/net/lapidist/colony/tests/scenario/GameSimulationDelayedTileUpdateTest.java
@@ -51,7 +51,7 @@ public class GameSimulationDelayedTileUpdateTest {
             Vector2 screen = CameraUtils.worldToScreenCoords(
                     sim.getCamera().getViewport(), 0, 0
             );
-            sim.getInput().tap(screen.x, screen.y, 1, 0);
+            sim.getSelection().tap(screen.x, screen.y, 1, 0);
 
             // Check immediately after tap - tile should not be selected yet
             TileComponent tile = findTile(sim);

--- a/tests/src/net/lapidist/colony/tests/scenario/GameSimulationInputSelectionTest.java
+++ b/tests/src/net/lapidist/colony/tests/scenario/GameSimulationInputSelectionTest.java
@@ -52,7 +52,7 @@ public class GameSimulationInputSelectionTest {
             Vector2 screen = CameraUtils.worldToScreenCoords(
                     sim.getCamera().getViewport(), 0, 0
             );
-            sim.getInput().tap(screen.x, screen.y, 1, 0);
+            sim.getSelection().tap(screen.x, screen.y, 1, 0);
 
             Thread.sleep(WAIT_MS);
             sim.step();


### PR DESCRIPTION
## Summary
- break InputSystem into CameraInputSystem, SelectionSystem and BuildPlacementSystem
- use new systems in MapWorldBuilder and GameSimulation
- update scenario tests and unit tests for new systems

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68476a357ec88328b4978cabf50b553d