### PR TITLE
feat(render): decouple map data from ECS

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The repository is split into four Gradle modules:
 - **tests** – JUnit tests and a custom `GdxTestRunner` that boots a headless LibGDX environment so game systems can be tested without a graphical context.
 
 ### Map Renderer Abstraction
-`MapWorldBuilder` uses a `MapRendererFactory` to create the renderer at build time. The default factory produces a sprite based renderer but alternative implementations can be supplied, including the experimental 3‑D renderer.
+`MapWorldBuilder` uses a `MapRendererFactory` to create the renderer at build time. The default factory produces a sprite based renderer but alternative implementations can be supplied, including the experimental 3‑D renderer. `MapRenderDataSystem` converts the live map into simple `RenderTile` and `RenderBuilding` objects so renderers work with plain data.
 
 Each module keeps its source under `src/` with all packages rooted at `net.lapidist.colony`. Shared constants and configuration files live in the `core` module and are imported by both the client and server.
 

--- a/client/src/net/lapidist/colony/client/render/MapRenderData.java
+++ b/client/src/net/lapidist/colony/client/render/MapRenderData.java
@@ -1,12 +1,14 @@
 package net.lapidist.colony.client.render;
 
-import com.artemis.Entity;
 import com.badlogic.gdx.utils.Array;
+import net.lapidist.colony.client.render.data.RenderBuilding;
+import net.lapidist.colony.client.render.data.RenderTile;
 
 /**
  * Read-only data describing map entities for rendering.
  */
 public interface MapRenderData {
-    Array<Entity> getTiles();
-    Array<Entity> getEntities();
+    Array<RenderTile> getTiles();
+
+    Array<RenderBuilding> getBuildings();
 }

--- a/client/src/net/lapidist/colony/client/render/MapRenderDataBuilder.java
+++ b/client/src/net/lapidist/colony/client/render/MapRenderDataBuilder.java
@@ -1,13 +1,57 @@
 package net.lapidist.colony.client.render;
 
+import com.artemis.ComponentMapper;
+import com.artemis.World;
+import com.artemis.Entity;
+import com.badlogic.gdx.utils.Array;
+import net.lapidist.colony.client.render.data.RenderBuilding;
+import net.lapidist.colony.client.render.data.RenderTile;
+import net.lapidist.colony.components.entities.BuildingComponent;
 import net.lapidist.colony.components.maps.MapComponent;
+import net.lapidist.colony.components.maps.TileComponent;
+import net.lapidist.colony.components.resources.ResourceComponent;
 
 /** Utility to convert {@link MapComponent} to {@link MapRenderData}. */
 public final class MapRenderDataBuilder {
     private MapRenderDataBuilder() {
     }
 
-    public static MapRenderData fromMap(final MapComponent map) {
-        return new SimpleMapRenderData(map.getTiles(), map.getEntities());
+    public static MapRenderData fromMap(final MapComponent map, final World world) {
+        ComponentMapper<TileComponent> tileMapper = world.getMapper(TileComponent.class);
+        ComponentMapper<ResourceComponent> resourceMapper = world.getMapper(ResourceComponent.class);
+        ComponentMapper<BuildingComponent> buildingMapper = world.getMapper(BuildingComponent.class);
+
+        Array<RenderTile> tiles = new Array<>();
+        Array<Entity> mapTiles = map.getTiles();
+        for (int i = 0; i < mapTiles.size; i++) {
+            Entity entity = mapTiles.get(i);
+            TileComponent tc = tileMapper.get(entity);
+            ResourceComponent rc = resourceMapper.get(entity);
+            RenderTile tile = RenderTile.builder()
+                    .x(tc.getX())
+                    .y(tc.getY())
+                    .tileType(tc.getTileType().toString())
+                    .selected(tc.isSelected())
+                    .wood(rc.getWood())
+                    .stone(rc.getStone())
+                    .food(rc.getFood())
+                    .build();
+            tiles.add(tile);
+        }
+
+        Array<RenderBuilding> buildings = new Array<>();
+        Array<Entity> mapEntities = map.getEntities();
+        for (int i = 0; i < mapEntities.size; i++) {
+            Entity entity = mapEntities.get(i);
+            BuildingComponent bc = buildingMapper.get(entity);
+            RenderBuilding building = RenderBuilding.builder()
+                    .x(bc.getX())
+                    .y(bc.getY())
+                    .buildingType(bc.getBuildingType().toString())
+                    .build();
+            buildings.add(building);
+        }
+
+        return new SimpleMapRenderData(tiles, buildings);
     }
 }

--- a/client/src/net/lapidist/colony/client/render/SimpleMapRenderData.java
+++ b/client/src/net/lapidist/colony/client/render/SimpleMapRenderData.java
@@ -1,27 +1,28 @@
 package net.lapidist.colony.client.render;
 
-import com.artemis.Entity;
 import com.badlogic.gdx.utils.Array;
+import net.lapidist.colony.client.render.data.RenderBuilding;
+import net.lapidist.colony.client.render.data.RenderTile;
 
 /**
  * Basic immutable implementation of {@link MapRenderData}.
  */
 public final class SimpleMapRenderData implements MapRenderData {
-    private final Array<Entity> tiles;
-    private final Array<Entity> entities;
+    private final Array<RenderTile> tiles;
+    private final Array<RenderBuilding> buildings;
 
-    public SimpleMapRenderData(final Array<Entity> tilesToUse, final Array<Entity> entitiesToUse) {
+    public SimpleMapRenderData(final Array<RenderTile> tilesToUse, final Array<RenderBuilding> buildingsToUse) {
         this.tiles = tilesToUse;
-        this.entities = entitiesToUse;
+        this.buildings = buildingsToUse;
     }
 
     @Override
-    public Array<Entity> getTiles() {
+    public Array<RenderTile> getTiles() {
         return tiles;
     }
 
     @Override
-    public Array<Entity> getEntities() {
-        return entities;
+    public Array<RenderBuilding> getBuildings() {
+        return buildings;
     }
 }

--- a/client/src/net/lapidist/colony/client/render/data/RenderBuilding.java
+++ b/client/src/net/lapidist/colony/client/render/data/RenderBuilding.java
@@ -1,0 +1,58 @@
+package net.lapidist.colony.client.render.data;
+
+/** Render data object for a building. */
+public final class RenderBuilding {
+    private final int x;
+    private final int y;
+    private final String buildingType;
+
+    private RenderBuilding(final Builder builder) {
+        this.x = builder.x;
+        this.y = builder.y;
+        this.buildingType = builder.buildingType;
+    }
+
+    public int getX() {
+        return x;
+    }
+
+    public int getY() {
+        return y;
+    }
+
+    public String getBuildingType() {
+        return buildingType;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder for {@link RenderBuilding}. */
+    public static final class Builder {
+        private int x;
+        private int y;
+        private String buildingType;
+
+        private Builder() { }
+
+        public Builder x(final int newX) {
+            this.x = newX;
+            return this;
+        }
+
+        public Builder y(final int newY) {
+            this.y = newY;
+            return this;
+        }
+
+        public Builder buildingType(final String newType) {
+            this.buildingType = newType;
+            return this;
+        }
+
+        public RenderBuilding build() {
+            return new RenderBuilding(this);
+        }
+    }
+}

--- a/client/src/net/lapidist/colony/client/render/data/RenderTile.java
+++ b/client/src/net/lapidist/colony/client/render/data/RenderTile.java
@@ -1,0 +1,106 @@
+package net.lapidist.colony.client.render.data;
+
+/** Render data object for a map tile. */
+public final class RenderTile {
+    private final int x;
+    private final int y;
+    private final String tileType;
+    private final boolean selected;
+    private final int wood;
+    private final int stone;
+    private final int food;
+
+    private RenderTile(final Builder builder) {
+        this.x = builder.x;
+        this.y = builder.y;
+        this.tileType = builder.tileType;
+        this.selected = builder.selected;
+        this.wood = builder.wood;
+        this.stone = builder.stone;
+        this.food = builder.food;
+    }
+
+    public int getX() {
+        return x;
+    }
+
+    public int getY() {
+        return y;
+    }
+
+    public String getTileType() {
+        return tileType;
+    }
+
+    public boolean isSelected() {
+        return selected;
+    }
+
+    public int getWood() {
+        return wood;
+    }
+
+    public int getStone() {
+        return stone;
+    }
+
+    public int getFood() {
+        return food;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder for {@link RenderTile}. */
+    public static final class Builder {
+        private int x;
+        private int y;
+        private String tileType;
+        private boolean selected;
+        private int wood;
+        private int stone;
+        private int food;
+
+        private Builder() { }
+
+        public Builder x(final int newX) {
+            this.x = newX;
+            return this;
+        }
+
+        public Builder y(final int newY) {
+            this.y = newY;
+            return this;
+        }
+
+        public Builder tileType(final String newType) {
+            this.tileType = newType;
+            return this;
+        }
+
+        public Builder selected(final boolean newSelected) {
+            this.selected = newSelected;
+            return this;
+        }
+
+        public Builder wood(final int newWood) {
+            this.wood = newWood;
+            return this;
+        }
+
+        public Builder stone(final int newStone) {
+            this.stone = newStone;
+            return this;
+        }
+
+        public Builder food(final int newFood) {
+            this.food = newFood;
+            return this;
+        }
+
+        public RenderTile build() {
+            return new RenderTile(this);
+        }
+    }
+}

--- a/client/src/net/lapidist/colony/client/render/data/package-info.java
+++ b/client/src/net/lapidist/colony/client/render/data/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Plain data objects consumed by client renderers.
+ */
+package net.lapidist.colony.client.render.data;

--- a/client/src/net/lapidist/colony/client/renderers/AssetResolver.java
+++ b/client/src/net/lapidist/colony/client/renderers/AssetResolver.java
@@ -1,7 +1,5 @@
 package net.lapidist.colony.client.renderers;
 
-import net.lapidist.colony.components.entities.BuildingComponent;
-import net.lapidist.colony.components.maps.TileComponent;
 
 /**
  * Resolves rendering resource references for map entities.
@@ -13,7 +11,7 @@ public interface AssetResolver {
      * @param type tile type
      * @return asset reference for rendering
      */
-    String tileAsset(TileComponent.TileType type);
+    String tileAsset(String type);
 
     /**
      * Resolve the texture or model identifier for a building type.
@@ -21,5 +19,5 @@ public interface AssetResolver {
      * @param type building type
      * @return asset reference for rendering
      */
-    String buildingAsset(BuildingComponent.BuildingType type);
+    String buildingAsset(String type);
 }

--- a/client/src/net/lapidist/colony/client/renderers/BuildingRenderer.java
+++ b/client/src/net/lapidist/colony/client/renderers/BuildingRenderer.java
@@ -1,7 +1,5 @@
 package net.lapidist.colony.client.renderers;
 
-import com.artemis.ComponentMapper;
-import com.artemis.Entity;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Vector2;
@@ -9,38 +7,34 @@ import com.badlogic.gdx.utils.Array;
 import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.client.systems.CameraProvider;
 import net.lapidist.colony.client.util.CameraUtils;
-import net.lapidist.colony.components.entities.BuildingComponent;
+import net.lapidist.colony.client.render.data.RenderBuilding;
 
 /**
  * Renders building entities.
  */
-public final class BuildingRenderer implements EntityRenderer {
+public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
 
     private final SpriteBatch spriteBatch;
     private final ResourceLoader resourceLoader;
     private final CameraProvider cameraSystem;
-    private final ComponentMapper<BuildingComponent> buildingMapper;
     private final AssetResolver resolver;
 
     public BuildingRenderer(
             final SpriteBatch spriteBatchToSet,
             final ResourceLoader resourceLoaderToSet,
             final CameraProvider cameraSystemToSet,
-            final ComponentMapper<BuildingComponent> buildingMapperToSet,
             final AssetResolver resolverToSet
     ) {
         this.spriteBatch = spriteBatchToSet;
         this.resourceLoader = resourceLoaderToSet;
         this.cameraSystem = cameraSystemToSet;
-        this.buildingMapper = buildingMapperToSet;
         this.resolver = resolverToSet;
     }
 
     @Override
-    public void render(final Array<Entity> entities) {
+    public void render(final Array<RenderBuilding> entities) {
         for (int i = 0; i < entities.size; i++) {
-            Entity entity = entities.get(i);
-            BuildingComponent building = buildingMapper.get(entity);
+            RenderBuilding building = entities.get(i);
             Vector2 worldCoords = CameraUtils.tileCoordsToWorldCoords(
                     building.getX(),
                     building.getY()

--- a/client/src/net/lapidist/colony/client/renderers/DefaultAssetResolver.java
+++ b/client/src/net/lapidist/colony/client/renderers/DefaultAssetResolver.java
@@ -6,16 +6,18 @@ import net.lapidist.colony.components.maps.TileComponent;
 /** Default implementation returning built-in asset references. */
 public final class DefaultAssetResolver implements AssetResolver {
     @Override
-    public String tileAsset(final TileComponent.TileType type) {
-        return switch (type) {
+    public String tileAsset(final String type) {
+        TileComponent.TileType tile = TileComponent.TileType.valueOf(type);
+        return switch (tile) {
             case EMPTY -> "dirt0";
             case GRASS -> "grass0";
         };
     }
 
     @Override
-    public String buildingAsset(final BuildingComponent.BuildingType type) {
-        return switch (type) {
+    public String buildingAsset(final String type) {
+        BuildingComponent.BuildingType building = BuildingComponent.BuildingType.valueOf(type);
+        return switch (building) {
             case HOUSE -> "house0";
             case MARKET -> "house0";
             case FACTORY -> "house0";

--- a/client/src/net/lapidist/colony/client/renderers/EntityRenderer.java
+++ b/client/src/net/lapidist/colony/client/renderers/EntityRenderer.java
@@ -1,16 +1,15 @@
 package net.lapidist.colony.client.renderers;
 
-import com.artemis.Entity;
 import com.badlogic.gdx.utils.Array;
 
 /**
  * Common interface for entity renderers.
  */
-public interface EntityRenderer {
+public interface EntityRenderer<T> {
     /**
      * Render the supplied entities.
      *
      * @param entities entities to render
      */
-    void render(Array<Entity> entities);
+    void render(Array<T> entities);
 }

--- a/client/src/net/lapidist/colony/client/renderers/ResourceRenderer.java
+++ b/client/src/net/lapidist/colony/client/renderers/ResourceRenderer.java
@@ -1,49 +1,38 @@
 package net.lapidist.colony.client.renderers;
 
-import com.artemis.ComponentMapper;
-import com.artemis.Entity;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.Array;
 import net.lapidist.colony.client.systems.CameraProvider;
 import net.lapidist.colony.client.util.CameraUtils;
-import net.lapidist.colony.components.maps.TileComponent;
-import net.lapidist.colony.components.resources.ResourceComponent;
+import net.lapidist.colony.client.render.data.RenderTile;
 import com.badlogic.gdx.utils.Disposable;
 
 /** Draws resource amounts on tiles. */
-public final class ResourceRenderer implements EntityRenderer, Disposable {
+public final class ResourceRenderer implements EntityRenderer<RenderTile>, Disposable {
     private final SpriteBatch spriteBatch;
     private final CameraProvider cameraSystem;
     private final BitmapFont font = new BitmapFont();
-    private final ComponentMapper<TileComponent> tileMapper;
-    private final ComponentMapper<ResourceComponent> resourceMapper;
     private static final float OFFSET_Y = 8f;
 
     public ResourceRenderer(
             final SpriteBatch spriteBatchToUse,
-            final CameraProvider cameraSystemToUse,
-            final ComponentMapper<TileComponent> tileMapperToUse,
-            final ComponentMapper<ResourceComponent> resourceMapperToUse
+            final CameraProvider cameraSystemToUse
     ) {
         this.spriteBatch = spriteBatchToUse;
         this.cameraSystem = cameraSystemToUse;
-        this.tileMapper = tileMapperToUse;
-        this.resourceMapper = resourceMapperToUse;
     }
 
     @Override
-    public void render(final Array<Entity> entities) {
+    public void render(final Array<RenderTile> entities) {
         for (int i = 0; i < entities.size; i++) {
-            Entity entity = entities.get(i);
-            TileComponent tile = tileMapper.get(entity);
+            RenderTile tile = entities.get(i);
             Vector2 worldCoords = CameraUtils.tileCoordsToWorldCoords(tile.getX(), tile.getY());
             if (!CameraUtils.withinCameraView(cameraSystem.getViewport(), worldCoords)) {
                 continue;
             }
-            ResourceComponent rc = resourceMapper.get(entity);
-            String text = rc.getWood() + "/" + rc.getStone() + "/" + rc.getFood();
+            String text = tile.getWood() + "/" + tile.getStone() + "/" + tile.getFood();
             font.draw(spriteBatch, text, worldCoords.x, worldCoords.y + OFFSET_Y);
         }
     }

--- a/client/src/net/lapidist/colony/client/renderers/SpriteBatchMapRenderer.java
+++ b/client/src/net/lapidist/colony/client/renderers/SpriteBatchMapRenderer.java
@@ -37,7 +37,7 @@ public final class SpriteBatchMapRenderer implements MapRenderer, Disposable {
         spriteBatch.begin();
 
         tileRenderer.render(map.getTiles());
-        buildingRenderer.render(map.getEntities());
+        buildingRenderer.render(map.getBuildings());
         resourceRenderer.render(map.getTiles());
 
         spriteBatch.end();

--- a/client/src/net/lapidist/colony/client/renderers/SpriteMapRendererFactory.java
+++ b/client/src/net/lapidist/colony/client/renderers/SpriteMapRendererFactory.java
@@ -1,6 +1,5 @@
 package net.lapidist.colony.client.renderers;
 
-import com.artemis.ComponentMapper;
 import com.artemis.World;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import net.lapidist.colony.client.core.io.FileLocation;
@@ -10,10 +9,7 @@ import net.lapidist.colony.client.systems.CameraProvider;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
 import net.lapidist.colony.settings.GraphicsSettings;
 import net.lapidist.colony.settings.Settings;
-import net.lapidist.colony.components.entities.BuildingComponent;
-import net.lapidist.colony.components.maps.TileComponent;
 import net.lapidist.colony.components.maps.MapComponent;
-import net.lapidist.colony.components.resources.ResourceComponent;
 
 import java.io.IOException;
 
@@ -51,29 +47,22 @@ public final class SpriteMapRendererFactory implements MapRendererFactory {
         SpriteBatch batch = new SpriteBatch();
 
         CameraProvider cameraSystem = world.getSystem(PlayerCameraSystem.class);
-        ComponentMapper<TileComponent> tileMapper = world.getMapper(TileComponent.class);
-        ComponentMapper<BuildingComponent> buildingMapper = world.getMapper(BuildingComponent.class);
-        ComponentMapper<ResourceComponent> resourceMapper = world.getMapper(ResourceComponent.class);
 
         TileRenderer tileRenderer = new TileRenderer(
                 batch,
                 resourceLoader,
                 cameraSystem,
-                tileMapper,
                 new DefaultAssetResolver()
         );
         BuildingRenderer buildingRenderer = new BuildingRenderer(
                 batch,
                 resourceLoader,
                 cameraSystem,
-                buildingMapper,
                 new DefaultAssetResolver()
         );
         ResourceRenderer resourceRenderer = new ResourceRenderer(
                 batch,
-                cameraSystem,
-                tileMapper,
-                resourceMapper
+                cameraSystem
         );
 
         // trigger map mapper initialization so MapRenderSystem can use it immediately

--- a/client/src/net/lapidist/colony/client/renderers/TileRenderer.java
+++ b/client/src/net/lapidist/colony/client/renderers/TileRenderer.java
@@ -1,7 +1,5 @@
 package net.lapidist.colony.client.renderers;
 
-import com.artemis.ComponentMapper;
-import com.artemis.Entity;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Vector2;
@@ -9,38 +7,34 @@ import com.badlogic.gdx.utils.Array;
 import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.client.systems.CameraProvider;
 import net.lapidist.colony.client.util.CameraUtils;
-import net.lapidist.colony.components.maps.TileComponent;
+import net.lapidist.colony.client.render.data.RenderTile;
 
 /**
  * Renders tile entities.
  */
-public final class TileRenderer implements EntityRenderer {
+public final class TileRenderer implements EntityRenderer<RenderTile> {
 
     private final SpriteBatch spriteBatch;
     private final ResourceLoader resourceLoader;
     private final CameraProvider cameraSystem;
-    private final ComponentMapper<TileComponent> tileMapper;
     private final AssetResolver resolver;
 
     public TileRenderer(
             final SpriteBatch spriteBatchToSet,
             final ResourceLoader resourceLoaderToSet,
             final CameraProvider cameraSystemToSet,
-            final ComponentMapper<TileComponent> tileMapperToSet,
             final AssetResolver resolverToSet
     ) {
         this.spriteBatch = spriteBatchToSet;
         this.resourceLoader = resourceLoaderToSet;
         this.cameraSystem = cameraSystemToSet;
-        this.tileMapper = tileMapperToSet;
         this.resolver = resolverToSet;
     }
 
     @Override
-    public void render(final Array<Entity> entities) {
+    public void render(final Array<RenderTile> entities) {
         for (int i = 0; i < entities.size; i++) {
-            Entity entity = entities.get(i);
-            TileComponent tile = tileMapper.get(entity);
+            RenderTile tile = entities.get(i);
             Vector2 worldCoords = CameraUtils.tileCoordsToWorldCoords(
                     tile.getX(),
                     tile.getY()

--- a/client/src/net/lapidist/colony/client/systems/MapRenderDataSystem.java
+++ b/client/src/net/lapidist/colony/client/systems/MapRenderDataSystem.java
@@ -20,7 +20,7 @@ public final class MapRenderDataSystem extends BaseSystem {
     public void initialize() {
         MapComponent map = MapUtils.findMap(world).orElse(null);
         if (map != null) {
-            renderData = MapRenderDataBuilder.fromMap(map);
+            renderData = MapRenderDataBuilder.fromMap(map, world);
         }
     }
 

--- a/client/src/net/lapidist/colony/client/ui/MinimapCache.java
+++ b/client/src/net/lapidist/colony/client/ui/MinimapCache.java
@@ -63,7 +63,7 @@ final class MinimapCache implements Disposable {
             Entity tile = tiles.get(i);
             TileComponent tileComponent = tileMapper.get(tile);
             TextureRegion region = resourceLoader.findRegion(
-                    resolver.tileAsset(tileComponent.getTileType()));
+                    resolver.tileAsset(tileComponent.getTileType().toString()));
             if (region != null) {
                 spriteCache.add(
                         region,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,10 +51,10 @@ as the prototype 3‑D renderer, can be plugged in by providing a different
 factory when calling `MapWorldBuilder.build`.
 
 `MapRenderData` acts as a lightweight view of the map state for renderers. A
-`MapRenderDataSystem` converts the ECS `MapComponent` into this immutable
-structure so renderers never depend on gameplay components. Swapping in a 3‑D
-renderer simply requires implementing the `MapRenderer` interface against this
-data.
+`MapRenderDataSystem` converts the ECS `MapComponent` into immutable
+`RenderTile` and `RenderBuilding` objects so renderers never depend on gameplay
+components. Swapping in a 3‑D renderer simply requires implementing the
+`MapRenderer` interface against this data.
 
 ## Future Platform Goals
 The project aims to evolve into a flexible simulation framework inspired by open-source games such as

--- a/tests/src/net/lapidist/colony/tests/client/render/data/DefaultAssetResolverTest.java
+++ b/tests/src/net/lapidist/colony/tests/client/render/data/DefaultAssetResolverTest.java
@@ -1,0 +1,15 @@
+package net.lapidist.colony.tests.client.render.data;
+
+import net.lapidist.colony.client.renderers.DefaultAssetResolver;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class DefaultAssetResolverTest {
+    @Test
+    public void returnsSpriteReferences() {
+        DefaultAssetResolver resolver = new DefaultAssetResolver();
+        assertEquals("grass0", resolver.tileAsset("GRASS"));
+        assertEquals("house0", resolver.buildingAsset("HOUSE"));
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/client/render/data/MapRenderDataBuilderTest.java
+++ b/tests/src/net/lapidist/colony/tests/client/render/data/MapRenderDataBuilderTest.java
@@ -1,0 +1,47 @@
+package net.lapidist.colony.tests.client.render.data;
+
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import net.lapidist.colony.client.entities.factories.MapFactory;
+import net.lapidist.colony.client.render.MapRenderData;
+import net.lapidist.colony.client.render.MapRenderDataBuilder;
+import net.lapidist.colony.components.maps.MapComponent;
+import net.lapidist.colony.components.state.BuildingData;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.TileData;
+import net.lapidist.colony.components.state.TilePos;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MapRenderDataBuilderTest {
+    private static final int TILE_X = 0;
+    private static final int TILE_Y = 0;
+    private static final int BUILDING_X = 1;
+    private static final int BUILDING_Y = 1;
+    private static final int WOOD = 1;
+    private static final int STONE = 2;
+    private static final int FOOD = 3;
+
+    @Test
+    public void convertsMapToRenderObjects() {
+        MapState state = new MapState();
+        state.tiles().put(new TilePos(TILE_X, TILE_Y), TileData.builder()
+                .x(TILE_X).y(TILE_Y).tileType("GRASS").passable(true)
+                .resources(new net.lapidist.colony.components.state.ResourceData(WOOD, STONE, FOOD))
+                .build());
+        state.buildings().add(new BuildingData(BUILDING_X, BUILDING_Y, "HOUSE"));
+
+        World world = new World(new WorldConfigurationBuilder().build());
+        MapComponent map = MapFactory.create(world, state).getComponent(MapComponent.class);
+
+        MapRenderData data = MapRenderDataBuilder.fromMap(map, world);
+        assertEquals(1, data.getTiles().size);
+        assertEquals(1, data.getBuildings().size);
+
+        var tile = data.getTiles().first();
+        assertEquals("grass", tile.getTileType());
+        assertEquals(1, tile.getWood());
+        assertEquals(BUILDING_X, data.getBuildings().first().getX());
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/client/render/data/RenderBuildingTest.java
+++ b/tests/src/net/lapidist/colony/tests/client/render/data/RenderBuildingTest.java
@@ -1,0 +1,24 @@
+package net.lapidist.colony.tests.client.render.data;
+
+import net.lapidist.colony.client.render.data.RenderBuilding;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class RenderBuildingTest {
+    private static final int X = 4;
+    private static final int Y = 7;
+
+    @Test
+    public void builderSetsFields() {
+        RenderBuilding building = RenderBuilding.builder()
+                .x(X)
+                .y(Y)
+                .buildingType("HOUSE")
+                .build();
+
+        assertEquals(X, building.getX());
+        assertEquals(Y, building.getY());
+        assertEquals("HOUSE", building.getBuildingType());
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/client/render/data/RenderTileTest.java
+++ b/tests/src/net/lapidist/colony/tests/client/render/data/RenderTileTest.java
@@ -1,0 +1,35 @@
+package net.lapidist.colony.tests.client.render.data;
+
+import net.lapidist.colony.client.render.data.RenderTile;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class RenderTileTest {
+    private static final int X = 1;
+    private static final int Y = 2;
+    private static final int WOOD = 5;
+    private static final int STONE = 3;
+    private static final int FOOD = 2;
+
+    @Test
+    public void builderSetsAllFields() {
+        RenderTile tile = RenderTile.builder()
+                .x(X)
+                .y(Y)
+                .tileType("GRASS")
+                .selected(true)
+                .wood(WOOD)
+                .stone(STONE)
+                .food(FOOD)
+                .build();
+
+        assertEquals(X, tile.getX());
+        assertEquals(Y, tile.getY());
+        assertEquals("GRASS", tile.getTileType());
+        assertTrue(tile.isSelected());
+        assertEquals(WOOD, tile.getWood());
+        assertEquals(STONE, tile.getStone());
+        assertEquals(FOOD, tile.getFood());
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/client/render/data/package-info.java
+++ b/tests/src/net/lapidist/colony/tests/client/render/data/package-info.java
@@ -1,0 +1,2 @@
+/** Tests for render data objects and builders. */
+package net.lapidist.colony.tests.client.render.data;

--- a/tests/src/net/lapidist/colony/tests/systems/MapRenderDataSystemTest.java
+++ b/tests/src/net/lapidist/colony/tests/systems/MapRenderDataSystemTest.java
@@ -41,6 +41,7 @@ public class MapRenderDataSystemTest {
         MapRenderDataSystem system = world.getSystem(MapRenderDataSystem.class);
         assertNotNull(system.getRenderData());
         assertEquals(1, system.getRenderData().getTiles().size);
+        assertEquals(0, system.getRenderData().getBuildings().size);
 
         world.dispose();
     }


### PR DESCRIPTION
## Summary
- add `RenderTile` and `RenderBuilding` POJOs
- refactor render data API to use the new objects
- update tile, building and resource renderers
- simplify sprite renderer factory
- document render data objects

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_68496136f2c483288bf823137da921e3