### PR TITLE
feat(client): enable anti-aliasing configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Each module keeps its source under `src/` with all packages rooted at `net.lapid
 ## Configuration
 Configuration defaults such as map size, autosave interval and network ports are defined in `core/src/main/resources/game.conf` and loaded at runtime. Per-user saves and settings are written to a platform specific directory under the user's home folder. `core/src/net/lapidist/colony/io/Paths.java` resolves the exact locations.
 
-All visible text is provided through resource bundles found in `core/src/main/resources/i18n`. The current locale can be changed in the in‑game settings screen and is persisted alongside the user's other settings.
+All visible text is provided through resource bundles found in `core/src/main/resources/i18n`. The current locale can be changed in the in‑game settings screen and is persisted alongside the user's other settings. Graphics options, such as anti‑aliasing, are stored under the `graphics` preference group in the same settings file.
 
 ## Networking Workflow
 Multiplayer features follow a strict request/response pattern:

--- a/client/src/net/lapidist/colony/client/ClientLauncher.java
+++ b/client/src/net/lapidist/colony/client/ClientLauncher.java
@@ -2,16 +2,30 @@ package net.lapidist.colony.client;
 
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Files;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Preferences;
 import com.badlogic.gdx.graphics.glutils.HdpiMode;
 import net.lapidist.colony.client.core.Constants;
+import net.lapidist.colony.settings.GraphicsSettings;
 
 
 public final class ClientLauncher {
+
+    private static final int COLOR_BITS = 8;
+    private static final int DEPTH_BITS = 16;
+    private static final int STENCIL_BITS = 8;
+    private static final int MSAA_SAMPLES = 4;
 
     private ClientLauncher() {
     }
 
     public static void main(final String[] args) {
+        Lwjgl3ApplicationConfiguration config = createConfiguration();
+
+        new Lwjgl3Application(new Colony(), config);
+    }
+
+    public static Lwjgl3ApplicationConfiguration createConfiguration() {
         Lwjgl3ApplicationConfiguration config =
                 new Lwjgl3ApplicationConfiguration();
 
@@ -20,6 +34,25 @@ public final class ClientLauncher {
         config.setIdleFPS(Constants.TARGET_FPS);
         config.setHdpiMode(HdpiMode.Logical);
 
-        new Lwjgl3Application(new Colony(), config);
+        com.badlogic.gdx.Preferences prefs;
+        if (com.badlogic.gdx.Gdx.app != null) {
+            prefs = com.badlogic.gdx.Gdx.app.getPreferences("settings");
+        } else {
+            prefs = new Lwjgl3Preferences("settings", Lwjgl3Files.externalPath + ".prefs/");
+        }
+        GraphicsSettings graphics = GraphicsSettings.load(prefs);
+        if (graphics.isAntialiasingEnabled()) {
+            config.setBackBufferConfig(
+                    COLOR_BITS,
+                    COLOR_BITS,
+                    COLOR_BITS,
+                    COLOR_BITS,
+                    DEPTH_BITS,
+                    STENCIL_BITS,
+                    MSAA_SAMPLES
+            );
+        }
+
+        return config;
     }
 }

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     implementation "net.onedaybeard.artemis:artemis-odb:$artemisVersion"
     implementation "com.badlogicgames.gdx:gdx:$gdxVersion"
     implementation "com.badlogicgames.gdx:gdx-backend-headless:$gdxVersion"
+    implementation "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion"
 
     runtimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
 

--- a/tests/src/net/lapidist/colony/tests/client/ClientLauncherTest.java
+++ b/tests/src/net/lapidist/colony/tests/client/ClientLauncherTest.java
@@ -1,0 +1,44 @@
+package net.lapidist.colony.tests.client;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Preferences;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
+import net.lapidist.colony.client.ClientLauncher;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(GdxTestRunner.class)
+public class ClientLauncherTest {
+
+    private static final int ENABLED_SAMPLES = 4;
+
+    @Test
+    public void configUsesAntiAliasingPreference() throws Exception {
+        Preferences prefs = Gdx.app.getPreferences("settings");
+        prefs.clear();
+        prefs.putBoolean("graphics.antialiasing", true);
+        prefs.flush();
+
+        Lwjgl3ApplicationConfiguration config = ClientLauncher.createConfiguration();
+        Field samples = Lwjgl3ApplicationConfiguration.class.getDeclaredField("samples");
+        samples.setAccessible(true);
+        assertEquals(ENABLED_SAMPLES, samples.getInt(config));
+    }
+
+    @Test
+    public void configDisablesAntiAliasingByDefault() throws Exception {
+        Preferences prefs = Gdx.app.getPreferences("settings");
+        prefs.clear();
+        prefs.flush();
+
+        Lwjgl3ApplicationConfiguration config = ClientLauncher.createConfiguration();
+        Field samples = Lwjgl3ApplicationConfiguration.class.getDeclaredField("samples");
+        samples.setAccessible(true);
+        assertEquals(0, samples.getInt(config));
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/client/package-info.java
+++ b/tests/src/net/lapidist/colony/tests/client/package-info.java
@@ -1,0 +1,2 @@
+/** Tests for the client launcher utilities. */
+package net.lapidist.colony.tests.client;


### PR DESCRIPTION
## Summary
- support loading graphics preferences during client startup
- enable multisample anti-aliasing when configured
- document graphics options in README
- add coverage for ClientLauncher configuration
- include LWJGL3 backend in test build

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_6848b70cc5b883288911cae76071a668