### PR TITLE
test: verify getLastAutosaveMarker delegation

### DIFF
--- a/tests/src/net/lapidist/colony/tests/core/io/PathsTest.java
+++ b/tests/src/net/lapidist/colony/tests/core/io/PathsTest.java
@@ -79,4 +79,16 @@ public class PathsTest {
         assertEquals(expected, actual);
         verify(service).getSettingsFile();
     }
+
+    @Test
+    public void delegatesGetLastAutosaveMarker() throws Exception {
+        PathService service = mock(PathService.class);
+        Path expected = java.nio.file.Paths.get("marker.dat");
+        when(service.getLastAutosaveMarker()).thenReturn(expected);
+        Paths paths = new Paths(service);
+
+        Path actual = paths.getLastAutosaveMarker();
+        assertEquals(expected, actual);
+        verify(service).getLastAutosaveMarker();
+    }
 }


### PR DESCRIPTION
## Summary
- ensure Paths delegates getLastAutosaveMarker to PathService
- run `spotlessApply`, `clean test`, and `check`

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply clean test check`

------
https://chatgpt.com/codex/tasks/task_e_6848978d3d9c8328845827a8451565af