### PR TITLE
refactor: centralize world builder setup

### DIFF
--- a/client/src/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -57,25 +57,7 @@ public final class MapWorldBuilder {
             final KeyBindings keyBindings,
             final ResourceData playerResources
     ) {
-        CameraInputSystem cameraInputSystem = new CameraInputSystem(keyBindings);
-        cameraInputSystem.addProcessor(stage);
-        SelectionSystem selectionSystem = new SelectionSystem(client, keyBindings);
-        BuildPlacementSystem buildPlacementSystem = new BuildPlacementSystem(client);
-
-        return new WorldConfigurationBuilder()
-                .with(
-                        new EventSystem(),
-                        new ClearScreenSystem(Color.BLACK),
-                        cameraInputSystem,
-                        selectionSystem,
-                        buildPlacementSystem,
-                        new PlayerInitSystem(playerResources),
-                        new TileUpdateSystem(client),
-                        new BuildingUpdateSystem(client),
-                        new ResourceUpdateSystem(client),
-                        new MapRenderSystem(new MapRendererFactory()),
-                        new UISystem(stage)
-                );
+        return createBuilder(client, stage, keyBindings, null, playerResources);
     }
 
     /**
@@ -93,11 +75,7 @@ public final class MapWorldBuilder {
             final Stage stage,
             final KeyBindings keyBindings
     ) {
-        return baseBuilder(client, stage, keyBindings, new ResourceData())
-                .with(
-                        new MapInitSystem(provider),
-                        new PlayerCameraSystem()
-                );
+        return createBuilder(client, stage, keyBindings, provider, new ResourceData());
     }
 
     /**
@@ -109,11 +87,50 @@ public final class MapWorldBuilder {
             final Stage stage,
             final KeyBindings keyBindings
     ) {
-        return baseBuilder(client, stage, keyBindings, state.playerResources())
+        return createBuilder(
+                client,
+                stage,
+                keyBindings,
+                new ProvidedMapStateProvider(state),
+                state.playerResources()
+        );
+    }
+
+    private static WorldConfigurationBuilder createBuilder(
+            final GameClient client,
+            final Stage stage,
+            final KeyBindings keyBindings,
+            final MapStateProvider provider,
+            final ResourceData playerResources
+    ) {
+        CameraInputSystem cameraInputSystem = new CameraInputSystem(keyBindings);
+        cameraInputSystem.addProcessor(stage);
+        SelectionSystem selectionSystem = new SelectionSystem(client, keyBindings);
+        BuildPlacementSystem buildPlacementSystem = new BuildPlacementSystem(client);
+
+        WorldConfigurationBuilder builder = new WorldConfigurationBuilder()
                 .with(
-                        new MapInitSystem(new ProvidedMapStateProvider(state)),
-                        new PlayerCameraSystem()
+                        new EventSystem(),
+                        new ClearScreenSystem(Color.BLACK),
+                        cameraInputSystem,
+                        selectionSystem,
+                        buildPlacementSystem,
+                        new PlayerInitSystem(playerResources),
+                        new TileUpdateSystem(client),
+                        new BuildingUpdateSystem(client),
+                        new ResourceUpdateSystem(client),
+                        new MapRenderSystem(new MapRendererFactory()),
+                        new UISystem(stage)
                 );
+
+        if (provider != null) {
+            builder.with(
+                    new MapInitSystem(provider),
+                    new PlayerCameraSystem()
+            );
+        }
+
+        return builder;
     }
 
     /**

--- a/tests/src/net/lapidist/colony/tests/screens/MapWorldBuilderConfigurationTest.java
+++ b/tests/src/net/lapidist/colony/tests/screens/MapWorldBuilderConfigurationTest.java
@@ -1,0 +1,124 @@
+package net.lapidist.colony.tests.screens;
+
+import com.artemis.Aspect;
+import com.artemis.World;
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.utils.viewport.ScreenViewport;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.client.screens.MapWorldBuilder;
+import net.lapidist.colony.client.systems.BuildPlacementSystem;
+import net.lapidist.colony.client.systems.CameraInputSystem;
+import net.lapidist.colony.client.systems.MapInitSystem;
+import net.lapidist.colony.client.systems.PlayerCameraSystem;
+import net.lapidist.colony.client.systems.SelectionSystem;
+import net.lapidist.colony.client.systems.PlayerInitSystem;
+import net.lapidist.colony.client.systems.MapRenderSystem;
+import net.lapidist.colony.components.resources.PlayerResourceComponent;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.ResourceData;
+import net.lapidist.colony.components.state.TileData;
+import net.lapidist.colony.components.state.TilePos;
+import net.lapidist.colony.map.ProvidedMapStateProvider;
+import net.lapidist.colony.settings.KeyBindings;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedConstruction;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(GdxTestRunner.class)
+public class MapWorldBuilderConfigurationTest {
+
+    private static final int WOOD = 7;
+    private static final int STONE = 3;
+    private static final int FOOD = 2;
+
+
+    @Test
+    public void baseBuilderRegistersDefaultSystems() {
+        Batch batch = mock(Batch.class);
+        when(batch.getTransformMatrix()).thenReturn(new com.badlogic.gdx.math.Matrix4());
+        when(batch.getProjectionMatrix()).thenReturn(new com.badlogic.gdx.math.Matrix4());
+        Stage stage = new Stage(new ScreenViewport(), batch);
+        GameClient client = mock(GameClient.class);
+        KeyBindings keys = new KeyBindings();
+        try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
+            World world = MapWorldBuilder.build(
+                    MapWorldBuilder.baseBuilder(client, stage, keys)
+                            .with(new PlayerCameraSystem())
+            );
+
+            assertNotNull(world.getSystem(CameraInputSystem.class));
+            assertNotNull(world.getSystem(SelectionSystem.class));
+            assertNotNull(world.getSystem(BuildPlacementSystem.class));
+            assertNotNull(world.getSystem(PlayerInitSystem.class));
+            assertNotNull(world.getSystem(MapRenderSystem.class));
+            assertNull(world.getSystem(MapInitSystem.class));
+
+            world.dispose();
+        }
+    }
+
+    @Test
+    public void builderRegistersMapSystems() {
+        MapState state = new MapState();
+        state.tiles().put(new TilePos(0, 0), TileData.builder()
+                .x(0).y(0).tileType("GRASS").textureRef("grass0").passable(true)
+                .build());
+        Batch batch = mock(Batch.class);
+        when(batch.getTransformMatrix()).thenReturn(new com.badlogic.gdx.math.Matrix4());
+        when(batch.getProjectionMatrix()).thenReturn(new com.badlogic.gdx.math.Matrix4());
+        Stage stage = new Stage(new ScreenViewport(), batch);
+        GameClient client = mock(GameClient.class);
+        KeyBindings keys = new KeyBindings();
+        try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
+            World world = MapWorldBuilder.build(
+                    MapWorldBuilder.builder(new ProvidedMapStateProvider(state), client, stage, keys)
+            );
+            world.process();
+
+            assertNotNull(world.getSystem(MapInitSystem.class));
+            assertNotNull(world.getSystem(PlayerCameraSystem.class));
+            assertEquals(1, world.getAspectSubscriptionManager()
+                    .get(Aspect.all(PlayerResourceComponent.class))
+                    .getEntities().size());
+
+            world.dispose();
+        }
+    }
+
+    @Test
+    public void builderFromStateUsesInitialResources() {
+        ResourceData resources = new ResourceData(WOOD, STONE, FOOD);
+        MapState state = MapState.builder()
+                .playerResources(resources)
+                .build();
+        Batch batch = mock(Batch.class);
+        when(batch.getTransformMatrix()).thenReturn(new com.badlogic.gdx.math.Matrix4());
+        when(batch.getProjectionMatrix()).thenReturn(new com.badlogic.gdx.math.Matrix4());
+        Stage stage = new Stage(new ScreenViewport(), batch);
+        GameClient client = mock(GameClient.class);
+        KeyBindings keys = new KeyBindings();
+        try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
+            World world = MapWorldBuilder.build(
+                    MapWorldBuilder.builder(state, client, stage, keys)
+            );
+            world.process();
+
+            var players = world.getAspectSubscriptionManager()
+                    .get(Aspect.all(PlayerResourceComponent.class))
+                    .getEntities();
+            var comp = world.getMapper(PlayerResourceComponent.class)
+                    .get(world.getEntity(players.get(0)));
+            assertEquals(WOOD, comp.getWood());
+            assertEquals(STONE, comp.getStone());
+            assertEquals(FOOD, comp.getFood());
+
+            world.dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract helper to assemble `WorldConfigurationBuilder`
- use helper across `MapWorldBuilder` methods

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`

------
https://chatgpt.com/codex/tasks/task_e_68485a8960888328ab6defd955c84160