### PR TITLE
feat(server): allow service injection

### DIFF
--- a/server/src/net/lapidist/colony/server/GameServer.java
+++ b/server/src/net/lapidist/colony/server/GameServer.java
@@ -50,26 +50,53 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
     private Iterable<CommandHandler<?>> commandHandlers;
 
     public GameServer(final GameServerConfig config) {
-        this(config, null, null);
+        this(config, null, null, null, null, null, null);
     }
 
     public GameServer(final GameServerConfig config,
                       final Iterable<MessageHandler<?>> handlersToUse) {
-        this(config, handlersToUse, null);
+        this(config, handlersToUse, null, null, null, null, null);
     }
 
     public GameServer(final GameServerConfig config,
                       final Iterable<MessageHandler<?>> handlersToUse,
                       final Iterable<CommandHandler<?>> commandHandlersToUse) {
+        this(config, handlersToUse, commandHandlersToUse, null, null, null, null);
+    }
+
+    /**
+     * Creates a new server instance using the provided services.
+     *
+     * @param config                configuration for the server
+     * @param handlersToUse         optional message handlers to register
+     * @param commandHandlersToUse  optional command handlers to register
+     * @param mapServiceToUse       map service implementation or {@code null} for the default
+     * @param networkServiceToUse   network service implementation or {@code null} for the default
+     * @param autosaveServiceToUse  autosave service implementation or {@code null} for the default
+     * @param commandBusToUse       command bus implementation or {@code null} for the default
+     */
+    public GameServer(
+            final GameServerConfig config,
+            final Iterable<MessageHandler<?>> handlersToUse,
+            final Iterable<CommandHandler<?>> commandHandlersToUse,
+            final MapService mapServiceToUse,
+            final NetworkService networkServiceToUse,
+            final AutosaveService autosaveServiceToUse,
+            final CommandBus commandBusToUse
+    ) {
         this.saveName = config.getSaveName();
         this.autosaveInterval = config.getAutosaveInterval();
         this.mapGenerator = config.getMapGenerator();
         this.handlers = handlersToUse;
         this.commandHandlers = commandHandlersToUse;
-        this.mapService = new MapService(mapGenerator, saveName);
-        this.networkService = new NetworkService(server, TCP_PORT, UDP_PORT);
-        this.autosaveService = new AutosaveService(autosaveInterval, saveName, () -> mapState);
-        this.commandBus = new CommandBus();
+        this.mapService = mapServiceToUse != null ? mapServiceToUse : new MapService(mapGenerator, saveName);
+        this.networkService = networkServiceToUse != null
+                ? networkServiceToUse
+                : new NetworkService(server, TCP_PORT, UDP_PORT);
+        this.autosaveService = autosaveServiceToUse != null
+                ? autosaveServiceToUse
+                : new AutosaveService(autosaveInterval, saveName, () -> mapState);
+        this.commandBus = commandBusToUse != null ? commandBusToUse : new CommandBus();
     }
 
     @Override

--- a/tests/src/net/lapidist/colony/tests/server/GameServerHandlerRegistrationTest.java
+++ b/tests/src/net/lapidist/colony/tests/server/GameServerHandlerRegistrationTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 
 import java.lang.reflect.Method;
 
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public class GameServerHandlerRegistrationTest {
@@ -74,10 +75,15 @@ public class GameServerHandlerRegistrationTest {
                 .saveName("handler-test")
                 .build();
         net.lapidist.colony.io.Paths.get().deleteAutosave("handler-test");
+        CommandBus bus = new CommandBus();
         GameServer server = new GameServer(
                 config,
                 java.util.List.of(messageHandler),
-                java.util.List.of(commandHandler)
+                java.util.List.of(commandHandler),
+                null,
+                null,
+                null,
+                bus
         );
         server.start();
 
@@ -89,6 +95,7 @@ public class GameServerHandlerRegistrationTest {
 
         assertTrue(messageHandler.handled());
         assertTrue(commandHandler.handled());
+        assertSame(bus, commandHandler.getBus());
 
         server.stop();
     }


### PR DESCRIPTION
## Summary
- allow injecting services when constructing `GameServer`
- verify service injection with `GameServerHandlerRegistrationTest`

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_68482908b91883288bf23a08e777d5d7