### PR TITLE
feat: introduce resource loader interface

### DIFF
--- a/client/assets/models/cube.g3dj
+++ b/client/assets/models/cube.g3dj
@@ -1,0 +1,20 @@
+{
+  "version": [0, 1],
+  "id": "minimal",
+  "meshes": [
+    {
+      "id": "mesh",
+      "attributes": ["POSITION"],
+      "vertices": [0.0, 0.0, 0.0],
+      "parts": [
+        {"id": "part", "type": "TRIANGLES", "indices": [0]}
+      ]
+    }
+  ],
+  "materials": [
+    {"id": "mat"}
+  ],
+  "nodes": [
+    {"id": "node", "parts": [{"meshpartid": "part", "materialid": "mat"}]}
+  ]
+}

--- a/client/src/net/lapidist/colony/client/core/io/G3dResourceLoader.java
+++ b/client/src/net/lapidist/colony/client/core/io/G3dResourceLoader.java
@@ -1,0 +1,101 @@
+package net.lapidist.colony.client.core.io;
+
+import com.badlogic.gdx.assets.AssetManager;
+import com.badlogic.gdx.graphics.g2d.TextureAtlas;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.graphics.g3d.Model;
+import net.lapidist.colony.settings.GraphicsSettings;
+
+import java.io.IOException;
+
+/**
+ * Resource loader capable of handling both texture atlases and g3d models.
+ */
+public final class G3dResourceLoader implements ResourceLoader {
+
+    private boolean disposed;
+    private boolean loaded;
+
+    private FileLocation fileLocation;
+    private AssetManager assetManager;
+    private TextureAtlas atlas;
+
+    @Override
+    public void loadTextures(
+            final FileLocation fileLocationToSet,
+            final String atlasPath,
+            final GraphicsSettings graphicsSettings
+    ) throws IOException {
+        fileLocation = fileLocationToSet;
+
+        if (!fileLocation.getFile(atlasPath).exists()) {
+            throw new IOException(String.format("%s does not exist", atlasPath));
+        }
+
+        assetManager = new AssetManager(fileLocation.getResolver());
+        assetManager.load(atlasPath, TextureAtlas.class);
+        assetManager.finishLoading();
+
+        atlas = assetManager.get(atlasPath, TextureAtlas.class);
+
+        loaded = true;
+    }
+
+    @Override
+    public void loadTextures(final FileLocation fileLocationToSet, final String atlasPath) throws IOException {
+        loadTextures(fileLocationToSet, atlasPath, null);
+    }
+
+    @Override
+    public void loadModel(final FileLocation fileLocationToSet, final String modelPath) throws IOException {
+        fileLocation = fileLocationToSet;
+
+        if (!fileLocation.getFile(modelPath).exists()) {
+            throw new IOException(String.format("%s does not exist", modelPath));
+        }
+
+        if (assetManager == null) {
+            assetManager = new AssetManager(fileLocation.getResolver());
+        }
+        assetManager.load(modelPath, Model.class);
+        assetManager.finishLoading();
+
+        loaded = true;
+    }
+
+    @Override
+    public boolean isLoaded() {
+        return loaded;
+    }
+
+    @Override
+    public TextureAtlas getAtlas() {
+        return atlas;
+    }
+
+    @Override
+    public TextureRegion findRegion(final String name) {
+        if (atlas == null) {
+            return null;
+        }
+        return atlas.findRegion(name);
+    }
+
+    @Override
+    public Model findModel(final String name) {
+        if (assetManager == null || !assetManager.isLoaded(name)) {
+            return null;
+        }
+        return assetManager.get(name, Model.class);
+    }
+
+    @Override
+    public void dispose() {
+        if (!disposed) {
+            disposed = true;
+            if (assetManager != null) {
+                assetManager.dispose();
+            }
+        }
+    }
+}

--- a/client/src/net/lapidist/colony/client/core/io/ResourceLoader.java
+++ b/client/src/net/lapidist/colony/client/core/io/ResourceLoader.java
@@ -1,110 +1,77 @@
 package net.lapidist.colony.client.core.io;
 
-import com.badlogic.gdx.assets.AssetManager;
-import com.badlogic.gdx.graphics.GLTexture;
-import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
-import net.lapidist.colony.settings.GraphicsSettings;
+import com.badlogic.gdx.graphics.g3d.Model;
 import com.badlogic.gdx.utils.Disposable;
+import net.lapidist.colony.settings.GraphicsSettings;
 
 import java.io.IOException;
 
 /**
- * Simplified resource loader using LibGDX's {@link TextureAtlas} to
- * manage textures. This replaces the previous implementation which
- * parsed a custom configuration file.
+ * Abstraction for loading graphical assets used by renderers.
  */
-public final class ResourceLoader implements Disposable {
-
-    private boolean disposed;
-    private boolean loaded;
-
-    private FileLocation fileLocation;
-    private AssetManager assetManager;
-    private TextureAtlas atlas;
+public interface ResourceLoader extends Disposable {
 
     /**
-     * Load all texture regions from the specified atlas file.
+     * Load texture regions from the given atlas.
      *
-     * @param fileLocationToSet location resolver
-     * @param atlasPath path to the .atlas file
-     * @throws IOException if the atlas cannot be found
+     * @param fileLocation location resolver
+     * @param atlasPath    path to the texture atlas
+     * @param graphicsSettings optional texture settings
+     * @throws IOException if the atlas cannot be loaded
      */
-    public void load(
-            final FileLocation fileLocationToSet,
-            final String atlasPath,
-            final GraphicsSettings graphicsSettings
-    ) throws IOException {
-        fileLocation = fileLocationToSet;
-
-        if (!fileLocation.getFile(atlasPath).exists()) {
-            throw new IOException(String.format("%s does not exist", atlasPath));
-        }
-
-        assetManager = new AssetManager(fileLocation.getResolver());
-        assetManager.load(atlasPath, TextureAtlas.class);
-        assetManager.finishLoading();
-
-        atlas = assetManager.get(atlasPath, TextureAtlas.class);
-
-        if (graphicsSettings != null) {
-            Texture.TextureFilter minFilter = graphicsSettings.isMipMapsEnabled()
-                    ? Texture.TextureFilter.MipMapLinearLinear
-                    : Texture.TextureFilter.Linear;
-            Texture.TextureFilter magFilter = Texture.TextureFilter.Linear;
-            for (Texture texture : atlas.getTextures()) {
-                texture.setFilter(minFilter, magFilter);
-                if (graphicsSettings.isAnisotropicFilteringEnabled()) {
-                    texture.setAnisotropicFilter(GLTexture.getMaxAnisotropicFilterLevel());
-                }
-            }
-        }
-
-        loaded = true;
-    }
-
-    public void load(final FileLocation fileLocationToSet, final String atlasPath) throws IOException {
-        load(fileLocationToSet, atlasPath, null);
-    }
-
-    public boolean isLoaded() {
-        return loaded;
-    }
-
-    public FileLocation getFileLocation() {
-        return fileLocation;
-    }
-
-    public TextureAtlas getAtlas() {
-        return atlas;
-    }
-
+    void loadTextures(
+            FileLocation fileLocation,
+            String atlasPath,
+            GraphicsSettings graphicsSettings
+    ) throws IOException;
 
     /**
-     * Find a texture region within the loaded atlas by name.
+     * Convenience overload without graphics settings.
      *
-     * @param name region name
-     * @return the {@link TextureRegion} or {@code null} if not found
+     * @param fileLocation location resolver
+     * @param atlasPath    path to the texture atlas
+     * @throws IOException if the atlas cannot be loaded
      */
-    public TextureRegion findRegion(final String name) {
-        if (atlas == null) {
-            return null;
-        }
-        return atlas.findRegion(name);
-    }
+    void loadTextures(FileLocation fileLocation, String atlasPath) throws IOException;
 
-    @Override
-    public void dispose() {
-        if (!disposed) {
-            disposed = true;
-            if (assetManager != null) {
-                assetManager.dispose();
-            }
-        }
-    }
+    /**
+     * Load a 3D model from the specified path.
+     *
+     * @param fileLocation location resolver
+     * @param modelPath    path to the model file
+     * @throws IOException if the model cannot be loaded
+     */
+    void loadModel(FileLocation fileLocation, String modelPath) throws IOException;
 
-    public boolean isDisposed() {
-        return disposed;
-    }
+    /**
+     * Check whether assets have been loaded.
+     *
+     * @return {@code true} if the loader has loaded resources
+     */
+    boolean isLoaded();
+
+    /**
+     * Access the atlas used for texture lookups.
+     *
+     * @return loaded texture atlas or {@code null}
+     */
+    TextureAtlas getAtlas();
+
+    /**
+     * Find a texture region by name.
+     *
+     * @param name region identifier
+     * @return matching region or {@code null}
+     */
+    TextureRegion findRegion(String name);
+
+    /**
+     * Retrieve a loaded 3D model by name.
+     *
+     * @param name model identifier
+     * @return matching model or {@code null}
+     */
+    Model findModel(String name);
 }

--- a/client/src/net/lapidist/colony/client/core/io/TextureAtlasResourceLoader.java
+++ b/client/src/net/lapidist/colony/client/core/io/TextureAtlasResourceLoader.java
@@ -1,0 +1,120 @@
+package net.lapidist.colony.client.core.io;
+
+import com.badlogic.gdx.assets.AssetManager;
+import com.badlogic.gdx.graphics.GLTexture;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.TextureAtlas;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.graphics.g3d.Model;
+import net.lapidist.colony.settings.GraphicsSettings;
+
+import java.io.IOException;
+
+/**
+ * {@link ResourceLoader} implementation that loads textures from a
+ * {@link TextureAtlas}. Model loading is not supported and will throw an
+ * {@link UnsupportedOperationException}.
+ */
+public final class TextureAtlasResourceLoader implements ResourceLoader {
+
+    private boolean disposed;
+    private boolean loaded;
+
+    private FileLocation fileLocation;
+    private AssetManager assetManager;
+    private TextureAtlas atlas;
+
+    /**
+     * Load all texture regions from the specified atlas file.
+     *
+     * @param fileLocationToSet location resolver
+     * @param atlasPath path to the .atlas file
+     * @throws IOException if the atlas cannot be found
+     */
+    public void loadTextures(
+            final FileLocation fileLocationToSet,
+            final String atlasPath,
+            final GraphicsSettings graphicsSettings
+    ) throws IOException {
+        fileLocation = fileLocationToSet;
+
+        if (!fileLocation.getFile(atlasPath).exists()) {
+            throw new IOException(String.format("%s does not exist", atlasPath));
+        }
+
+        assetManager = new AssetManager(fileLocation.getResolver());
+        assetManager.load(atlasPath, TextureAtlas.class);
+        assetManager.finishLoading();
+
+        atlas = assetManager.get(atlasPath, TextureAtlas.class);
+
+        if (graphicsSettings != null) {
+            Texture.TextureFilter minFilter = graphicsSettings.isMipMapsEnabled()
+                    ? Texture.TextureFilter.MipMapLinearLinear
+                    : Texture.TextureFilter.Linear;
+            Texture.TextureFilter magFilter = Texture.TextureFilter.Linear;
+            for (Texture texture : atlas.getTextures()) {
+                texture.setFilter(minFilter, magFilter);
+                if (graphicsSettings.isAnisotropicFilteringEnabled()) {
+                    texture.setAnisotropicFilter(GLTexture.getMaxAnisotropicFilterLevel());
+                }
+            }
+        }
+
+        loaded = true;
+    }
+
+    public void loadTextures(final FileLocation fileLocationToSet, final String atlasPath) throws IOException {
+        loadTextures(fileLocationToSet, atlasPath, null);
+    }
+
+    public boolean isLoaded() {
+        return loaded;
+    }
+
+    public FileLocation getFileLocation() {
+        return fileLocation;
+    }
+
+    public TextureAtlas getAtlas() {
+        return atlas;
+    }
+
+
+    /**
+     * Find a texture region within the loaded atlas by name.
+     *
+     * @param name region name
+     * @return the {@link TextureRegion} or {@code null} if not found
+     */
+    public TextureRegion findRegion(final String name) {
+        if (atlas == null) {
+            return null;
+        }
+        return atlas.findRegion(name);
+    }
+
+    @Override
+    public void loadModel(final FileLocation fileLocationToSet, final String modelPath) throws IOException {
+        throw new UnsupportedOperationException("Model loading not supported");
+    }
+
+    @Override
+    public Model findModel(final String name) {
+        return null;
+    }
+
+    @Override
+    public void dispose() {
+        if (!disposed) {
+            disposed = true;
+            if (assetManager != null) {
+                assetManager.dispose();
+            }
+        }
+    }
+
+    public boolean isDisposed() {
+        return disposed;
+    }
+}

--- a/client/src/net/lapidist/colony/client/renderers/MapRendererFactory.java
+++ b/client/src/net/lapidist/colony/client/renderers/MapRendererFactory.java
@@ -5,6 +5,7 @@ import com.artemis.World;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import net.lapidist.colony.client.core.io.FileLocation;
 import net.lapidist.colony.client.core.io.ResourceLoader;
+import net.lapidist.colony.client.core.io.TextureAtlasResourceLoader;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
 import net.lapidist.colony.settings.GraphicsSettings;
 import net.lapidist.colony.settings.Settings;
@@ -23,21 +24,26 @@ public final class MapRendererFactory {
 
     private final FileLocation fileLocation;
     private final String atlasPath;
+    private final ResourceLoader resourceLoader;
 
     public MapRendererFactory() {
-        this(FileLocation.INTERNAL, "textures/textures.atlas");
+        this(new TextureAtlasResourceLoader(), FileLocation.INTERNAL, "textures/textures.atlas");
+    }
+
+    public MapRendererFactory(final ResourceLoader loader, final FileLocation location, final String path) {
+        this.fileLocation = location;
+        this.atlasPath = path;
+        this.resourceLoader = loader;
     }
 
     public MapRendererFactory(final FileLocation location, final String path) {
-        this.fileLocation = location;
-        this.atlasPath = path;
+        this(new TextureAtlasResourceLoader(), location, path);
     }
 
     public MapRenderer create(final World world) {
-        ResourceLoader loader = new ResourceLoader();
         try {
             GraphicsSettings graphics = Settings.load().getGraphicsSettings();
-            loader.load(fileLocation, atlasPath, graphics);
+            resourceLoader.loadTextures(fileLocation, atlasPath, graphics);
         } catch (IOException e) {
             // ignore loading errors in headless tests
         }
@@ -52,14 +58,14 @@ public final class MapRendererFactory {
 
         TileRenderer tileRenderer = new TileRenderer(
                 batch,
-                loader,
+                resourceLoader,
                 cameraSystem,
                 tileMapper,
                 textureMapper
         );
         BuildingRenderer buildingRenderer = new BuildingRenderer(
                 batch,
-                loader,
+                resourceLoader,
                 cameraSystem,
                 buildingMapper,
                 textureMapper
@@ -76,7 +82,7 @@ public final class MapRendererFactory {
 
         return new SpriteBatchMapRenderer(
                 batch,
-                loader,
+                resourceLoader,
                 tileRenderer,
                 buildingRenderer,
                 resourceRenderer

--- a/client/src/net/lapidist/colony/client/ui/MinimapActor.java
+++ b/client/src/net/lapidist/colony/client/ui/MinimapActor.java
@@ -11,6 +11,7 @@ import com.badlogic.gdx.utils.Disposable;
 import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.client.core.io.FileLocation;
 import net.lapidist.colony.client.core.io.ResourceLoader;
+import net.lapidist.colony.client.core.io.TextureAtlasResourceLoader;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
 import net.lapidist.colony.settings.GraphicsSettings;
 import net.lapidist.colony.settings.Settings;
@@ -30,7 +31,7 @@ public final class MinimapActor extends Actor implements Disposable {
     private static final int DEFAULT_SIZE = 128;
 
     private final World world;
-    private final ResourceLoader resourceLoader = new ResourceLoader();
+    private final ResourceLoader resourceLoader = new TextureAtlasResourceLoader();
     private ViewportOverlayRenderer overlayRenderer;
     private ComponentMapper<MapComponent> mapMapper;
     private ComponentMapper<TileComponent> tileMapper;
@@ -103,7 +104,7 @@ public final class MinimapActor extends Actor implements Disposable {
         this.world = worldToSet;
         setSize(DEFAULT_SIZE, DEFAULT_SIZE);
         try {
-            resourceLoader.load(FileLocation.INTERNAL, "textures/textures.atlas", graphicsSettings);
+            resourceLoader.loadTextures(FileLocation.INTERNAL, "textures/textures.atlas", graphicsSettings);
         } catch (IOException e) {
             // ignore loading errors in headless tests
         }

--- a/tests/src/net/lapidist/colony/tests/client/renderers/MapRendererFactoryTest.java
+++ b/tests/src/net/lapidist/colony/tests/client/renderers/MapRendererFactoryTest.java
@@ -1,0 +1,88 @@
+package net.lapidist.colony.tests.client.renderers;
+
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import net.lapidist.colony.client.renderers.MapRenderer;
+import net.lapidist.colony.client.renderers.MapRendererFactory;
+import net.lapidist.colony.client.systems.PlayerCameraSystem;
+import net.lapidist.colony.client.core.io.FileLocation;
+import net.lapidist.colony.client.core.io.ResourceLoader;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedConstruction;
+import static org.mockito.Mockito.mockConstruction;
+
+import static org.junit.Assert.*;
+
+@RunWith(GdxTestRunner.class)
+public class MapRendererFactoryTest {
+
+    private static final class DummyLoader implements ResourceLoader {
+        private boolean loaded;
+
+        @Override
+        public void loadTextures(
+                final FileLocation location,
+                final String path,
+                final net.lapidist.colony.settings.GraphicsSettings settings
+        ) {
+            loaded = true;
+        }
+
+        @Override
+        public void loadTextures(final FileLocation location, final String path) {
+            loaded = true;
+        }
+
+        @Override
+        public void loadModel(final FileLocation location, final String path) {
+        }
+
+        @Override
+        public boolean isLoaded() {
+            return loaded;
+        }
+
+        @Override
+        public com.badlogic.gdx.graphics.g2d.TextureAtlas getAtlas() {
+            return null;
+        }
+
+        @Override
+        public com.badlogic.gdx.graphics.g2d.TextureRegion findRegion(final String name) {
+            return null;
+        }
+
+        @Override
+        public com.badlogic.gdx.graphics.g3d.Model findModel(final String name) {
+            return null;
+        }
+
+        @Override
+        public void dispose() {
+        }
+    }
+
+    @Test
+    public void createLoadsResources() {
+        DummyLoader loader = new DummyLoader();
+        World world = new World(new WorldConfigurationBuilder()
+                .with(new PlayerCameraSystem())
+                .build());
+        try (MockedConstruction<SpriteBatch> ignored =
+                mockConstruction(SpriteBatch.class)) {
+            MapRendererFactory factory = new MapRendererFactory(
+                    loader,
+                    FileLocation.INTERNAL,
+                    "textures/textures.atlas"
+            );
+            MapRenderer renderer = factory.create(world);
+
+            assertNotNull(renderer);
+            assertTrue(loader.loaded);
+        }
+        world.dispose();
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/client/renderers/package-info.java
+++ b/tests/src/net/lapidist/colony/tests/client/renderers/package-info.java
@@ -1,0 +1,2 @@
+/** Tests for map renderer factory and related classes. */
+package net.lapidist.colony.tests.client.renderers;

--- a/tests/src/net/lapidist/colony/tests/core/io/G3dResourceLoaderTest.java
+++ b/tests/src/net/lapidist/colony/tests/core/io/G3dResourceLoaderTest.java
@@ -1,0 +1,33 @@
+package net.lapidist.colony.tests.core.io;
+
+import net.lapidist.colony.client.core.io.FileLocation;
+import net.lapidist.colony.client.core.io.G3dResourceLoader;
+import net.lapidist.colony.client.core.io.ResourceLoader;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+
+@RunWith(GdxTestRunner.class)
+public class G3dResourceLoaderTest {
+
+    @Test
+    public void loadsModelAndTextures() throws IOException {
+        ResourceLoader loader = new G3dResourceLoader();
+        loader.loadTextures(FileLocation.INTERNAL, "textures/textures.atlas");
+        loader.loadModel(FileLocation.INTERNAL, "models/cube.g3dj");
+
+        assertTrue(loader.isLoaded());
+        assertNotNull(loader.getAtlas());
+        assertNotNull(loader.findModel("models/cube.g3dj"));
+    }
+
+    @Test(expected = IOException.class)
+    public void loadModelThrowsForMissingFile() throws IOException {
+        ResourceLoader loader = new G3dResourceLoader();
+        loader.loadModel(FileLocation.INTERNAL, "models/missing.g3dj");
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/core/io/ResourceLoaderTest.java
+++ b/tests/src/net/lapidist/colony/tests/core/io/ResourceLoaderTest.java
@@ -2,6 +2,7 @@ package net.lapidist.colony.tests.core.io;
 
 import net.lapidist.colony.client.core.io.FileLocation;
 import net.lapidist.colony.client.core.io.ResourceLoader;
+import net.lapidist.colony.client.core.io.TextureAtlasResourceLoader;
 import net.lapidist.colony.tests.GdxTestRunner;
 import net.lapidist.colony.settings.GraphicsSettings;
 import com.badlogic.gdx.graphics.Texture;
@@ -17,13 +18,13 @@ public class ResourceLoaderTest {
 
     @Test
     public final void testLoadsResources() throws IOException {
-        ResourceLoader resourceLoader = new ResourceLoader();
+        ResourceLoader resourceLoader = new TextureAtlasResourceLoader();
 
         GraphicsSettings gs = new GraphicsSettings();
         gs.setMipMapsEnabled(true);
         gs.setAnisotropicFilteringEnabled(true);
 
-        resourceLoader.load(
+        resourceLoader.loadTextures(
                 FileLocation.INTERNAL,
                 "textures/textures.atlas",
                 gs
@@ -36,9 +37,9 @@ public class ResourceLoaderTest {
         GraphicsSettings gs = new GraphicsSettings();
         gs.setMipMapsEnabled(true);
         gs.setAnisotropicFilteringEnabled(true);
-        ResourceLoader resourceLoader = new ResourceLoader();
+        ResourceLoader resourceLoader = new TextureAtlasResourceLoader();
 
-        resourceLoader.load(FileLocation.INTERNAL, "textures/textures.atlas", gs);
+        resourceLoader.loadTextures(FileLocation.INTERNAL, "textures/textures.atlas", gs);
 
         for (Texture texture : resourceLoader.getAtlas().getTextures()) {
             assertEquals(Texture.TextureFilter.MipMapLinearLinear, texture.getMinFilter());


### PR DESCRIPTION
## Summary
- generalize `ResourceLoader` as an interface
- keep current texture loader as `TextureAtlasResourceLoader`
- allow passing a loader to `MapRendererFactory`
- add 3D `G3dResourceLoader`
- adjust usage and tests

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_68493efa69a0832883a4e1629348c897