### PR TITLE
docs: add localization guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# Documentation
+
+Additional guides for developing and contributing to Colony.
+
+- [Architecture Overview](architecture.md)
+- [Localization Guide](i18n.md)

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,0 +1,51 @@
+# Localization Guide
+
+Colony uses a lightweight translation system backed by Java's `ResourceBundle`.
+All user-facing text is stored in property files and retrieved at runtime through
+`I18n`.
+
+## I18n Utility
+
+The class `net.lapidist.colony.i18n.I18n` exposes two simple methods:
+
+- `I18n.get("key")` – return the translated string for `key`. Missing keys are
+  returned as `!key!` so they are easy to spot during development.
+- `I18n.setLocale(Locale locale)` – change the active language. The current
+  locale can be read with `I18n.getLocale()`.
+
+`SettingsScreen` provides buttons that call `I18n.setLocale` and store the
+selection in the user's settings so the chosen language is loaded on the next
+startup.
+
+## Translation Files
+
+Translation bundles live under `core/src/main/resources/i18n`. `messages.properties`
+contains the default English strings. Additional locales use the filename
+`messages_<code>.properties` where `<code>` is an ISO 639 language code. For
+example:
+
+- `messages_es.properties` – Spanish
+- `messages_fr.properties` – French
+- `messages_de.properties` – German
+
+Each file defines the same keys, for example:
+
+```properties
+main.continue=Continue
+main.newGame=New Game
+```
+
+## Adding a New Locale
+
+1. Create a `messages_<code>.properties` file next to the existing bundles.
+2. Copy all keys from `messages.properties` and translate each value.
+3. Rebuild the project so the resource bundle is updated.
+4. Call `I18n.setLocale(new Locale("<code>"))` from the client to use the new
+   translations. You can extend `SettingsScreen` with another button to let
+   players switch to the new language.
+
+## Switching Languages In-Game
+
+Open the Settings screen from the main menu. Choosing a language button invokes
+`I18n.setLocale` and saves the choice to the user's settings. The selected
+locale is applied immediately and restored on the next launch.


### PR DESCRIPTION
## Summary
- document I18n usage and translation files
- explain how to add and switch locales
- index the guide from docs/README

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_6848a2cf3f7c83288ae8d36de3e8427c