### PR TITLE
build: enforce coverage threshold

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,6 +31,9 @@ jobs:
         ./gradlew tests:copyAssets
         ./gradlew clean codeCoverageReport
 
+    - name: Verify coverage threshold
+      run: ./gradlew jacocoTestCoverageVerification
+
     - name: Run style checks
       run: ./gradlew check
 

--- a/build.gradle
+++ b/build.gradle
@@ -164,6 +164,35 @@ tasks.register('codeCoverageReport', JacocoReport) {
     }
 }
 
+tasks.named('jacocoTestCoverageVerification', JacocoCoverageVerification) {
+    dependsOn subprojects.collect { it.tasks.withType(Test) }
+
+    def coverageFiles = subprojects.collect { proj ->
+        proj.tasks.withType(Test).collect {
+            it.extensions.getByType(JacocoTaskExtension).destinationFile
+        }
+    }
+    executionData.setFrom(files(coverageFiles))
+
+    def sources = subprojects.collect { it.sourceSets.main.allSource.srcDirs }
+    sourceDirectories.setFrom(files(sources))
+
+    def classes = subprojects.collect { it.sourceSets.main.output }
+    classDirectories.setFrom(files(classes).collect {
+        fileTree(dir: it, exclude: ['**/generated/**', '**/*Launcher*'])
+    })
+
+    violationRules {
+        rule {
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+        }
+    }
+}
+
 tasks.register('aggregateJavadocs', Javadoc) {
     dependsOn subprojects.collect { it.tasks.javadoc }
     destinationDir = file("${buildDir}/docs/javadoc")
@@ -175,4 +204,5 @@ tasks.register('aggregateJavadocs', Javadoc) {
 
 tasks.named('check') {
     dependsOn 'aggregateJavadocs'
+    dependsOn 'jacocoTestCoverageVerification'
 }


### PR DESCRIPTION
## Summary
- add aggregated jacocoTestCoverageVerification with 80% threshold
- run verification in CI and make `check` depend on it

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check` *(fails: lines covered ratio is 0.68 but expected minimum is 0.80)*

------
https://chatgpt.com/codex/tasks/task_e_6848881004cc8328a5a69bebb8fbfbab