### PR TITLE
feat: decouple map rendering pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ The repository is split into four Gradle modules:
 - **server** – headless game server. It exposes networking services using Kryonet and runs the same ECS logic as the client to keep game state in sync.
 - **tests** – JUnit tests and a custom `GdxTestRunner` that boots a headless LibGDX environment so game systems can be tested without a graphical context.
 
+### Map Renderer Abstraction
+`MapWorldBuilder` uses a `MapRendererFactory` to create the renderer at build time. The default factory produces a sprite based renderer but alternative implementations can be supplied, including the experimental 3‑D renderer.
+
 Each module keeps its source under `src/` with all packages rooted at `net.lapidist.colony`. Shared constants and configuration files live in the `core` module and are imported by both the client and server.
 
 ## Configuration

--- a/client/src/net/lapidist/colony/client/renderers/MapRendererFactory.java
+++ b/client/src/net/lapidist/colony/client/renderers/MapRendererFactory.java
@@ -1,92 +1,16 @@
 package net.lapidist.colony.client.renderers;
 
-import com.artemis.ComponentMapper;
 import com.artemis.World;
-import com.badlogic.gdx.graphics.g2d.SpriteBatch;
-import net.lapidist.colony.client.core.io.FileLocation;
-import net.lapidist.colony.client.core.io.ResourceLoader;
-import net.lapidist.colony.client.core.io.TextureAtlasResourceLoader;
-import net.lapidist.colony.client.systems.CameraProvider;
-import net.lapidist.colony.client.systems.PlayerCameraSystem;
-import net.lapidist.colony.settings.GraphicsSettings;
-import net.lapidist.colony.settings.Settings;
-import net.lapidist.colony.components.assets.TextureRegionReferenceComponent;
-import net.lapidist.colony.components.entities.BuildingComponent;
-import net.lapidist.colony.components.maps.TileComponent;
-import net.lapidist.colony.components.maps.MapComponent;
-import net.lapidist.colony.components.resources.ResourceComponent;
-
-import java.io.IOException;
 
 /**
- * Factory that loads textures and creates renderers for the map system.
+ * Factory interface for creating {@link MapRenderer} instances.
  */
-public final class MapRendererFactory {
-
-    private final FileLocation fileLocation;
-    private final String atlasPath;
-    private final ResourceLoader resourceLoader;
-
-    public MapRendererFactory() {
-        this(new TextureAtlasResourceLoader(), FileLocation.INTERNAL, "textures/textures.atlas");
-    }
-
-    public MapRendererFactory(final ResourceLoader loader, final FileLocation location, final String path) {
-        this.fileLocation = location;
-        this.atlasPath = path;
-        this.resourceLoader = loader;
-    }
-
-    public MapRendererFactory(final FileLocation location, final String path) {
-        this(new TextureAtlasResourceLoader(), location, path);
-    }
-
-    public MapRenderer create(final World world) {
-        try {
-            GraphicsSettings graphics = Settings.load().getGraphicsSettings();
-            resourceLoader.loadTextures(fileLocation, atlasPath, graphics);
-        } catch (IOException e) {
-            // ignore loading errors in headless tests
-        }
-        SpriteBatch batch = new SpriteBatch();
-
-        CameraProvider cameraSystem = world.getSystem(PlayerCameraSystem.class);
-        ComponentMapper<TileComponent> tileMapper = world.getMapper(TileComponent.class);
-        ComponentMapper<BuildingComponent> buildingMapper = world.getMapper(BuildingComponent.class);
-        ComponentMapper<TextureRegionReferenceComponent> textureMapper =
-                world.getMapper(TextureRegionReferenceComponent.class);
-        ComponentMapper<ResourceComponent> resourceMapper = world.getMapper(ResourceComponent.class);
-
-        TileRenderer tileRenderer = new TileRenderer(
-                batch,
-                resourceLoader,
-                cameraSystem,
-                tileMapper,
-                textureMapper
-        );
-        BuildingRenderer buildingRenderer = new BuildingRenderer(
-                batch,
-                resourceLoader,
-                cameraSystem,
-                buildingMapper,
-                textureMapper
-        );
-        ResourceRenderer resourceRenderer = new ResourceRenderer(
-                batch,
-                cameraSystem,
-                tileMapper,
-                resourceMapper
-        );
-
-        // trigger map mapper initialization so MapRenderSystem can use it immediately
-        world.getMapper(MapComponent.class);
-
-        return new SpriteBatchMapRenderer(
-                batch,
-                resourceLoader,
-                tileRenderer,
-                buildingRenderer,
-                resourceRenderer
-        );
-    }
+public interface MapRendererFactory {
+    /**
+     * Create a renderer for the given world.
+     *
+     * @param world game world context
+     * @return configured map renderer
+     */
+    MapRenderer create(World world);
 }

--- a/client/src/net/lapidist/colony/client/renderers/ModelBatchMapRenderer.java
+++ b/client/src/net/lapidist/colony/client/renderers/ModelBatchMapRenderer.java
@@ -1,0 +1,35 @@
+package net.lapidist.colony.client.renderers;
+
+import com.badlogic.gdx.graphics.g3d.ModelBatch;
+import com.badlogic.gdx.graphics.g3d.ModelInstance;
+import com.badlogic.gdx.utils.Disposable;
+import net.lapidist.colony.client.systems.CameraProvider;
+import net.lapidist.colony.components.maps.MapComponent;
+
+/**
+ * Very basic 3-D implementation of {@link MapRenderer} for experiments.
+ */
+public final class ModelBatchMapRenderer implements MapRenderer, Disposable {
+
+    private final ModelBatch modelBatch;
+    private final ModelInstance tileModel;
+
+    public ModelBatchMapRenderer(final ModelBatch batch, final ModelInstance tileModelToSet) {
+        this.modelBatch = batch;
+        this.tileModel = tileModelToSet;
+    }
+
+    @Override
+    public void render(final MapComponent map, final CameraProvider camera) {
+        modelBatch.begin(camera.getCamera());
+        for (int i = 0; i < map.getTiles().size; i++) {
+            modelBatch.render(tileModel);
+        }
+        modelBatch.end();
+    }
+
+    @Override
+    public void dispose() {
+        modelBatch.dispose();
+    }
+}

--- a/client/src/net/lapidist/colony/client/renderers/ModelBatchMapRendererFactory.java
+++ b/client/src/net/lapidist/colony/client/renderers/ModelBatchMapRendererFactory.java
@@ -1,0 +1,46 @@
+package net.lapidist.colony.client.renderers;
+
+import com.artemis.World;
+import com.badlogic.gdx.graphics.g3d.Model;
+import com.badlogic.gdx.graphics.g3d.ModelBatch;
+import com.badlogic.gdx.graphics.g3d.ModelInstance;
+import net.lapidist.colony.client.core.io.FileLocation;
+import net.lapidist.colony.client.core.io.G3dResourceLoader;
+import net.lapidist.colony.client.core.io.ResourceLoader;
+
+/**
+ * Factory creating a simple {@link ModelBatchMapRenderer} using {@link G3dResourceLoader}.
+ */
+public final class ModelBatchMapRendererFactory implements MapRendererFactory {
+
+    private final FileLocation location;
+    private final String modelPath;
+    private final ResourceLoader loader;
+
+    public ModelBatchMapRendererFactory() {
+        this(new G3dResourceLoader(), FileLocation.INTERNAL, "models/cube.g3dj");
+    }
+
+    public ModelBatchMapRendererFactory(
+            final ResourceLoader loaderToSet,
+            final FileLocation locationToSet,
+            final String path
+    ) {
+        this.location = locationToSet;
+        this.modelPath = path;
+        this.loader = loaderToSet;
+    }
+
+    @Override
+    public MapRenderer create(final World world) {
+        try {
+            loader.loadTextures(location, "textures/textures.atlas");
+            loader.loadModel(location, modelPath);
+        } catch (Exception e) {
+            // ignore errors in headless tests
+        }
+        Model model = loader.findModel(modelPath);
+        ModelInstance instance = model != null ? new ModelInstance(model) : null;
+        return new ModelBatchMapRenderer(new ModelBatch(), instance);
+    }
+}

--- a/client/src/net/lapidist/colony/client/renderers/SpriteMapRendererFactory.java
+++ b/client/src/net/lapidist/colony/client/renderers/SpriteMapRendererFactory.java
@@ -1,0 +1,93 @@
+package net.lapidist.colony.client.renderers;
+
+import com.artemis.ComponentMapper;
+import com.artemis.World;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import net.lapidist.colony.client.core.io.FileLocation;
+import net.lapidist.colony.client.core.io.ResourceLoader;
+import net.lapidist.colony.client.core.io.TextureAtlasResourceLoader;
+import net.lapidist.colony.client.systems.CameraProvider;
+import net.lapidist.colony.client.systems.PlayerCameraSystem;
+import net.lapidist.colony.settings.GraphicsSettings;
+import net.lapidist.colony.settings.Settings;
+import net.lapidist.colony.components.assets.TextureRegionReferenceComponent;
+import net.lapidist.colony.components.entities.BuildingComponent;
+import net.lapidist.colony.components.maps.TileComponent;
+import net.lapidist.colony.components.maps.MapComponent;
+import net.lapidist.colony.components.resources.ResourceComponent;
+
+import java.io.IOException;
+
+/**
+ * Factory that loads textures and creates sprite batch based renderers for the map system.
+ */
+public final class SpriteMapRendererFactory implements MapRendererFactory {
+
+    private final FileLocation fileLocation;
+    private final String atlasPath;
+    private final ResourceLoader resourceLoader;
+
+    public SpriteMapRendererFactory() {
+        this(new TextureAtlasResourceLoader(), FileLocation.INTERNAL, "textures/textures.atlas");
+    }
+
+    public SpriteMapRendererFactory(final ResourceLoader loader, final FileLocation location, final String path) {
+        this.fileLocation = location;
+        this.atlasPath = path;
+        this.resourceLoader = loader;
+    }
+
+    public SpriteMapRendererFactory(final FileLocation location, final String path) {
+        this(new TextureAtlasResourceLoader(), location, path);
+    }
+
+    @Override
+    public MapRenderer create(final World world) {
+        try {
+            GraphicsSettings graphics = Settings.load().getGraphicsSettings();
+            resourceLoader.loadTextures(fileLocation, atlasPath, graphics);
+        } catch (IOException e) {
+            // ignore loading errors in headless tests
+        }
+        SpriteBatch batch = new SpriteBatch();
+
+        CameraProvider cameraSystem = world.getSystem(PlayerCameraSystem.class);
+        ComponentMapper<TileComponent> tileMapper = world.getMapper(TileComponent.class);
+        ComponentMapper<BuildingComponent> buildingMapper = world.getMapper(BuildingComponent.class);
+        ComponentMapper<TextureRegionReferenceComponent> textureMapper =
+                world.getMapper(TextureRegionReferenceComponent.class);
+        ComponentMapper<ResourceComponent> resourceMapper = world.getMapper(ResourceComponent.class);
+
+        TileRenderer tileRenderer = new TileRenderer(
+                batch,
+                resourceLoader,
+                cameraSystem,
+                tileMapper,
+                textureMapper
+        );
+        BuildingRenderer buildingRenderer = new BuildingRenderer(
+                batch,
+                resourceLoader,
+                cameraSystem,
+                buildingMapper,
+                textureMapper
+        );
+        ResourceRenderer resourceRenderer = new ResourceRenderer(
+                batch,
+                cameraSystem,
+                tileMapper,
+                resourceMapper
+        );
+
+        // trigger map mapper initialization so MapRenderSystem can use it immediately
+        world.getMapper(MapComponent.class);
+
+        return new SpriteBatchMapRenderer(
+                batch,
+                resourceLoader,
+                tileRenderer,
+                buildingRenderer,
+                resourceRenderer
+        );
+    }
+}

--- a/client/src/net/lapidist/colony/client/renderers/TileRenderer.java
+++ b/client/src/net/lapidist/colony/client/renderers/TileRenderer.java
@@ -51,11 +51,12 @@ public final class TileRenderer implements EntityRenderer {
                 continue;
             }
 
-            TextureRegion region = resourceLoader.findRegion(
-                    textureMapper.get(entity).getResourceRef()
-            );
-            if (region != null) {
-                spriteBatch.draw(region, worldCoords.x, worldCoords.y);
+            TextureRegionReferenceComponent tex = textureMapper.get(entity);
+            if (tex != null) {
+                TextureRegion region = resourceLoader.findRegion(tex.getResourceRef());
+                if (region != null) {
+                    spriteBatch.draw(region, worldCoords.x, worldCoords.y);
+                }
             }
 
             if (tile.isSelected()) {

--- a/client/src/net/lapidist/colony/client/screens/MapScreen.java
+++ b/client/src/net/lapidist/colony/client/screens/MapScreen.java
@@ -25,7 +25,8 @@ public final class MapScreen implements Screen {
         this.colony = colonyToSet;
         stage = new Stage(new ScreenViewport());
         world = MapWorldBuilder.build(
-                MapWorldBuilder.builder(state, client, stage, colony.getSettings().getKeyBindings())
+                MapWorldBuilder.builder(state, client, stage, colony.getSettings().getKeyBindings()),
+                null
         );
         MapUi ui = MapUiBuilder.build(stage, world, client, colony);
         minimapActor = ui.getMinimapActor();

--- a/client/src/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -7,6 +7,7 @@ import com.badlogic.gdx.scenes.scene2d.Stage;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.client.renderers.MapRendererFactory;
 import net.lapidist.colony.client.renderers.MapRenderer;
+import net.lapidist.colony.client.renderers.SpriteMapRendererFactory;
 import net.lapidist.colony.client.systems.ClearScreenSystem;
 import net.lapidist.colony.client.systems.CameraInputSystem;
 import net.lapidist.colony.client.systems.SelectionSystem;
@@ -18,6 +19,7 @@ import net.lapidist.colony.client.systems.network.TileUpdateSystem;
 import net.lapidist.colony.client.systems.network.BuildingUpdateSystem;
 import net.lapidist.colony.client.systems.network.ResourceUpdateSystem;
 import net.lapidist.colony.client.systems.MapInitSystem;
+import net.lapidist.colony.client.systems.MapRenderInitSystem;
 import net.lapidist.colony.client.systems.PlayerInitSystem;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.ResourceData;
@@ -38,7 +40,8 @@ public final class MapWorldBuilder {
     /**
      * Create a base {@link WorldConfigurationBuilder} containing the default
      * systems for the map screen except the map initialization system. Tests can
-     * customise the returned builder before calling {@link #build(WorldConfigurationBuilder)}.
+     * customise the returned builder before calling
+     * {@link #build(WorldConfigurationBuilder, MapRendererFactory)}.
      *
      * @param client game client for network updates
      * @param stage  stage used by the UI system
@@ -127,6 +130,7 @@ public final class MapWorldBuilder {
         if (provider != null) {
             builder.with(
                     new MapInitSystem(provider),
+                    new MapRenderInitSystem(),
                     new PlayerCameraSystem()
             );
         }
@@ -138,13 +142,15 @@ public final class MapWorldBuilder {
      * Build a world using the supplied configuration.
      *
      * @param builder preconfigured world builder with all desired systems
+     * @param factory optional factory for creating the map renderer
      * @return configured world instance
      */
-    public static World build(final WorldConfigurationBuilder builder) {
+    public static World build(final WorldConfigurationBuilder builder, final MapRendererFactory factory) {
         World world = new World(builder.build());
         MapRenderSystem renderSystem = world.getSystem(MapRenderSystem.class);
         if (renderSystem != null) {
-            MapRenderer renderer = new MapRendererFactory().create(world);
+            MapRendererFactory actualFactory = factory != null ? factory : new SpriteMapRendererFactory();
+            MapRenderer renderer = actualFactory.create(world);
             renderSystem.setMapRenderer(renderer);
         }
         Events.init(world.getSystem(EventSystem.class));

--- a/client/src/net/lapidist/colony/client/systems/MapInitSystem.java
+++ b/client/src/net/lapidist/colony/client/systems/MapInitSystem.java
@@ -2,10 +2,7 @@ package net.lapidist.colony.client.systems;
 
 import com.artemis.BaseSystem;
 import net.lapidist.colony.client.entities.factories.MapFactory;
-import net.lapidist.colony.client.entities.factories.RenderComponentFactory;
-import net.lapidist.colony.client.renderers.DefaultAssetResolver;
 import net.lapidist.colony.map.MapStateProvider;
-import net.lapidist.colony.components.maps.MapComponent;
 
 /**
  * Initializes the game world using a {@link MapStateProvider}.
@@ -19,15 +16,7 @@ public class MapInitSystem extends BaseSystem {
 
     @Override
     public final void initialize() {
-        var mapEntity = MapFactory.create(world, provider.provide());
-        var map = mapEntity.getComponent(MapComponent.class);
-        var resolver = new DefaultAssetResolver();
-        for (int i = 0; i < map.getTiles().size; i++) {
-            RenderComponentFactory.addTileRendering(world, map.getTiles().get(i), resolver);
-        }
-        for (int i = 0; i < map.getEntities().size; i++) {
-            RenderComponentFactory.addBuildingRendering(world, map.getEntities().get(i), resolver);
-        }
+        MapFactory.create(world, provider.provide());
     }
 
     @Override

--- a/client/src/net/lapidist/colony/client/systems/MapRenderInitSystem.java
+++ b/client/src/net/lapidist/colony/client/systems/MapRenderInitSystem.java
@@ -1,0 +1,34 @@
+package net.lapidist.colony.client.systems;
+
+import com.artemis.BaseSystem;
+import net.lapidist.colony.client.entities.factories.RenderComponentFactory;
+import net.lapidist.colony.client.renderers.DefaultAssetResolver;
+import net.lapidist.colony.components.maps.MapComponent;
+import net.lapidist.colony.map.MapUtils;
+
+/**
+ * Adds rendering components to map entities after the logical map has been created.
+ * Runs once after {@link MapInitSystem}.
+ */
+public final class MapRenderInitSystem extends BaseSystem {
+
+    @Override
+    public void initialize() {
+        MapComponent map = MapUtils.findMap(world).orElse(null);
+        if (map == null) {
+            return;
+        }
+        var resolver = new DefaultAssetResolver();
+        for (int i = 0; i < map.getTiles().size; i++) {
+            RenderComponentFactory.addTileRendering(world, map.getTiles().get(i), resolver);
+        }
+        for (int i = 0; i < map.getEntities().size; i++) {
+            RenderComponentFactory.addBuildingRendering(world, map.getEntities().get(i), resolver);
+        }
+    }
+
+    @Override
+    protected void processSystem() {
+        // initialization occurs once in initialize
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,6 +42,14 @@ sequenceDiagram
 
 For a detailed walkthrough see [networking.md](networking.md).
 
+## Render Abstraction
+
+Rendering code is decoupled from map creation through the `MapRendererFactory`
+interface. `MapWorldBuilder` accepts a factory instance when building the world
+and defaults to a sprite batch based implementation. Alternative renderers, such
+as the prototype 3‑D renderer, can be plugged in by providing a different
+factory when calling `MapWorldBuilder.build`.
+
 ## Future Platform Goals
 The project aims to evolve into a flexible simulation framework inspired by open-source games such as
 [Mindustry](https://github.com/Anuken/Mindustry) and

--- a/tests/src/net/lapidist/colony/tests/client/renderers/MapRendererFactoryTest.java
+++ b/tests/src/net/lapidist/colony/tests/client/renderers/MapRendererFactoryTest.java
@@ -5,6 +5,7 @@ import com.artemis.WorldConfigurationBuilder;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import net.lapidist.colony.client.renderers.MapRenderer;
 import net.lapidist.colony.client.renderers.MapRendererFactory;
+import net.lapidist.colony.client.renderers.SpriteMapRendererFactory;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
 import net.lapidist.colony.client.core.io.FileLocation;
 import net.lapidist.colony.client.core.io.ResourceLoader;
@@ -73,7 +74,7 @@ public class MapRendererFactoryTest {
                 .build());
         try (MockedConstruction<SpriteBatch> ignored =
                 mockConstruction(SpriteBatch.class)) {
-            MapRendererFactory factory = new MapRendererFactory(
+            MapRendererFactory factory = new SpriteMapRendererFactory(
                     loader,
                     FileLocation.INTERNAL,
                     "textures/textures.atlas"

--- a/tests/src/net/lapidist/colony/tests/client/renderers/ModelBatchMapRendererFactoryTest.java
+++ b/tests/src/net/lapidist/colony/tests/client/renderers/ModelBatchMapRendererFactoryTest.java
@@ -1,0 +1,29 @@
+package net.lapidist.colony.tests.client.renderers;
+
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import com.badlogic.gdx.graphics.g3d.ModelBatch;
+import net.lapidist.colony.client.renderers.MapRenderer;
+import net.lapidist.colony.client.renderers.ModelBatchMapRendererFactory;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.mockito.MockedConstruction;
+import static org.mockito.Mockito.mockConstruction;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(GdxTestRunner.class)
+public class ModelBatchMapRendererFactoryTest {
+
+    @Test
+    public void createsRendererWithResources() {
+        World world = new World(new WorldConfigurationBuilder().build());
+        try (MockedConstruction<ModelBatch> ignored = mockConstruction(ModelBatch.class)) {
+            ModelBatchMapRendererFactory factory = new ModelBatchMapRendererFactory();
+            MapRenderer renderer = factory.create(world);
+            assertNotNull(renderer);
+        }
+        world.dispose();
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/screens/MapWorldBuilderConfigurationTest.java
+++ b/tests/src/net/lapidist/colony/tests/screens/MapWorldBuilderConfigurationTest.java
@@ -15,6 +15,7 @@ import net.lapidist.colony.client.systems.PlayerCameraSystem;
 import net.lapidist.colony.client.systems.SelectionSystem;
 import net.lapidist.colony.client.systems.PlayerInitSystem;
 import net.lapidist.colony.client.systems.MapRenderSystem;
+import net.lapidist.colony.client.systems.MapRenderInitSystem;
 import net.lapidist.colony.components.resources.PlayerResourceComponent;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.ResourceData;
@@ -49,7 +50,8 @@ public class MapWorldBuilderConfigurationTest {
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
             World world = MapWorldBuilder.build(
                     MapWorldBuilder.baseBuilder(client, stage, keys)
-                            .with(new PlayerCameraSystem())
+                            .with(new PlayerCameraSystem()),
+                    null
             );
 
             assertNotNull(world.getSystem(CameraInputSystem.class));
@@ -58,6 +60,7 @@ public class MapWorldBuilderConfigurationTest {
             assertNotNull(world.getSystem(PlayerInitSystem.class));
             assertNotNull(world.getSystem(MapRenderSystem.class));
             assertNull(world.getSystem(MapInitSystem.class));
+            assertNull(world.getSystem(MapRenderInitSystem.class));
 
             world.dispose();
         }
@@ -77,12 +80,14 @@ public class MapWorldBuilderConfigurationTest {
         KeyBindings keys = new KeyBindings();
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
             World world = MapWorldBuilder.build(
-                    MapWorldBuilder.builder(new ProvidedMapStateProvider(state), client, stage, keys)
+                    MapWorldBuilder.builder(new ProvidedMapStateProvider(state), client, stage, keys),
+                    null
             );
             world.process();
 
             assertNotNull(world.getSystem(MapInitSystem.class));
             assertNotNull(world.getSystem(PlayerCameraSystem.class));
+            assertNotNull(world.getSystem(MapRenderInitSystem.class));
             assertEquals(1, world.getAspectSubscriptionManager()
                     .get(Aspect.all(PlayerResourceComponent.class))
                     .getEntities().size());
@@ -105,7 +110,8 @@ public class MapWorldBuilderConfigurationTest {
         KeyBindings keys = new KeyBindings();
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
             World world = MapWorldBuilder.build(
-                    MapWorldBuilder.builder(state, client, stage, keys)
+                    MapWorldBuilder.builder(state, client, stage, keys),
+                    null
             );
             world.process();
 

--- a/tests/src/net/lapidist/colony/tests/screens/MapWorldBuilderTest.java
+++ b/tests/src/net/lapidist/colony/tests/screens/MapWorldBuilderTest.java
@@ -32,7 +32,7 @@ public class MapWorldBuilderTest {
         WorldConfigurationBuilder builder = new WorldConfigurationBuilder()
                 .with(new EventSystem(), dummy);
 
-        World world = MapWorldBuilder.build(builder);
+        World world = MapWorldBuilder.build(builder, null);
         world.setDelta(0f);
         world.process();
 


### PR DESCRIPTION
## Summary
- separate map rendering setup into new MapRenderInitSystem
- introduce MapRendererFactory interface and SpriteMapRendererFactory impl
- allow MapWorldBuilder to accept a custom renderer factory
- add experimental ModelBatchMapRenderer and factory
- document render abstraction in README and architecture docs
- update tests for new systems and factories

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_684951826ac88328969da3b67f968842