### PR TITLE
test: add menu screen interaction tests

### DIFF
--- a/tests/src/net/lapidist/colony/tests/screens/LoadGameScreenTest.java
+++ b/tests/src/net/lapidist/colony/tests/screens/LoadGameScreenTest.java
@@ -1,0 +1,75 @@
+package net.lapidist.colony.tests.screens;
+
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
+import net.lapidist.colony.client.Colony;
+import net.lapidist.colony.client.screens.LoadGameScreen;
+import net.lapidist.colony.client.screens.MainMenuScreen;
+import net.lapidist.colony.io.Paths;
+import org.mockito.MockedConstruction;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.mockito.Mockito.mockConstruction;
+
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(GdxTestRunner.class)
+public class LoadGameScreenTest {
+
+    private static Table getRoot(final LoadGameScreen screen) throws Exception {
+        Field f = screen.getClass().getSuperclass().getDeclaredField("root");
+        f.setAccessible(true);
+        return (Table) f.get(screen);
+    }
+
+    @Test
+    public void backButtonReturnsToMainMenu() throws Exception {
+        Colony colony = mock(Colony.class);
+        try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
+            LoadGameScreen screen = new LoadGameScreen(colony);
+            Table root = getRoot(screen);
+            TextButton back = (TextButton) root.getChildren().peek();
+            back.fire(new ChangeListener.ChangeEvent());
+            verify(colony).setScreen(isA(MainMenuScreen.class));
+            screen.dispose();
+        }
+    }
+
+    @Test
+    public void loadButtonStartsGame() throws Exception {
+        String save = "test-" + UUID.randomUUID();
+        Path folder = Path.of(System.getProperty("user.home"), ".colony", "saves");
+        Files.createDirectories(folder);
+        Files.createFile(folder.resolve(save + Paths.AUTOSAVE_SUFFIX));
+
+        Colony colony = mock(Colony.class);
+        try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
+            LoadGameScreen screen = new LoadGameScreen(colony);
+            Table root = getRoot(screen);
+            Table row = null;
+            for (com.badlogic.gdx.scenes.scene2d.Actor child : root.getChildren()) {
+                if (child instanceof Table t) {
+                    TextButton btn = (TextButton) t.getChildren().first();
+                    if (save.equals(btn.getText().toString())) {
+                        row = t;
+                        break;
+                    }
+                }
+            }
+            TextButton load = (TextButton) row.getChildren().get(0);
+            load.fire(new ChangeListener.ChangeEvent());
+
+            verify(colony).startGame(save);
+            Files.deleteIfExists(folder.resolve(save + Paths.AUTOSAVE_SUFFIX));
+            screen.dispose();
+        }
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/screens/MainMenuScreenTest.java
+++ b/tests/src/net/lapidist/colony/tests/screens/MainMenuScreenTest.java
@@ -1,0 +1,70 @@
+package net.lapidist.colony.tests.screens;
+
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import net.lapidist.colony.client.Colony;
+import net.lapidist.colony.client.screens.LoadGameScreen;
+import net.lapidist.colony.client.screens.MainMenuScreen;
+import net.lapidist.colony.client.screens.NewGameScreen;
+import net.lapidist.colony.client.screens.SettingsScreen;
+import org.mockito.MockedConstruction;
+import static org.mockito.Mockito.mockConstruction;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(GdxTestRunner.class)
+public class MainMenuScreenTest {
+
+    private static final int NEW_GAME_INDEX = 1;
+    private static final int LOAD_GAME_INDEX = 2;
+    private static final int SETTINGS_INDEX = 3;
+
+    private static Table getRoot(final MainMenuScreen screen) throws Exception {
+        Field f = screen.getClass().getSuperclass().getDeclaredField("root");
+        f.setAccessible(true);
+        return (Table) f.get(screen);
+    }
+
+    @Test
+    public void clickingNewGameOpensNewGameScreen() throws Exception {
+        Colony colony = mock(Colony.class);
+        try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
+            MainMenuScreen screen = new MainMenuScreen(colony);
+            TextButton newGame = (TextButton) getRoot(screen).getChildren().get(NEW_GAME_INDEX);
+            newGame.fire(new ChangeListener.ChangeEvent());
+            verify(colony).setScreen(isA(NewGameScreen.class));
+            screen.dispose();
+        }
+    }
+
+    @Test
+    public void clickingLoadGameOpensLoadGameScreen() throws Exception {
+        Colony colony = mock(Colony.class);
+        try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
+            MainMenuScreen screen = new MainMenuScreen(colony);
+            TextButton load = (TextButton) getRoot(screen).getChildren().get(LOAD_GAME_INDEX);
+            load.fire(new ChangeListener.ChangeEvent());
+            verify(colony).setScreen(isA(LoadGameScreen.class));
+            screen.dispose();
+        }
+    }
+
+    @Test
+    public void clickingSettingsOpensSettingsScreen() throws Exception {
+        Colony colony = mock(Colony.class);
+        try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
+            MainMenuScreen screen = new MainMenuScreen(colony);
+            TextButton settings = (TextButton) getRoot(screen).getChildren().get(SETTINGS_INDEX);
+            settings.fire(new ChangeListener.ChangeEvent());
+            verify(colony).setScreen(isA(SettingsScreen.class));
+            screen.dispose();
+        }
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/screens/NewGameScreenTest.java
+++ b/tests/src/net/lapidist/colony/tests/screens/NewGameScreenTest.java
@@ -1,0 +1,60 @@
+package net.lapidist.colony.tests.screens;
+
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
+import com.badlogic.gdx.scenes.scene2d.ui.TextField;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
+import net.lapidist.colony.client.Colony;
+import net.lapidist.colony.client.screens.MainMenuScreen;
+import net.lapidist.colony.client.screens.NewGameScreen;
+import org.mockito.MockedConstruction;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.mockito.Mockito.mockConstruction;
+
+import java.lang.reflect.Field;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(GdxTestRunner.class)
+public class NewGameScreenTest {
+
+    private static final int NAME_FIELD_INDEX = 1;
+    private static final int START_BUTTON_INDEX = 2;
+    private static final int BACK_BUTTON_INDEX = 3;
+
+    private static Table getRoot(final NewGameScreen screen) throws Exception {
+        Field f = screen.getClass().getSuperclass().getDeclaredField("root");
+        f.setAccessible(true);
+        return (Table) f.get(screen);
+    }
+
+    @Test
+    public void startButtonBeginsGameWithEnteredName() throws Exception {
+        Colony colony = mock(Colony.class);
+        try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
+            NewGameScreen screen = new NewGameScreen(colony);
+            Table root = getRoot(screen);
+            TextField field = (TextField) root.getChildren().get(NAME_FIELD_INDEX);
+            TextButton start = (TextButton) root.getChildren().get(START_BUTTON_INDEX);
+            field.setText("mysave");
+            start.fire(new ChangeListener.ChangeEvent());
+            verify(colony).startGame("mysave");
+            screen.dispose();
+        }
+    }
+
+    @Test
+    public void backButtonReturnsToMainMenu() throws Exception {
+        Colony colony = mock(Colony.class);
+        try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
+            NewGameScreen screen = new NewGameScreen(colony);
+            TextButton back = (TextButton) getRoot(screen).getChildren().get(BACK_BUTTON_INDEX);
+            back.fire(new ChangeListener.ChangeEvent());
+            verify(colony).setScreen(isA(MainMenuScreen.class));
+            screen.dispose();
+        }
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/screens/SettingsScreenTest.java
+++ b/tests/src/net/lapidist/colony/tests/screens/SettingsScreenTest.java
@@ -1,0 +1,59 @@
+package net.lapidist.colony.tests.screens;
+
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
+import net.lapidist.colony.client.Colony;
+import net.lapidist.colony.client.screens.KeybindsScreen;
+import net.lapidist.colony.client.screens.MainMenuScreen;
+import net.lapidist.colony.client.screens.SettingsScreen;
+import net.lapidist.colony.settings.Settings;
+import org.mockito.MockedConstruction;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.mockito.Mockito.mockConstruction;
+
+import java.lang.reflect.Field;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(GdxTestRunner.class)
+public class SettingsScreenTest {
+
+    private static final int KEYBINDS_INDEX = 4;
+    private static final int BACK_BUTTON_INDEX = 5;
+
+    private static Table getRoot(final SettingsScreen screen) throws Exception {
+        Field f = screen.getClass().getSuperclass().getDeclaredField("root");
+        f.setAccessible(true);
+        return (Table) f.get(screen);
+    }
+
+    @Test
+    public void keybindsButtonOpensKeybindsScreen() throws Exception {
+        Colony colony = mock(Colony.class);
+        when(colony.getSettings()).thenReturn(new Settings());
+        try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
+            SettingsScreen screen = new SettingsScreen(colony);
+            TextButton keybinds = (TextButton) getRoot(screen).getChildren().get(KEYBINDS_INDEX);
+            keybinds.fire(new ChangeListener.ChangeEvent());
+            verify(colony).setScreen(isA(KeybindsScreen.class));
+            screen.dispose();
+        }
+    }
+
+    @Test
+    public void backButtonReturnsToMainMenu() throws Exception {
+        Colony colony = mock(Colony.class);
+        when(colony.getSettings()).thenReturn(new Settings());
+        try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
+            SettingsScreen screen = new SettingsScreen(colony);
+            TextButton back = (TextButton) getRoot(screen).getChildren().get(BACK_BUTTON_INDEX);
+            back.fire(new ChangeListener.ChangeEvent());
+            verify(colony).setScreen(isA(MainMenuScreen.class));
+            screen.dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new interaction tests for menu screens
- ensure each screen dispatches the correct colony methods on button clicks

## Testing
- `./gradlew clean test`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_684994a707f48328849d3aff7f7f8552