### PR TITLE
docs: provide module-specific agent guidance

### DIFF
--- a/client/AGENTS.md
+++ b/client/AGENTS.md
@@ -1,0 +1,10 @@
+# Purpose
+Desktop LibGDX client providing the game loop, rendering and user interface.
+
+# Key tasks
+- Integrate networking code to communicate with the server.
+- Run the game locally with `./gradlew :client:run`.
+
+# Testing notes
+- Ensure assets remain under the `assets` directory for packaging.
+- Full build and style checks are triggered via `./gradlew clean test check`.

--- a/core/AGENTS.md
+++ b/core/AGENTS.md
@@ -1,0 +1,10 @@
+# Purpose
+Shared ECS components, constants and serialization code used by the client and server modules.
+
+# Key tasks
+- Implement cross-platform game logic and common data classes here.
+- Maintain Kryo registration consistency across versions.
+
+# Testing notes
+- Run `./gradlew tests:copyAssets` before executing the main test suite.
+- Execute `./gradlew clean test` and `./gradlew check` to verify changes.

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -1,0 +1,9 @@
+# Purpose
+Headless game server running the same ECS logic as the client and exposing network services.
+
+# Key tasks
+- Launch via `./gradlew :server:run`.
+- Broadcast state updates to connected clients.
+
+# Testing notes
+- Follow the root module steps before running tests: `tests:copyAssets`, `clean test`, and `check`.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,9 @@
+# Purpose
+JUnit tests and utilities including `GdxTestRunner` for headless LibGDX execution.
+
+# Key tasks
+- Provide scenario tests using `GameSimulation` for gameplay validation.
+- Copy assets from the client module via `./gradlew tests:copyAssets` before running tests.
+
+# Testing notes
+- Run `./gradlew clean test` followed by `./gradlew check` to ensure style and coverage.


### PR DESCRIPTION
## Summary
- add AGENTS files for core, client, server and tests modules

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_6848880b31908328b88172141424623b