### PR TITLE
feat: introduce graphics settings and shader utilities

### DIFF
--- a/client/src/net/lapidist/colony/client/graphics/ShaderManager.java
+++ b/client/src/net/lapidist/colony/client/graphics/ShaderManager.java
@@ -1,0 +1,53 @@
+package net.lapidist.colony.client.graphics;
+
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import net.lapidist.colony.client.core.io.FileLocation;
+
+import java.io.IOException;
+
+/**
+ * Utility for loading and compiling shader programs.
+ */
+import java.util.function.BiFunction;
+
+public final class ShaderManager {
+
+    private final BiFunction<FileHandle, FileHandle, ShaderProgram> factory;
+
+    public ShaderManager() {
+        this(ShaderProgram::new);
+    }
+
+    public ShaderManager(final BiFunction<FileHandle, FileHandle, ShaderProgram> factoryToUse) {
+        this.factory = factoryToUse;
+    }
+
+    /**
+     * Load and compile a shader program from the given file paths.
+     *
+     * @param location the location type for resolving files
+     * @param vertexPath path to the vertex shader source
+     * @param fragmentPath path to the fragment shader source
+     * @return the compiled {@link ShaderProgram}
+     * @throws IOException if sources are missing or compilation fails
+     */
+    public ShaderProgram load(
+            final FileLocation location,
+            final String vertexPath,
+            final String fragmentPath
+    ) throws IOException {
+        FileHandle vertexFile = location.getFile(vertexPath);
+        FileHandle fragmentFile = location.getFile(fragmentPath);
+        if (!vertexFile.exists() || !fragmentFile.exists()) {
+            throw new IOException("Shader source not found");
+        }
+        ShaderProgram program = factory.apply(vertexFile, fragmentFile);
+        if (!program.isCompiled()) {
+            String log = program.getLog();
+            program.dispose();
+            throw new IOException(log);
+        }
+        return program;
+    }
+}

--- a/client/src/net/lapidist/colony/client/graphics/package-info.java
+++ b/client/src/net/lapidist/colony/client/graphics/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Graphics utilities including shader loading.
+ */
+package net.lapidist.colony.client.graphics;

--- a/core/src/net/lapidist/colony/settings/GraphicsSettings.java
+++ b/core/src/net/lapidist/colony/settings/GraphicsSettings.java
@@ -1,0 +1,69 @@
+package net.lapidist.colony.settings;
+
+import com.badlogic.gdx.Preferences;
+
+/**
+ * Graphics configuration flags controlling advanced rendering options.
+ */
+public final class GraphicsSettings {
+    private static final String PREFIX = "graphics.";
+    private static final String AA_KEY = PREFIX + "antialiasing";
+    private static final String MIP_KEY = PREFIX + "mipmaps";
+    private static final String AF_KEY = PREFIX + "anisotropic";
+    private static final String SHADER_KEY = PREFIX + "shaders";
+
+    private boolean antialiasingEnabled;
+    private boolean mipMapsEnabled;
+    private boolean anisotropicFilteringEnabled;
+    private boolean shadersEnabled;
+
+    public boolean isAntialiasingEnabled() {
+        return antialiasingEnabled;
+    }
+
+    public void setAntialiasingEnabled(final boolean enabled) {
+        this.antialiasingEnabled = enabled;
+    }
+
+    public boolean isMipMapsEnabled() {
+        return mipMapsEnabled;
+    }
+
+    public void setMipMapsEnabled(final boolean enabled) {
+        this.mipMapsEnabled = enabled;
+    }
+
+    public boolean isAnisotropicFilteringEnabled() {
+        return anisotropicFilteringEnabled;
+    }
+
+    public void setAnisotropicFilteringEnabled(final boolean enabled) {
+        this.anisotropicFilteringEnabled = enabled;
+    }
+
+    public boolean isShadersEnabled() {
+        return shadersEnabled;
+    }
+
+    public void setShadersEnabled(final boolean enabled) {
+        this.shadersEnabled = enabled;
+    }
+
+    /** Load graphics settings from the given preferences. */
+    public static GraphicsSettings load(final Preferences prefs) {
+        GraphicsSettings gs = new GraphicsSettings();
+        gs.antialiasingEnabled = prefs.getBoolean(AA_KEY, false);
+        gs.mipMapsEnabled = prefs.getBoolean(MIP_KEY, false);
+        gs.anisotropicFilteringEnabled = prefs.getBoolean(AF_KEY, false);
+        gs.shadersEnabled = prefs.getBoolean(SHADER_KEY, false);
+        return gs;
+    }
+
+    /** Save graphics settings to the provided preferences. */
+    public void save(final Preferences prefs) {
+        prefs.putBoolean(AA_KEY, antialiasingEnabled);
+        prefs.putBoolean(MIP_KEY, mipMapsEnabled);
+        prefs.putBoolean(AF_KEY, anisotropicFilteringEnabled);
+        prefs.putBoolean(SHADER_KEY, shadersEnabled);
+    }
+}

--- a/core/src/net/lapidist/colony/settings/Settings.java
+++ b/core/src/net/lapidist/colony/settings/Settings.java
@@ -14,11 +14,16 @@ public final class Settings {
     private static final String LANGUAGE_KEY = "language";
 
     private final KeyBindings keyBindings = new KeyBindings();
+    private final GraphicsSettings graphicsSettings = new GraphicsSettings();
 
     private Locale locale = Locale.getDefault();
 
     public KeyBindings getKeyBindings() {
         return keyBindings;
+    }
+
+    public GraphicsSettings getGraphicsSettings() {
+        return graphicsSettings;
     }
 
     public Locale getLocale() {
@@ -45,6 +50,12 @@ public final class Settings {
             for (KeyAction action : KeyAction.values()) {
                 settings.keyBindings.setKey(action, loaded.getKey(action));
             }
+            GraphicsSettings gLoaded = GraphicsSettings.load(prefs);
+            settings.graphicsSettings.setAntialiasingEnabled(gLoaded.isAntialiasingEnabled());
+            settings.graphicsSettings.setMipMapsEnabled(gLoaded.isMipMapsEnabled());
+            settings.graphicsSettings.setAnisotropicFilteringEnabled(
+                    gLoaded.isAnisotropicFilteringEnabled());
+            settings.graphicsSettings.setShadersEnabled(gLoaded.isShadersEnabled());
         }
         return settings;
     }
@@ -59,6 +70,7 @@ public final class Settings {
         Preferences prefs = Gdx.app.getPreferences("settings");
         prefs.putString(LANGUAGE_KEY, locale.toLanguageTag());
         keyBindings.save(prefs);
+        graphicsSettings.save(prefs);
         prefs.flush();
     }
 }

--- a/tests/src/net/lapidist/colony/tests/GdxTestRunner.java
+++ b/tests/src/net/lapidist/colony/tests/GdxTestRunner.java
@@ -50,6 +50,9 @@ public class GdxTestRunner
         doNothing().when(Gdx.gl20).glCompileShader(anyInt());
         doNothing().when(Gdx.gl20).glAttachShader(anyInt(), anyInt());
         doNothing().when(Gdx.gl20).glLinkProgram(anyInt());
+        when(Gdx.gl20.glGetAttribLocation(anyInt(), any())).thenReturn(0);
+        when(Gdx.gl20.glGetUniformLocation(anyInt(), any())).thenReturn(0);
+        doNothing().when(Gdx.gl20).glUseProgram(anyInt());
         doNothing().when(Gdx.gl20).glDeleteShader(anyInt());
         doNothing().when(Gdx.gl20).glDeleteProgram(anyInt());
     }

--- a/tests/src/net/lapidist/colony/tests/core/settings/GraphicsSettingsTest.java
+++ b/tests/src/net/lapidist/colony/tests/core/settings/GraphicsSettingsTest.java
@@ -1,0 +1,48 @@
+package net.lapidist.colony.tests.core.settings;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Preferences;
+import net.lapidist.colony.settings.GraphicsSettings;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+@RunWith(GdxTestRunner.class)
+public class GraphicsSettingsTest {
+
+    @Test
+    public void savesAndLoadsValues() {
+        Preferences prefs = Gdx.app.getPreferences("settings");
+        prefs.clear();
+        prefs.flush();
+
+        GraphicsSettings gs = new GraphicsSettings();
+        gs.setAntialiasingEnabled(true);
+        gs.setMipMapsEnabled(true);
+        gs.setAnisotropicFilteringEnabled(true);
+        gs.setShadersEnabled(true);
+        gs.save(prefs);
+        prefs.flush();
+
+        GraphicsSettings loaded = GraphicsSettings.load(prefs);
+        assertTrue(loaded.isAntialiasingEnabled());
+        assertTrue(loaded.isMipMapsEnabled());
+        assertTrue(loaded.isAnisotropicFilteringEnabled());
+        assertTrue(loaded.isShadersEnabled());
+    }
+
+    @Test
+    public void defaultsWhenNoPreferences() {
+        Preferences prefs = Gdx.app.getPreferences("settings");
+        prefs.clear();
+        prefs.flush();
+
+        GraphicsSettings loaded = GraphicsSettings.load(prefs);
+        assertFalse(loaded.isAntialiasingEnabled());
+        assertFalse(loaded.isMipMapsEnabled());
+        assertFalse(loaded.isAnisotropicFilteringEnabled());
+        assertFalse(loaded.isShadersEnabled());
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/core/settings/SettingsTest.java
+++ b/tests/src/net/lapidist/colony/tests/core/settings/SettingsTest.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Preferences;
 import net.lapidist.colony.settings.Settings;
 import net.lapidist.colony.settings.KeyAction;
+import net.lapidist.colony.settings.GraphicsSettings;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -60,5 +61,24 @@ public class SettingsTest {
         settings.getKeyBindings().setKey(KeyAction.MOVE_UP, com.badlogic.gdx.Input.Keys.Z);
         settings.getKeyBindings().reset();
         assertEquals(com.badlogic.gdx.Input.Keys.W, settings.getKeyBindings().getKey(KeyAction.MOVE_UP));
+    }
+
+    @Test
+    public void savesAndLoadsGraphicsSettings() throws IOException {
+        Preferences prefs = Gdx.app.getPreferences("settings");
+        prefs.clear();
+        prefs.flush();
+
+        Settings settings = new Settings();
+        GraphicsSettings graphics = settings.getGraphicsSettings();
+        graphics.setAntialiasingEnabled(true);
+        graphics.setMipMapsEnabled(true);
+        settings.save();
+
+        Settings loaded = Settings.load();
+        assertEquals(true, loaded.getGraphicsSettings().isAntialiasingEnabled());
+        assertEquals(true, loaded.getGraphicsSettings().isMipMapsEnabled());
+        assertEquals(false, loaded.getGraphicsSettings().isAnisotropicFilteringEnabled());
+        assertEquals(false, loaded.getGraphicsSettings().isShadersEnabled());
     }
 }

--- a/tests/src/net/lapidist/colony/tests/graphics/ShaderManagerTest.java
+++ b/tests/src/net/lapidist/colony/tests/graphics/ShaderManagerTest.java
@@ -1,0 +1,52 @@
+package net.lapidist.colony.tests.graphics;
+
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import net.lapidist.colony.client.core.io.FileLocation;
+import net.lapidist.colony.client.graphics.ShaderManager;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(GdxTestRunner.class)
+public class ShaderManagerTest {
+
+    @Test
+    public void loadsShaderProgram() throws IOException {
+        File vertex = File.createTempFile("test", ".vert");
+        File fragment = File.createTempFile("test", ".frag");
+        String vert = String.join("\n",
+                "attribute vec4 a_position;",
+                "void main(){",
+                "    gl_Position = a_position;",
+                "}",
+                "");
+        String frag = String.join("\n",
+                "#ifdef GL_ES",
+                "precision mediump float;",
+                "#endif",
+                "void main(){",
+                "    gl_FragColor = vec4(1.0);",
+                "}",
+                "");
+        Files.writeString(vertex.toPath(), vert);
+        Files.writeString(fragment.toPath(), frag);
+
+        ShaderProgram program = Mockito.mock(ShaderProgram.class);
+        Mockito.when(program.isCompiled()).thenReturn(true);
+
+        ShaderManager manager = new ShaderManager((v, f) -> program);
+        ShaderProgram loaded = manager.load(FileLocation.ABSOLUTE,
+                vertex.getAbsolutePath(), fragment.getAbsolutePath());
+        assertTrue(loaded.isCompiled());
+        loaded.dispose();
+        vertex.delete();
+        fragment.delete();
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/graphics/package-info.java
+++ b/tests/src/net/lapidist/colony/tests/graphics/package-info.java
@@ -1,0 +1,1 @@
+package net.lapidist.colony.tests.graphics;


### PR DESCRIPTION
## Summary
- add `GraphicsSettings` for advanced rendering options
- extend `Settings` to persist new graphics settings
- implement `ShaderManager` to load shader programs
- improve `GdxTestRunner` for shader tests
- add new unit tests for graphics settings and shader manager

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_6848b2a0b4f083289eff74dc34e39503