### PR TITLE
docs: reduce javadoc warnings

### DIFF
--- a/client/src/net/lapidist/colony/client/events/GameInitEvent.java
+++ b/client/src/net/lapidist/colony/client/events/GameInitEvent.java
@@ -1,6 +1,10 @@
 package net.lapidist.colony.client.events;
 
 import net.lapidist.colony.core.events.SimpleEvent;
+
+/**
+ * Event fired when the game has finished initialisation.
+ */
 public final class GameInitEvent extends SimpleEvent {
 
 }

--- a/client/src/net/lapidist/colony/client/events/HideEvent.java
+++ b/client/src/net/lapidist/colony/client/events/HideEvent.java
@@ -1,6 +1,10 @@
 package net.lapidist.colony.client.events;
 
 import net.lapidist.colony.core.events.SimpleEvent;
+
+/**
+ * Event fired when the UI should be hidden.
+ */
 public final class HideEvent extends SimpleEvent {
 
 }

--- a/client/src/net/lapidist/colony/client/network/handlers/package-info.java
+++ b/client/src/net/lapidist/colony/client/network/handlers/package-info.java
@@ -1,1 +1,4 @@
+/**
+ * Client-side message handler implementations.
+ */
 package net.lapidist.colony.client.network.handlers;

--- a/client/src/net/lapidist/colony/client/network/package-info.java
+++ b/client/src/net/lapidist/colony/client/network/package-info.java
@@ -1,1 +1,4 @@
+/**
+ * Networking utilities and client endpoints.
+ */
 package net.lapidist.colony.client.network;

--- a/client/src/net/lapidist/colony/client/renderers/package-info.java
+++ b/client/src/net/lapidist/colony/client/renderers/package-info.java
@@ -1,1 +1,4 @@
+/**
+ * Rendering utilities for the Colony client.
+ */
 package net.lapidist.colony.client.renderers;

--- a/client/src/net/lapidist/colony/client/screens/BaseScreen.java
+++ b/client/src/net/lapidist/colony/client/screens/BaseScreen.java
@@ -17,10 +17,18 @@ public abstract class BaseScreen extends ScreenAdapter {
     private final Skin skin;
     private final Table root;
 
+    /**
+     * Creates a screen with a default {@link Stage} instance.
+     */
     protected BaseScreen() {
         this(new Stage(new ScreenViewport()));
     }
 
+    /**
+     * Creates a screen using the provided stage.
+     *
+     * @param customStage stage used to display the UI
+     */
     protected BaseScreen(final Stage customStage) {
         stage = customStage;
         skin = new Skin(Gdx.files.internal("skin/default.json"));
@@ -30,14 +38,29 @@ public abstract class BaseScreen extends ScreenAdapter {
         Gdx.input.setInputProcessor(stage);
     }
 
+    /**
+     * Returns the stage used for rendering.
+     *
+     * @return the stage used for rendering
+     */
     protected final Stage getStage() {
         return stage;
     }
 
+    /**
+     * Returns the skin used for UI elements.
+     *
+     * @return the UI skin in use
+     */
     protected final Skin getSkin() {
         return skin;
     }
 
+    /**
+     * Returns the root table containing all actors.
+     *
+     * @return the root table containing all actors
+     */
     protected final Table getRoot() {
         return root;
     }

--- a/client/src/net/lapidist/colony/client/systems/input/package-info.java
+++ b/client/src/net/lapidist/colony/client/systems/input/package-info.java
@@ -1,1 +1,4 @@
+/**
+ * Input handling systems for user interaction.
+ */
 package net.lapidist.colony.client.systems.input;

--- a/client/src/net/lapidist/colony/client/systems/network/package-info.java
+++ b/client/src/net/lapidist/colony/client/systems/network/package-info.java
@@ -1,1 +1,4 @@
+/**
+ * Systems synchronizing state with the server.
+ */
 package net.lapidist.colony.client.systems.network;

--- a/client/src/net/lapidist/colony/client/ui/package-info.java
+++ b/client/src/net/lapidist/colony/client/ui/package-info.java
@@ -1,1 +1,4 @@
+/**
+ * User interface actors and widgets.
+ */
 package net.lapidist.colony.client.ui;

--- a/core/src/net/lapidist/colony/components/assets/package-info.java
+++ b/core/src/net/lapidist/colony/components/assets/package-info.java
@@ -1,1 +1,4 @@
+/**
+ * Components describing loaded game assets.
+ */
 package net.lapidist.colony.components.assets;

--- a/core/src/net/lapidist/colony/components/entities/package-info.java
+++ b/core/src/net/lapidist/colony/components/entities/package-info.java
@@ -1,1 +1,4 @@
+/**
+ * Components representing in-world entities.
+ */
 package net.lapidist.colony.components.entities;

--- a/core/src/net/lapidist/colony/components/maps/package-info.java
+++ b/core/src/net/lapidist/colony/components/maps/package-info.java
@@ -1,1 +1,4 @@
+/**
+ * Map and tile related components.
+ */
 package net.lapidist.colony.components.maps;

--- a/core/src/net/lapidist/colony/components/package-info.java
+++ b/core/src/net/lapidist/colony/components/package-info.java
@@ -1,1 +1,4 @@
+/**
+ * Artemis ECS components used throughout the game.
+ */
 package net.lapidist.colony.components;

--- a/core/src/net/lapidist/colony/components/state/package-info.java
+++ b/core/src/net/lapidist/colony/components/state/package-info.java
@@ -1,1 +1,4 @@
+/**
+ * Components holding persistent map state.
+ */
 package net.lapidist.colony.components.state;

--- a/core/src/net/lapidist/colony/network/AbstractMessageHandler.java
+++ b/core/src/net/lapidist/colony/network/AbstractMessageHandler.java
@@ -3,6 +3,8 @@ package net.lapidist.colony.network;
 /**
  * Convenience base class for {@link MessageHandler} implementations that
  * handle a fixed message type.
+ *
+ * @param <T> the message type this handler processes
  */
 public abstract class AbstractMessageHandler<T> implements MessageHandler<T> {
 

--- a/core/src/net/lapidist/colony/network/MessageDispatcher.java
+++ b/core/src/net/lapidist/colony/network/MessageDispatcher.java
@@ -11,10 +11,21 @@ public final class MessageDispatcher {
 
     private final Map<Class<?>, Consumer<?>> handlers = new ConcurrentHashMap<>();
 
+    /**
+     * Registers a handler for the given message type.
+     *
+     * @param type    the message class to handle
+     * @param handler consumer that processes messages of {@code type}
+     */
     public <T> void register(final Class<T> type, final Consumer<? super T> handler) {
         handlers.put(type, handler);
     }
 
+    /**
+     * Dispatches the supplied message to the registered handler if present.
+     *
+     * @param message the message to dispatch
+     */
     @SuppressWarnings("unchecked")
     public <T> void dispatch(final T message) {
         Consumer<T> handler = (Consumer<T>) handlers.get(message.getClass());

--- a/core/src/net/lapidist/colony/network/package-info.java
+++ b/core/src/net/lapidist/colony/network/package-info.java
@@ -1,1 +1,4 @@
+/**
+ * Common networking interfaces shared by client and server.
+ */
 package net.lapidist.colony.network;

--- a/server/src/net/lapidist/colony/server/events/AutosaveEvent.java
+++ b/server/src/net/lapidist/colony/server/events/AutosaveEvent.java
@@ -12,6 +12,9 @@ import java.nio.file.Path;
  */
 public record AutosaveEvent(Path location, long size) implements Event {
 
+    /**
+     * Creates a new {@code AutosaveEvent}.
+     */
     public AutosaveEvent {
         // explicit constructor for future validation
     }

--- a/server/src/net/lapidist/colony/server/events/BuildingPlacedEvent.java
+++ b/server/src/net/lapidist/colony/server/events/BuildingPlacedEvent.java
@@ -11,6 +11,9 @@ import net.mostlyoriginal.api.event.common.Event;
  */
 public record BuildingPlacedEvent(int x, int y, String buildingType) implements Event {
 
+    /**
+     * Creates a new event instance.
+     */
     public BuildingPlacedEvent {
         // explicit constructor for future validation
     }

--- a/server/src/net/lapidist/colony/server/events/ShutdownSaveEvent.java
+++ b/server/src/net/lapidist/colony/server/events/ShutdownSaveEvent.java
@@ -12,6 +12,9 @@ import java.nio.file.Path;
  */
 public record ShutdownSaveEvent(Path location, long size) implements Event {
 
+    /**
+     * Creates a new {@code ShutdownSaveEvent}.
+     */
     public ShutdownSaveEvent {
         // explicit constructor for future validation
     }

--- a/server/src/net/lapidist/colony/server/events/TileSelectionEvent.java
+++ b/server/src/net/lapidist/colony/server/events/TileSelectionEvent.java
@@ -11,6 +11,9 @@ import net.mostlyoriginal.api.event.common.Event;
  */
 public record TileSelectionEvent(int x, int y, boolean selected) implements Event {
 
+    /**
+     * Creates a new event instance.
+     */
     public TileSelectionEvent {
         // explicit constructor for future validation
     }

--- a/server/src/net/lapidist/colony/server/handlers/package-info.java
+++ b/server/src/net/lapidist/colony/server/handlers/package-info.java
@@ -1,1 +1,4 @@
+/**
+ * Server-side message handlers responding to client requests.
+ */
 package net.lapidist.colony.server.handlers;

--- a/server/src/net/lapidist/colony/server/io/package-info.java
+++ b/server/src/net/lapidist/colony/server/io/package-info.java
@@ -1,1 +1,4 @@
+/**
+ * Loading and saving utilities for server state.
+ */
 package net.lapidist.colony.server.io;

--- a/server/src/net/lapidist/colony/server/services/package-info.java
+++ b/server/src/net/lapidist/colony/server/services/package-info.java
@@ -1,1 +1,4 @@
+/**
+ * Core services used by the dedicated server.
+ */
 package net.lapidist.colony.server.services;


### PR DESCRIPTION
## Summary
- add missing package-level Javadocs
- document constructors and accessors
- clarify generics for network classes
- document event record constructors

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6848add75d2c83288b78d6c0e683df60