### PR TITLE
test: verify map state sent on connect

### DIFF
--- a/client/src/net/lapidist/colony/client/network/GameClient.java
+++ b/client/src/net/lapidist/colony/client/network/GameClient.java
@@ -106,6 +106,13 @@ public final class GameClient extends AbstractMessageEndpoint {
         return playerId;
     }
 
+    /**
+     * Returns true if the underlying network client is connected to the server.
+     */
+    public boolean isConnected() {
+        return client.isConnected();
+    }
+
     @SuppressWarnings("unchecked")
     public <T> T poll(final Class<T> type) {
         Queue<T> queue = (Queue<T>) messageQueues.get(type);

--- a/server/src/net/lapidist/colony/server/GameServer.java
+++ b/server/src/net/lapidist/colony/server/GameServer.java
@@ -120,6 +120,14 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
         return mapState;
     }
 
+    /**
+     * Indicates if the server network thread is currently running.
+     */
+    public boolean isRunning() {
+        Thread t = server.getUpdateThread();
+        return t != null && t.isAlive();
+    }
+
     public void broadcast(final Object message) {
         networkService.broadcast(message);
     }

--- a/tests/src/net/lapidist/colony/tests/scenario/GameSimulationMapLoadNetworkTest.java
+++ b/tests/src/net/lapidist/colony/tests/scenario/GameSimulationMapLoadNetworkTest.java
@@ -1,0 +1,57 @@
+package net.lapidist.colony.tests.scenario;
+
+import com.artemis.Aspect;
+import com.artemis.Entity;
+import com.artemis.utils.IntBag;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.components.maps.MapComponent;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.server.GameServer;
+import net.lapidist.colony.server.GameServerConfig;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+/**
+ * Scenario test verifying that a client receives map data from the server and
+ * can load it into a simulation world.
+ */
+@RunWith(GdxTestRunner.class)
+public class GameSimulationMapLoadNetworkTest {
+
+    @Test
+    public void clientLoadsInitialMapFromServer() throws Exception {
+        GameServer server = new GameServer(GameServerConfig.builder().build());
+        server.start();
+
+        GameClient client = new GameClient();
+        CountDownLatch latch = new CountDownLatch(1);
+        client.start(state -> latch.countDown());
+        latch.await(1, TimeUnit.SECONDS);
+
+        assertTrue(client.isConnected());
+        MapState state = client.getMapState();
+        assertNotNull(state);
+        assertEquals(server.getMapState().name(), state.name());
+
+        GameSimulation sim = new GameSimulation(state, client);
+        sim.step();
+
+        IntBag maps = sim.getWorld().getAspectSubscriptionManager()
+                .get(Aspect.all(MapComponent.class))
+                .getEntities();
+        assertEquals(1, maps.size());
+
+        Entity map = sim.getWorld().getEntity(maps.get(0));
+        MapComponent mapComponent = sim.getWorld().getMapper(MapComponent.class).get(map);
+        assertFalse(mapComponent.getTiles().isEmpty());
+
+        client.stop();
+        server.stop();
+    }
+}


### PR DESCRIPTION
## Summary
- expose connection status in `GameClient`
- expose server running status in `GameServer`
- add `GameSimulationMapLoadNetworkTest` to ensure map data is received on connect

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`

------
https://chatgpt.com/codex/tasks/task_e_68489a6267708328aebc473f624cebb2