### PR TITLE
feat(graphics): add mip map and anisotropic options

### DIFF
--- a/client/src/net/lapidist/colony/client/core/io/ResourceLoader.java
+++ b/client/src/net/lapidist/colony/client/core/io/ResourceLoader.java
@@ -1,8 +1,11 @@
 package net.lapidist.colony.client.core.io;
 
 import com.badlogic.gdx.assets.AssetManager;
+import com.badlogic.gdx.graphics.GLTexture;
+import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import net.lapidist.colony.settings.GraphicsSettings;
 import com.badlogic.gdx.utils.Disposable;
 
 import java.io.IOException;
@@ -28,7 +31,11 @@ public final class ResourceLoader implements Disposable {
      * @param atlasPath path to the .atlas file
      * @throws IOException if the atlas cannot be found
      */
-    public void load(final FileLocation fileLocationToSet, final String atlasPath) throws IOException {
+    public void load(
+            final FileLocation fileLocationToSet,
+            final String atlasPath,
+            final GraphicsSettings graphicsSettings
+    ) throws IOException {
         fileLocation = fileLocationToSet;
 
         if (!fileLocation.getFile(atlasPath).exists()) {
@@ -41,7 +48,24 @@ public final class ResourceLoader implements Disposable {
 
         atlas = assetManager.get(atlasPath, TextureAtlas.class);
 
+        if (graphicsSettings != null) {
+            Texture.TextureFilter minFilter = graphicsSettings.isMipMapsEnabled()
+                    ? Texture.TextureFilter.MipMapLinearLinear
+                    : Texture.TextureFilter.Linear;
+            Texture.TextureFilter magFilter = Texture.TextureFilter.Linear;
+            for (Texture texture : atlas.getTextures()) {
+                texture.setFilter(minFilter, magFilter);
+                if (graphicsSettings.isAnisotropicFilteringEnabled()) {
+                    texture.setAnisotropicFilter(GLTexture.getMaxAnisotropicFilterLevel());
+                }
+            }
+        }
+
         loaded = true;
+    }
+
+    public void load(final FileLocation fileLocationToSet, final String atlasPath) throws IOException {
+        load(fileLocationToSet, atlasPath, null);
     }
 
     public boolean isLoaded() {
@@ -50,6 +74,10 @@ public final class ResourceLoader implements Disposable {
 
     public FileLocation getFileLocation() {
         return fileLocation;
+    }
+
+    public TextureAtlas getAtlas() {
+        return atlas;
     }
 
 

--- a/client/src/net/lapidist/colony/client/renderers/MapRendererFactory.java
+++ b/client/src/net/lapidist/colony/client/renderers/MapRendererFactory.java
@@ -6,6 +6,8 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import net.lapidist.colony.client.core.io.FileLocation;
 import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
+import net.lapidist.colony.settings.GraphicsSettings;
+import net.lapidist.colony.settings.Settings;
 import net.lapidist.colony.components.assets.TextureRegionReferenceComponent;
 import net.lapidist.colony.components.entities.BuildingComponent;
 import net.lapidist.colony.components.maps.TileComponent;
@@ -34,7 +36,8 @@ public final class MapRendererFactory {
     public MapRenderers create(final World world) {
         ResourceLoader loader = new ResourceLoader();
         try {
-            loader.load(fileLocation, atlasPath);
+            GraphicsSettings graphics = Settings.load().getGraphicsSettings();
+            loader.load(fileLocation, atlasPath, graphics);
         } catch (IOException e) {
             // ignore loading errors in headless tests
         }

--- a/client/src/net/lapidist/colony/client/screens/MapUiBuilder.java
+++ b/client/src/net/lapidist/colony/client/screens/MapUiBuilder.java
@@ -18,6 +18,7 @@ import net.lapidist.colony.client.ui.PlayerResourcesActor;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.i18n.I18n;
 import net.lapidist.colony.settings.KeyBindings;
+import net.lapidist.colony.settings.GraphicsSettings;
 import net.lapidist.colony.settings.KeyAction;
 
 /**
@@ -59,7 +60,8 @@ public final class MapUiBuilder {
         stage.addActor(chatTable);
 
         TextButton menuButton = new TextButton(I18n.get("map.menu"), skin);
-        MinimapActor minimapActor = new MinimapActor(world);
+        GraphicsSettings graphics = colony.getSettings().getGraphicsSettings();
+        MinimapActor minimapActor = new MinimapActor(world, graphics);
         ChatBox chatBox = new ChatBox(skin, client);
         PlayerResourcesActor resourcesActor = new PlayerResourcesActor(skin, world);
 

--- a/client/src/net/lapidist/colony/client/ui/MinimapActor.java
+++ b/client/src/net/lapidist/colony/client/ui/MinimapActor.java
@@ -12,6 +12,8 @@ import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.client.core.io.FileLocation;
 import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
+import net.lapidist.colony.settings.GraphicsSettings;
+import net.lapidist.colony.settings.Settings;
 import net.lapidist.colony.components.assets.TextureRegionReferenceComponent;
 import net.lapidist.colony.components.maps.MapComponent;
 import net.lapidist.colony.components.maps.TileComponent;
@@ -91,11 +93,17 @@ public final class MinimapActor extends Actor implements Disposable {
 
 
     public MinimapActor(final World worldToSet) {
+        this(worldToSet, Settings.load().getGraphicsSettings());
+    }
+
+    public MinimapActor(
+            final World worldToSet,
+            final GraphicsSettings graphicsSettings
+    ) {
         this.world = worldToSet;
-        // Overlay renderer will draw the viewport rectangle when GL is available
         setSize(DEFAULT_SIZE, DEFAULT_SIZE);
         try {
-            resourceLoader.load(FileLocation.INTERNAL, "textures/textures.atlas");
+            resourceLoader.load(FileLocation.INTERNAL, "textures/textures.atlas", graphicsSettings);
         } catch (IOException e) {
             // ignore loading errors in headless tests
         }

--- a/tests/src/net/lapidist/colony/tests/core/io/ResourceLoaderTest.java
+++ b/tests/src/net/lapidist/colony/tests/core/io/ResourceLoaderTest.java
@@ -3,12 +3,14 @@ package net.lapidist.colony.tests.core.io;
 import net.lapidist.colony.client.core.io.FileLocation;
 import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.tests.GdxTestRunner;
+import net.lapidist.colony.settings.GraphicsSettings;
+import com.badlogic.gdx.graphics.Texture;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 @RunWith(GdxTestRunner.class)
 public class ResourceLoaderTest {
@@ -17,10 +19,30 @@ public class ResourceLoaderTest {
     public final void testLoadsResources() throws IOException {
         ResourceLoader resourceLoader = new ResourceLoader();
 
+        GraphicsSettings gs = new GraphicsSettings();
+        gs.setMipMapsEnabled(true);
+        gs.setAnisotropicFilteringEnabled(true);
+
         resourceLoader.load(
                 FileLocation.INTERNAL,
-                "textures/textures.atlas"
+                "textures/textures.atlas",
+                gs
         );
         assertTrue(resourceLoader.isLoaded());
+    }
+
+    @Test
+    public void appliesTextureSettings() throws IOException {
+        GraphicsSettings gs = new GraphicsSettings();
+        gs.setMipMapsEnabled(true);
+        gs.setAnisotropicFilteringEnabled(true);
+        ResourceLoader resourceLoader = new ResourceLoader();
+
+        resourceLoader.load(FileLocation.INTERNAL, "textures/textures.atlas", gs);
+
+        for (Texture texture : resourceLoader.getAtlas().getTextures()) {
+            assertEquals(Texture.TextureFilter.MipMapLinearLinear, texture.getMinFilter());
+            assertTrue(texture.getAnisotropicFilter() >= 1f);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- allow ResourceLoader to apply mip-map and anisotropic filtering
- pass GraphicsSettings when loading textures
- expose atlas from ResourceLoader
- construct MinimapActor with graphics settings
- test the new texture filtering behaviour

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_68491da8b53883288cd07f643e6f1be6