### PR TITLE
docs: clarify javadocs

### DIFF
--- a/client/src/net/lapidist/colony/client/core/io/package-info.java
+++ b/client/src/net/lapidist/colony/client/core/io/package-info.java
@@ -1,1 +1,4 @@
+/**
+ * I/O utilities for the Colony client.
+ */
 package net.lapidist.colony.client.core.io;

--- a/client/src/net/lapidist/colony/client/core/package-info.java
+++ b/client/src/net/lapidist/colony/client/core/package-info.java
@@ -1,1 +1,4 @@
+/**
+ * Core classes for the Colony client.
+ */
 package net.lapidist.colony.client.core;

--- a/client/src/net/lapidist/colony/client/entities/factories/BuildingFactory.java
+++ b/client/src/net/lapidist/colony/client/entities/factories/BuildingFactory.java
@@ -7,11 +7,23 @@ import net.lapidist.colony.components.entities.BuildingComponent;
 
 import static net.lapidist.colony.client.entities.factories.SpriteFactoryUtil.createEntity;
 
+/**
+ * Factory methods for creating building entities.
+ */
 public final class BuildingFactory {
 
     private BuildingFactory() {
     }
 
+    /**
+     * Create a new building entity.
+     *
+     * @param world        the Artemis world the entity belongs to
+     * @param buildingType the building type
+     * @param resourceRef  texture or atlas reference for the sprite
+     * @param coords       spawn coordinates
+     * @return created entity
+     */
     public static Entity create(
             final World world,
             final BuildingComponent.BuildingType buildingType,

--- a/client/src/net/lapidist/colony/client/entities/factories/package-info.java
+++ b/client/src/net/lapidist/colony/client/entities/factories/package-info.java
@@ -1,1 +1,4 @@
+/**
+ * Factory classes for creating client-side entities.
+ */
 package net.lapidist.colony.client.entities.factories;

--- a/client/src/net/lapidist/colony/client/events/ResizeEvent.java
+++ b/client/src/net/lapidist/colony/client/events/ResizeEvent.java
@@ -4,6 +4,9 @@ import net.mostlyoriginal.api.event.common.Event;
 
 /**
  * Event fired when the window is resized.
+ *
+ * @param width  the new window width
+ * @param height the new window height
  */
 public record ResizeEvent(int width, int height) implements Event {
 

--- a/client/src/net/lapidist/colony/client/events/package-info.java
+++ b/client/src/net/lapidist/colony/client/events/package-info.java
@@ -1,1 +1,4 @@
+/**
+ * Event classes dispatched by the Colony client.
+ */
 package net.lapidist.colony.client.events;

--- a/core/src/net/lapidist/colony/components/state/BuildingPlacementData.java
+++ b/core/src/net/lapidist/colony/components/state/BuildingPlacementData.java
@@ -4,6 +4,10 @@ import net.lapidist.colony.serialization.KryoType;
 
 /**
  * Request message sent by clients when placing a building.
+ *
+ * @param x            tile x coordinate
+ * @param y            tile y coordinate
+ * @param buildingType building type identifier
  */
 @KryoType
 public record BuildingPlacementData(int x, int y, String buildingType) {

--- a/core/src/net/lapidist/colony/components/state/ResourceData.java
+++ b/core/src/net/lapidist/colony/components/state/ResourceData.java
@@ -4,6 +4,10 @@ import net.lapidist.colony.serialization.KryoType;
 
 /**
  * Immutable resource amounts attached to a tile.
+ *
+ * @param wood  wood amount
+ * @param stone stone amount
+ * @param food  food amount
  */
 @KryoType
 public record ResourceData(int wood, int stone, int food) {

--- a/core/src/net/lapidist/colony/components/state/ResourceGatherRequestData.java
+++ b/core/src/net/lapidist/colony/components/state/ResourceGatherRequestData.java
@@ -2,6 +2,12 @@ package net.lapidist.colony.components.state;
 
 import net.lapidist.colony.serialization.KryoType;
 
-/** Request message for gathering resources from a tile. */
+/**
+ * Request message for gathering resources from a tile.
+ *
+ * @param x            tile x coordinate
+ * @param y            tile y coordinate
+ * @param resourceType type of resource to gather
+ */
 @KryoType
 public record ResourceGatherRequestData(int x, int y, String resourceType) { }

--- a/core/src/net/lapidist/colony/components/state/ResourceUpdateData.java
+++ b/core/src/net/lapidist/colony/components/state/ResourceUpdateData.java
@@ -2,6 +2,14 @@ package net.lapidist.colony.components.state;
 
 import net.lapidist.colony.serialization.KryoType;
 
-/** Broadcast message containing updated resources for a tile. */
+/**
+ * Broadcast message containing updated resources for a tile.
+ *
+ * @param x     tile x coordinate
+ * @param y     tile y coordinate
+ * @param wood  wood amount
+ * @param stone stone amount
+ * @param food  food amount
+ */
 @KryoType
 public record ResourceUpdateData(int x, int y, int wood, int stone, int food) { }

--- a/core/src/net/lapidist/colony/components/state/TileData.java
+++ b/core/src/net/lapidist/colony/components/state/TileData.java
@@ -4,6 +4,14 @@ import net.lapidist.colony.serialization.KryoType;
 
 /**
  * Immutable tile representation used in {@link MapState}.
+ *
+ * @param x          tile x coordinate
+ * @param y          tile y coordinate
+ * @param tileType   tile terrain type identifier
+ * @param textureRef sprite reference for rendering
+ * @param passable   whether units can move over the tile
+ * @param selected   whether the tile is currently selected
+ * @param resources  resources contained on the tile
  */
 @KryoType
 public record TileData(

--- a/core/src/net/lapidist/colony/components/state/TilePos.java
+++ b/core/src/net/lapidist/colony/components/state/TilePos.java
@@ -4,6 +4,9 @@ import net.lapidist.colony.serialization.KryoType;
 
 /**
  * Coordinate key used for tile lookup in {@link MapState}.
+ *
+ * @param x tile x coordinate
+ * @param y tile y coordinate
  */
 @KryoType
 public record TilePos(int x, int y) { }

--- a/core/src/net/lapidist/colony/save/SaveData.java
+++ b/core/src/net/lapidist/colony/save/SaveData.java
@@ -5,6 +5,10 @@ import net.lapidist.colony.serialization.KryoType;
 
 /**
  * Wrapper object persisted to disk containing save metadata and map state.
+ *
+ * @param version  the save format version
+ * @param kryoHash hash used to validate serializer configuration
+ * @param mapState the game state snapshot
  */
 @KryoType
 public record SaveData(int version, int kryoHash, MapState mapState) {

--- a/server/src/net/lapidist/colony/server/commands/BuildCommand.java
+++ b/server/src/net/lapidist/colony/server/commands/BuildCommand.java
@@ -4,6 +4,10 @@ import net.lapidist.colony.components.entities.BuildingComponent;
 
 /**
  * Command representing a building placement request.
+ *
+ * @param x    tile x coordinate
+ * @param y    tile y coordinate
+ * @param type building type
  */
 public record BuildCommand(int x, int y, BuildingComponent.BuildingType type) implements ServerCommand {
 }

--- a/server/src/net/lapidist/colony/server/commands/GatherCommand.java
+++ b/server/src/net/lapidist/colony/server/commands/GatherCommand.java
@@ -1,5 +1,11 @@
 package net.lapidist.colony.server.commands;
 
-/** Command representing a resource gather request. */
+/**
+ * Command representing a resource gather request.
+ *
+ * @param x            tile x coordinate
+ * @param y            tile y coordinate
+ * @param resourceType type of resource to gather
+ */
 public record GatherCommand(int x, int y, String resourceType) implements ServerCommand {
 }

--- a/server/src/net/lapidist/colony/server/commands/TileSelectionCommand.java
+++ b/server/src/net/lapidist/colony/server/commands/TileSelectionCommand.java
@@ -2,6 +2,10 @@ package net.lapidist.colony.server.commands;
 
 /**
  * Command representing a tile selection toggle.
+ *
+ * @param x        tile x coordinate
+ * @param y        tile y coordinate
+ * @param selected whether the tile should be selected
  */
 public record TileSelectionCommand(int x, int y, boolean selected) implements ServerCommand {
 }

--- a/server/src/net/lapidist/colony/server/commands/package-info.java
+++ b/server/src/net/lapidist/colony/server/commands/package-info.java
@@ -1,1 +1,4 @@
+/**
+ * Command objects issued by clients and processed by the server.
+ */
 package net.lapidist.colony.server.commands;

--- a/server/src/net/lapidist/colony/server/events/AutosaveEvent.java
+++ b/server/src/net/lapidist/colony/server/events/AutosaveEvent.java
@@ -6,6 +6,9 @@ import java.nio.file.Path;
 
 /**
  * Event fired when the server writes a game state autosave file.
+ *
+ * @param location path to the autosave file
+ * @param size     file size in bytes
  */
 public record AutosaveEvent(Path location, long size) implements Event {
 

--- a/server/src/net/lapidist/colony/server/events/BuildingPlacedEvent.java
+++ b/server/src/net/lapidist/colony/server/events/BuildingPlacedEvent.java
@@ -4,6 +4,10 @@ import net.mostlyoriginal.api.event.common.Event;
 
 /**
  * Event fired when a building is placed on the map.
+ *
+ * @param x            tile x coordinate
+ * @param y            tile y coordinate
+ * @param buildingType the building type
  */
 public record BuildingPlacedEvent(int x, int y, String buildingType) implements Event {
 

--- a/server/src/net/lapidist/colony/server/events/ShutdownSaveEvent.java
+++ b/server/src/net/lapidist/colony/server/events/ShutdownSaveEvent.java
@@ -6,6 +6,9 @@ import java.nio.file.Path;
 
 /**
  * Event fired when the server saves the game on shutdown.
+ *
+ * @param location path to the save file
+ * @param size     file size in bytes
  */
 public record ShutdownSaveEvent(Path location, long size) implements Event {
 

--- a/server/src/net/lapidist/colony/server/events/TileSelectionEvent.java
+++ b/server/src/net/lapidist/colony/server/events/TileSelectionEvent.java
@@ -4,6 +4,10 @@ import net.mostlyoriginal.api.event.common.Event;
 
 /**
  * Event fired when a tile selection state changes.
+ *
+ * @param x        tile x coordinate
+ * @param y        tile y coordinate
+ * @param selected whether the tile is selected
  */
 public record TileSelectionEvent(int x, int y, boolean selected) implements Event {
 

--- a/server/src/net/lapidist/colony/server/events/package-info.java
+++ b/server/src/net/lapidist/colony/server/events/package-info.java
@@ -1,1 +1,4 @@
+/**
+ * Events emitted by the server during gameplay.
+ */
 package net.lapidist.colony.server.events;

--- a/server/src/net/lapidist/colony/server/package-info.java
+++ b/server/src/net/lapidist/colony/server/package-info.java
@@ -1,1 +1,4 @@
+/**
+ * Headless server implementation and supporting classes.
+ */
 package net.lapidist.colony.server;


### PR DESCRIPTION
## Summary
- expand javadoc for event/command records
- document several server and client packages
- add basic docs for entity factory methods

## Testing
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68489a2b82088328add94345b3e1e4cd