### PR TITLE
test: add factory unit tests

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -9,10 +9,18 @@ dependencies {
     implementation "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion"
     implementation "net.onedaybeard.artemis:artemis-odb:$artemisVersion"
     runtimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
+
+    testImplementation "junit:junit:$jUnitVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
 }
 
 application {
     mainClass = 'net.lapidist.colony.client.ClientLauncher'
+}
+
+sourceSets {
+    main.java.srcDirs = ['src/net']
+    test.java.srcDirs = ['src/test/java']
 }
 
 eclipse.project.name = "$appName-client"

--- a/client/src/test/java/net/lapidist/colony/client/entities/factories/BuildingFactoryTest.java
+++ b/client/src/test/java/net/lapidist/colony/client/entities/factories/BuildingFactoryTest.java
@@ -1,0 +1,26 @@
+package net.lapidist.colony.client.entities.factories;
+
+import com.artemis.Entity;
+import com.artemis.World;
+import com.badlogic.gdx.math.Vector2;
+import net.lapidist.colony.components.entities.BuildingComponent;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class BuildingFactoryTest {
+
+    @Test
+    public void setsBuildingComponentType() {
+        World world = new World();
+        Entity entity = BuildingFactory.create(
+                world,
+                BuildingComponent.BuildingType.MARKET,
+                "market0",
+                new Vector2(0, 0)
+        );
+
+        BuildingComponent component = world.getMapper(BuildingComponent.class).get(entity);
+        assertEquals(BuildingComponent.BuildingType.MARKET, component.getBuildingType());
+    }
+}

--- a/client/src/test/java/net/lapidist/colony/client/entities/factories/MapFactoryTest.java
+++ b/client/src/test/java/net/lapidist/colony/client/entities/factories/MapFactoryTest.java
@@ -1,0 +1,49 @@
+package net.lapidist.colony.client.entities.factories;
+
+import com.artemis.Entity;
+import com.artemis.World;
+import net.lapidist.colony.components.maps.MapComponent;
+import net.lapidist.colony.components.maps.TileComponent;
+import net.lapidist.colony.components.entities.BuildingComponent;
+import net.lapidist.colony.components.state.BuildingData;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.TileData;
+import net.lapidist.colony.components.state.TilePos;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MapFactoryTest {
+
+    @Test
+    public void createsMapWithTilesAndBuildings() {
+        MapState state = new MapState();
+        TileData tile = TileData.builder()
+                .x(0)
+                .y(0)
+                .tileType("GRASS")
+                .textureRef("grass0")
+                .passable(true)
+                .build();
+        state.tiles().put(new TilePos(0, 0), tile);
+
+        BuildingData building = new BuildingData(1, 1, "HOUSE", "house0");
+        state.buildings().add(building);
+
+        World world = new World();
+        Entity mapEntity = MapFactory.create(world, state);
+
+        MapComponent map = world.getMapper(MapComponent.class).get(mapEntity);
+        assertEquals(1, map.getTiles().size);
+        assertEquals(1, map.getTileMap().size());
+        assertEquals(1, map.getEntities().size);
+
+        TileComponent tileComponent = world.getMapper(TileComponent.class)
+                .get(map.getTiles().get(0));
+        assertEquals(TileComponent.TileType.GRASS, tileComponent.getTileType());
+
+        BuildingComponent bc = world.getMapper(BuildingComponent.class)
+                .get(map.getEntities().get(0));
+        assertEquals(BuildingComponent.BuildingType.HOUSE, bc.getBuildingType());
+    }
+}

--- a/client/src/test/java/net/lapidist/colony/client/entities/factories/package-info.java
+++ b/client/src/test/java/net/lapidist/colony/client/entities/factories/package-info.java
@@ -1,0 +1,1 @@
+package net.lapidist.colony.client.entities.factories;


### PR DESCRIPTION
## Summary
- add MapFactoryTest verifying tiles and building entities
- add BuildingFactoryTest covering component type
- allow client module test source and dependencies

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_6848960440808328b3d2870359eeff05