### PR TITLE
feat(core): generate maps with perlin noise

### DIFF
--- a/core/src/net/lapidist/colony/map/DefaultMapGenerator.java
+++ b/core/src/net/lapidist/colony/map/DefaultMapGenerator.java
@@ -10,11 +10,13 @@ import net.lapidist.colony.i18n.I18n;
 import java.util.Random;
 
 /**
- * Default {@link MapGenerator} implementation generating a simple random map.
+ * Default {@link MapGenerator} implementation generating a simple random map
+ * using {@link PerlinNoise} to vary terrain textures.
  */
 public final class DefaultMapGenerator implements MapGenerator {
 
     private static final String[] TEXTURES = {"grass0", "dirt0"};
+    private static final double NOISE_SCALE = 0.1;
     private static final int NAME_RANGE = 100000;
     private static final int DEFAULT_WOOD = 10;
     private static final int DEFAULT_STONE = 5;
@@ -24,6 +26,7 @@ public final class DefaultMapGenerator implements MapGenerator {
     public MapState generate(final int width, final int height) {
         MapState state = new MapState();
         Random random = new Random();
+        PerlinNoise noise = new PerlinNoise(random.nextLong());
         state = state.toBuilder()
                 .name("map-" + random.nextInt(NAME_RANGE))
                 .description(I18n.get("generator.generatedMap"))
@@ -31,7 +34,7 @@ public final class DefaultMapGenerator implements MapGenerator {
 
         for (int x = 0; x < width; x++) {
             for (int y = 0; y < height; y++) {
-                state.tiles().put(new TilePos(x, y), createTile(x, y, random));
+                state.tiles().put(new TilePos(x, y), createTile(x, y, random, noise));
             }
         }
 
@@ -45,12 +48,19 @@ public final class DefaultMapGenerator implements MapGenerator {
         return state;
     }
 
-    private static TileData createTile(final int x, final int y, final Random random) {
+    private static TileData createTile(
+            final int x,
+            final int y,
+            final Random random,
+            final PerlinNoise noise
+    ) {
+        double value = noise.noise(x * NOISE_SCALE, y * NOISE_SCALE);
+        String texture = value > 0 ? TEXTURES[0] : TEXTURES[1];
         return TileData.builder()
                 .x(x)
                 .y(y)
                 .tileType("GRASS")
-                .textureRef(TEXTURES[random.nextInt(TEXTURES.length)])
+                .textureRef(texture)
                 .passable(true)
                 .selected(false)
                 .resources(new ResourceData(DEFAULT_WOOD, DEFAULT_STONE, DEFAULT_FOOD))

--- a/core/src/net/lapidist/colony/map/PerlinNoise.java
+++ b/core/src/net/lapidist/colony/map/PerlinNoise.java
@@ -1,0 +1,76 @@
+package net.lapidist.colony.map;
+
+import java.util.Random;
+
+/**
+ * Simple 2D Perlin noise generator based on Ken Perlin's reference
+ * implementation.
+ */
+public final class PerlinNoise {
+
+    private static final int TABLE_SIZE = 256;
+    private static final int TABLE_MASK = TABLE_SIZE - 1;
+    private static final int PERM_SIZE = TABLE_SIZE * 2;
+    private static final int GRADIENT_MASK = 3;
+    private static final double FADE_A = 6.0;
+    private static final double FADE_B = 15.0;
+    private static final double FADE_C = 10.0;
+
+    private final int[] perm = new int[PERM_SIZE];
+
+    public PerlinNoise(final long seed) {
+        int[] p = new int[TABLE_SIZE];
+        for (int i = 0; i < TABLE_SIZE; i++) {
+            p[i] = i;
+        }
+        Random random = new Random(seed);
+        for (int i = TABLE_MASK; i > 0; i--) {
+            int j = random.nextInt(i + 1);
+            int tmp = p[i];
+            p[i] = p[j];
+            p[j] = tmp;
+        }
+        for (int i = 0; i < PERM_SIZE; i++) {
+            perm[i] = p[i & TABLE_MASK];
+        }
+    }
+
+    public double noise(final double x, final double y) {
+        int xi = fastFloor(x) & TABLE_MASK;
+        int yi = fastFloor(y) & TABLE_MASK;
+        double xf = x - fastFloor(x);
+        double yf = y - fastFloor(y);
+
+        double u = fade(xf);
+        double v = fade(yf);
+
+        int aa = perm[xi] + yi;
+        int ab = perm[xi] + yi + 1;
+        int ba = perm[xi + 1] + yi;
+        int bb = perm[xi + 1] + yi + 1;
+
+        double x1 = lerp(u, grad(perm[aa], xf, yf), grad(perm[ba], xf - 1, yf));
+        double x2 = lerp(u, grad(perm[ab], xf, yf - 1), grad(perm[bb], xf - 1, yf - 1));
+
+        return lerp(v, x1, x2);
+    }
+
+    private static int fastFloor(final double x) {
+        return x > 0 ? (int) x : (int) x - 1;
+    }
+
+    private static double fade(final double t) {
+        return t * t * t * (t * (t * FADE_A - FADE_B) + FADE_C);
+    }
+
+    private static double lerp(final double t, final double a, final double b) {
+        return a + t * (b - a);
+    }
+
+    private static double grad(final int hash, final double x, final double y) {
+        int h = hash & GRADIENT_MASK;
+        double u = h < 2 ? x : y;
+        double v = h < 2 ? y : x;
+        return ((h & 1) == 0 ? u : -u) + ((h & 2) == 0 ? v : -v);
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/map/PerlinNoiseTest.java
+++ b/tests/src/net/lapidist/colony/tests/map/PerlinNoiseTest.java
@@ -1,0 +1,34 @@
+package net.lapidist.colony.tests.map;
+
+import net.lapidist.colony.map.PerlinNoise;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PerlinNoiseTest {
+
+    private static final long SEED_ONE = 42L;
+    private static final long SEED_TWO = 123L;
+    private static final double X_POS = 1.5;
+    private static final double Y_POS = 2.5;
+    private static final double X2 = 0.2;
+    private static final double Y2 = 0.8;
+    private static final double EPSILON = 1e-6;
+
+    @Test
+    public void sameSeedProducesSameValues() {
+        PerlinNoise a = new PerlinNoise(SEED_ONE);
+        PerlinNoise b = new PerlinNoise(SEED_ONE);
+        double va = a.noise(X_POS, Y_POS);
+        double vb = b.noise(X_POS, Y_POS);
+        assertEquals(va, vb, EPSILON);
+    }
+
+    @Test
+    public void noiseWithinExpectedRange() {
+        PerlinNoise noise = new PerlinNoise(SEED_TWO);
+        double value = noise.noise(X2, Y2);
+        assertTrue(value >= -1.0 && value <= 1.0);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `PerlinNoise` utility
- use perlin noise in `DefaultMapGenerator` for varied terrain
- add unit test for `PerlinNoise`

## Testing
- `./gradlew spotlessApply`
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`

------
https://chatgpt.com/codex/tasks/task_e_68489845db1883288673d768b6cb3dbf