### PR TITLE
chore: add helper script for local checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Java 21 toolchains are configured via the Gradle wrapper. Run the following comm
 ./gradlew check              # run Checkstyle and Spotless verification
 ```
 
+You can also run all of these steps at once:
+
+```bash
+./scripts/check.sh
+```
+
 The `tests:copyAssets` task is required so that resources used by the test suite are available. `spotlessApply` will automatically format all Java sources and must be executed before committing.
 
 ### Running the Game

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+./gradlew tests:copyAssets
+./gradlew spotlessApply
+./gradlew clean test
+./gradlew check


### PR DESCRIPTION
## Summary
- add a script for running local gradle checks
- document the helper script in the README

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68488816082083289a36b6dbb7ec51e0