### PR TITLE
feat(io): replace FileHandle with NIO paths

### DIFF
--- a/core/src/net/lapidist/colony/io/AbstractPathService.java
+++ b/core/src/net/lapidist/colony/io/AbstractPathService.java
@@ -1,13 +1,11 @@
 package net.lapidist.colony.io;
 
-import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.files.FileHandle;
-
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Base {@link PathService} implementation providing shared logic.
@@ -17,48 +15,45 @@ abstract class AbstractPathService implements PathService {
     private static final String AUTOSAVE_SUFFIX = Paths.AUTOSAVE_SUFFIX;
     private static final String SETTINGS_FILE = "settings.properties";
 
-    protected abstract String getGameFolderPath();
+    protected abstract Path getGameFolderPath();
 
-    private FileHandle getGameFolder() {
-        if (Gdx.files != null) {
-            return Gdx.files.external(".colony");
-        }
-        return new FileHandle(getGameFolderPath());
+    private Path getGameFolder() {
+        return GdxPathAdapter.resolveGameFolder(getGameFolderPath());
     }
 
-    private FileHandle getSaveFolder() {
-        return getGameFolder().child("saves");
+    private Path getSaveFolder() {
+        return getGameFolder().resolve("saves");
     }
 
-    private FileHandle getSettingsHandle() {
-        return getGameFolder().child(SETTINGS_FILE);
+    private Path getSettingsPath() {
+        return getGameFolder().resolve(SETTINGS_FILE);
     }
 
-    private void ensureExists(final FileHandle handle) {
-        if (!handle.exists()) {
-            handle.mkdirs();
+    private void ensureExists(final Path path) throws IOException {
+        if (!Files.exists(path)) {
+            Files.createDirectories(path);
         }
     }
 
     @Override
     public void createGameFoldersIfNotExists() throws IOException {
-        FileHandle gameFolder = getGameFolder();
+        Path gameFolder = getGameFolder();
         ensureExists(gameFolder);
 
-        FileHandle saveFolder = getSaveFolder();
+        Path saveFolder = getSaveFolder();
         ensureExists(saveFolder);
     }
 
     @Override
     public Path getSettingsFile() throws IOException {
         createGameFoldersIfNotExists();
-        return getSettingsHandle().file().toPath();
+        return getSettingsPath();
     }
 
     @Override
     public Path getSaveFile(final String fileName) throws IOException {
         createGameFoldersIfNotExists();
-        return getSaveFolder().child(fileName).file().toPath();
+        return getSaveFolder().resolve(fileName);
     }
 
     @Override
@@ -78,26 +73,24 @@ abstract class AbstractPathService implements PathService {
 
     @Override
     public List<String> listAutosaves() throws IOException {
-        FileHandle folder = getSaveFolder();
-        if (!folder.exists()) {
+        Path folder = getSaveFolder();
+        if (!Files.exists(folder)) {
             return Collections.emptyList();
         }
         int suffixLength = AUTOSAVE_SUFFIX.length();
-        List<String> saves = new ArrayList<>();
-        for (FileHandle file : folder.list()) {
-            String name = file.name();
-            if (name.endsWith(AUTOSAVE_SUFFIX)) {
-                saves.add(name.substring(0, name.length() - suffixLength));
-            }
+        try (var stream = Files.list(folder)) {
+            return stream
+                    .map(Path::getFileName)
+                    .map(Path::toString)
+                    .filter(name -> name.endsWith(AUTOSAVE_SUFFIX))
+                    .map(name -> name.substring(0, name.length() - suffixLength))
+                    .collect(Collectors.toList());
         }
-        return saves;
     }
 
     @Override
     public void deleteAutosave(final String saveName) throws IOException {
-        FileHandle file = getSaveFolder().child(saveName + AUTOSAVE_SUFFIX);
-        if (file.exists()) {
-            file.delete();
-        }
+        Path file = getSaveFolder().resolve(saveName + AUTOSAVE_SUFFIX);
+        Files.deleteIfExists(file);
     }
 }

--- a/core/src/net/lapidist/colony/io/GdxPathAdapter.java
+++ b/core/src/net/lapidist/colony/io/GdxPathAdapter.java
@@ -1,0 +1,30 @@
+package net.lapidist.colony.io;
+
+import com.badlogic.gdx.Gdx;
+import java.nio.file.Path;
+
+/**
+ * Resolves the game folder path using LibGDX's {@code Files} API when
+ * available. If {@code Gdx.files} is {@code null} (for example on the
+ * server) the provided fallback path is used instead.
+ */
+final class GdxPathAdapter {
+
+    private GdxPathAdapter() {
+    }
+
+    /**
+     * Resolve the game folder path. When running inside a LibGDX
+     * environment {@link Gdx#files} is used to determine the external
+     * storage directory. Otherwise the supplied fallback path is returned.
+     *
+     * @param fallback path to use when LibGDX is not available
+     * @return resolved game folder path
+     */
+    static Path resolveGameFolder(final Path fallback) {
+        if (Gdx.files != null) {
+            return Gdx.files.external(".colony").file().toPath();
+        }
+        return fallback;
+    }
+}

--- a/core/src/net/lapidist/colony/io/UnixPathService.java
+++ b/core/src/net/lapidist/colony/io/UnixPathService.java
@@ -6,8 +6,8 @@ package net.lapidist.colony.io;
 public final class UnixPathService extends AbstractPathService {
 
     @Override
-    protected String getGameFolderPath() {
+    protected java.nio.file.Path getGameFolderPath() {
         String home = System.getProperty("user.home");
-        return java.nio.file.Paths.get(home, ".colony").toString();
+        return java.nio.file.Paths.get(home, ".colony");
     }
 }

--- a/core/src/net/lapidist/colony/io/WindowsPathService.java
+++ b/core/src/net/lapidist/colony/io/WindowsPathService.java
@@ -6,11 +6,11 @@ package net.lapidist.colony.io;
 public final class WindowsPathService extends AbstractPathService {
 
     @Override
-    protected String getGameFolderPath() {
+    protected java.nio.file.Path getGameFolderPath() {
         String base = System.getenv("APPDATA");
         if (base == null || base.isBlank()) {
             base = System.getProperty("user.home");
         }
-        return java.nio.file.Paths.get(base, ".colony").toString();
+        return java.nio.file.Paths.get(base, ".colony");
     }
 }

--- a/tests/src/net/lapidist/colony/tests/core/io/PathServiceGdxTest.java
+++ b/tests/src/net/lapidist/colony/tests/core/io/PathServiceGdxTest.java
@@ -1,0 +1,26 @@
+package net.lapidist.colony.tests.core.io;
+
+import com.badlogic.gdx.Gdx;
+import net.lapidist.colony.io.Paths;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Verifies that {@link Paths} resolves locations using LibGDX when
+ * a Files implementation is present.
+ */
+@RunWith(GdxTestRunner.class)
+public class PathServiceGdxTest {
+
+    @Test
+    public void resolvesSavePathUsingGdxFiles() throws Exception {
+        Path expected = Gdx.files.external(".colony/saves/foo.dat").file().toPath();
+        Path actual = Paths.get().getSave("foo");
+        assertEquals(expected.toAbsolutePath().normalize(), actual.toAbsolutePath().normalize());
+    }
+}


### PR DESCRIPTION
## Summary
- drop FileHandle usage from path services
- use new `GdxPathAdapter` to detect optional LibGDX environment
- update `UnixPathService` and `WindowsPathService` for `Path`
- cover LibGDX path resolution in tests

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_68481160deac8328977494a508668c44