### PR TITLE
feat(client): unify message polling via map

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The code mirrors this flow with clearly named methods:
 
 - Clients call `sendTileSelectionRequest` to issue actions.
 - The server uses `broadcast` to relay updates to all clients.
-- Each client processes queued updates via `pollTileSelectionUpdate` inside its update systems.
+- Each client processes queued updates via `poll(TileSelectionData.class)` inside its update systems.
 
 ## Development Guidelines
 ### Code Style

--- a/client/src/net/lapidist/colony/client/network/handlers/BuildingUpdateHandler.java
+++ b/client/src/net/lapidist/colony/client/network/handlers/BuildingUpdateHandler.java
@@ -3,21 +3,26 @@ package net.lapidist.colony.client.network.handlers;
 import net.lapidist.colony.components.state.BuildingData;
 import net.lapidist.colony.network.AbstractMessageHandler;
 
+import java.util.Map;
 import java.util.Queue;
 
 /**
  * Queues building updates received from the server.
  */
 public final class BuildingUpdateHandler extends AbstractMessageHandler<BuildingData> {
-    private final Queue<BuildingData> queue;
+    private final Map<Class<?>, Queue<?>> queues;
 
-    public BuildingUpdateHandler(final Queue<BuildingData> queueToUse) {
+    public BuildingUpdateHandler(final Map<Class<?>, Queue<?>> queuesToUse) {
         super(BuildingData.class);
-        this.queue = queueToUse;
+        this.queues = queuesToUse;
     }
 
     @Override
     public void handle(final BuildingData message) {
-        queue.add(message);
+        @SuppressWarnings("unchecked")
+        Queue<BuildingData> queue = (Queue<BuildingData>) queues.get(BuildingData.class);
+        if (queue != null) {
+            queue.add(message);
+        }
     }
 }

--- a/client/src/net/lapidist/colony/client/network/handlers/ChatMessageHandler.java
+++ b/client/src/net/lapidist/colony/client/network/handlers/ChatMessageHandler.java
@@ -3,21 +3,26 @@ package net.lapidist.colony.client.network.handlers;
 import net.lapidist.colony.chat.ChatMessage;
 import net.lapidist.colony.network.AbstractMessageHandler;
 
+import java.util.Map;
 import java.util.Queue;
 
 /**
  * Queues chat messages received from the server.
  */
 public final class ChatMessageHandler extends AbstractMessageHandler<ChatMessage> {
-    private final Queue<ChatMessage> queue;
+    private final Map<Class<?>, Queue<?>> queues;
 
-    public ChatMessageHandler(final Queue<ChatMessage> queueToUse) {
+    public ChatMessageHandler(final Map<Class<?>, Queue<?>> queuesToUse) {
         super(ChatMessage.class);
-        this.queue = queueToUse;
+        this.queues = queuesToUse;
     }
 
     @Override
     public void handle(final ChatMessage message) {
-        queue.add(message);
+        @SuppressWarnings("unchecked")
+        Queue<ChatMessage> queue = (Queue<ChatMessage>) queues.get(ChatMessage.class);
+        if (queue != null) {
+            queue.add(message);
+        }
     }
 }

--- a/client/src/net/lapidist/colony/client/network/handlers/ResourceUpdateHandler.java
+++ b/client/src/net/lapidist/colony/client/network/handlers/ResourceUpdateHandler.java
@@ -3,19 +3,24 @@ package net.lapidist.colony.client.network.handlers;
 import net.lapidist.colony.components.state.ResourceUpdateData;
 import net.lapidist.colony.network.AbstractMessageHandler;
 
+import java.util.Map;
 import java.util.Queue;
 
 /** Queues resource updates received from the server. */
 public final class ResourceUpdateHandler extends AbstractMessageHandler<ResourceUpdateData> {
-    private final Queue<ResourceUpdateData> queue;
+    private final Map<Class<?>, Queue<?>> queues;
 
-    public ResourceUpdateHandler(final Queue<ResourceUpdateData> queueToUse) {
+    public ResourceUpdateHandler(final Map<Class<?>, Queue<?>> queuesToUse) {
         super(ResourceUpdateData.class);
-        this.queue = queueToUse;
+        this.queues = queuesToUse;
     }
 
     @Override
     public void handle(final ResourceUpdateData message) {
-        queue.add(message);
+        @SuppressWarnings("unchecked")
+        Queue<ResourceUpdateData> queue = (Queue<ResourceUpdateData>) queues.get(ResourceUpdateData.class);
+        if (queue != null) {
+            queue.add(message);
+        }
     }
 }

--- a/client/src/net/lapidist/colony/client/network/handlers/TileSelectionUpdateHandler.java
+++ b/client/src/net/lapidist/colony/client/network/handlers/TileSelectionUpdateHandler.java
@@ -3,21 +3,26 @@ package net.lapidist.colony.client.network.handlers;
 import net.lapidist.colony.components.state.TileSelectionData;
 import net.lapidist.colony.network.AbstractMessageHandler;
 
+import java.util.Map;
 import java.util.Queue;
 
 /**
  * Queues tile selection updates received from the server.
  */
 public final class TileSelectionUpdateHandler extends AbstractMessageHandler<TileSelectionData> {
-    private final Queue<TileSelectionData> queue;
+    private final Map<Class<?>, Queue<?>> queues;
 
-    public TileSelectionUpdateHandler(final Queue<TileSelectionData> queueToUse) {
+    public TileSelectionUpdateHandler(final Map<Class<?>, Queue<?>> queuesToUse) {
         super(TileSelectionData.class);
-        this.queue = queueToUse;
+        this.queues = queuesToUse;
     }
 
     @Override
     public void handle(final TileSelectionData message) {
-        queue.add(message);
+        @SuppressWarnings("unchecked")
+        Queue<TileSelectionData> queue = (Queue<TileSelectionData>) queues.get(TileSelectionData.class);
+        if (queue != null) {
+            queue.add(message);
+        }
     }
 }

--- a/client/src/net/lapidist/colony/client/systems/network/BuildingUpdateSystem.java
+++ b/client/src/net/lapidist/colony/client/systems/network/BuildingUpdateSystem.java
@@ -30,7 +30,7 @@ public final class BuildingUpdateSystem extends BaseSystem {
         }
 
         BuildingData update;
-        while ((update = client.pollBuildingUpdate()) != null) {
+        while ((update = client.poll(BuildingData.class)) != null) {
             world.createEntity();
             map.addEntity(BuildingFactory.create(
                     world,

--- a/client/src/net/lapidist/colony/client/systems/network/ResourceUpdateSystem.java
+++ b/client/src/net/lapidist/colony/client/systems/network/ResourceUpdateSystem.java
@@ -43,7 +43,7 @@ public final class ResourceUpdateSystem extends BaseSystem {
             }
         }
         ResourceUpdateData update;
-        while ((update = client.pollResourceUpdate()) != null) {
+        while ((update = client.poll(ResourceUpdateData.class)) != null) {
             final ResourceUpdateData data = update;
             MapUtils.findTile(mapComponent, data.x(), data.y(), tileMapper)
                     .ifPresent(tile -> {

--- a/client/src/net/lapidist/colony/client/systems/network/TileUpdateSystem.java
+++ b/client/src/net/lapidist/colony/client/systems/network/TileUpdateSystem.java
@@ -34,7 +34,7 @@ public final class TileUpdateSystem extends BaseSystem {
 
         MapComponent mapComponent = mapMapper.get(map);
         TileSelectionData update;
-        while ((update = client.pollTileSelectionUpdate()) != null) {
+        while ((update = client.poll(TileSelectionData.class)) != null) {
             final TileSelectionData data = update;
             MapUtils.findTile(mapComponent, data.x(), data.y(), tileMapper)
                     .ifPresent(t -> tileMapper.get(t).setSelected(data.selected()));

--- a/client/src/net/lapidist/colony/client/ui/ChatBox.java
+++ b/client/src/net/lapidist/colony/client/ui/ChatBox.java
@@ -75,7 +75,7 @@ public final class ChatBox extends Table {
     public void act(final float delta) {
         super.act(delta);
         ChatMessage msg;
-        while ((msg = client.pollChatMessage()) != null) {
+        while ((msg = client.poll(ChatMessage.class)) != null) {
             addMessage(msg);
         }
     }

--- a/tests/src/net/lapidist/colony/tests/network/GameServerBroadcastTest.java
+++ b/tests/src/net/lapidist/colony/tests/network/GameServerBroadcastTest.java
@@ -38,7 +38,7 @@ public class GameServerBroadcastTest {
 
         Thread.sleep(WAIT_MS);
 
-        TileSelectionData update = clientB.pollTileSelectionUpdate();
+        TileSelectionData update = clientB.poll(TileSelectionData.class);
         assertNotNull(update);
         assertEquals(data.selected(), update.selected());
         assertEquals(data.x(), update.x());

--- a/tests/src/net/lapidist/colony/tests/network/GameServerBuildBroadcastTest.java
+++ b/tests/src/net/lapidist/colony/tests/network/GameServerBuildBroadcastTest.java
@@ -40,7 +40,7 @@ public class GameServerBuildBroadcastTest {
 
         Thread.sleep(WAIT_MS);
 
-        BuildingData update = clientB.pollBuildingUpdate();
+        BuildingData update = clientB.poll(BuildingData.class);
         assertNotNull(update);
         assertEquals(data.x(), update.x());
         assertEquals(data.y(), update.y());

--- a/tests/src/net/lapidist/colony/tests/network/GameServerChatBroadcastTest.java
+++ b/tests/src/net/lapidist/colony/tests/network/GameServerChatBroadcastTest.java
@@ -38,7 +38,7 @@ public class GameServerChatBroadcastTest {
         clientA.sendChatMessage(msg);
         Thread.sleep(WAIT_MS);
 
-        ChatMessage received = clientB.pollChatMessage();
+        ChatMessage received = clientB.poll(ChatMessage.class);
         assertNotNull(received);
         assertEquals(msg.text(), received.text());
 

--- a/tests/src/net/lapidist/colony/tests/network/GameServerGatherBroadcastTest.java
+++ b/tests/src/net/lapidist/colony/tests/network/GameServerGatherBroadcastTest.java
@@ -40,7 +40,7 @@ public class GameServerGatherBroadcastTest {
 
         Thread.sleep(WAIT_MS);
 
-        ResourceUpdateData update = clientB.pollResourceUpdate();
+        ResourceUpdateData update = clientB.poll(ResourceUpdateData.class);
         assertNotNull(update);
         assertEquals(0, update.x());
         assertEquals(0, update.y());

--- a/tests/src/net/lapidist/colony/tests/ui/ChatBoxTest.java
+++ b/tests/src/net/lapidist/colony/tests/ui/ChatBoxTest.java
@@ -21,7 +21,7 @@ public class ChatBoxTest {
     @Test
     public void pollsClientMessagesIntoLog() throws Exception {
         GameClient client = mock(GameClient.class);
-        when(client.pollChatMessage()).thenReturn(new ChatMessage(1, "hi"), null);
+        when(client.poll(ChatMessage.class)).thenReturn(new ChatMessage(1, "hi"), null);
 
         Skin skin = new Skin(Gdx.files.internal("skin/default.json"));
         ChatBox box = new ChatBox(skin, client);


### PR DESCRIPTION
## Summary
- create a generic message queue map inside `GameClient`
- adjust handlers to enqueue using the map
- expose generic `poll(Class)` API
- update systems, UI, and tests to use the new polling method
- document new method in README

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_6847f42a0d6c83289122430f834d5d89