### PR TITLE
test: add input handler unit tests

### DIFF
--- a/tests/src/net/lapidist/colony/tests/client/input/BuildingPlacementHandlerTest.java
+++ b/tests/src/net/lapidist/colony/tests/client/input/BuildingPlacementHandlerTest.java
@@ -1,0 +1,61 @@
+package net.lapidist.colony.tests.client.input;
+
+import com.artemis.Entity;
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.math.Vector2;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.client.systems.PlayerCameraSystem;
+import net.lapidist.colony.client.systems.input.BuildingPlacementHandler;
+import net.lapidist.colony.client.util.CameraUtils;
+import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.components.maps.MapComponent;
+import net.lapidist.colony.components.maps.TileComponent;
+import net.lapidist.colony.components.state.TilePos;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+@RunWith(GdxTestRunner.class)
+public class BuildingPlacementHandlerTest {
+
+    @Test
+    public void tapOnTileSendsBuildRequest() {
+        GameClient client = mock(GameClient.class);
+        PlayerCameraSystem cameraSystem = new PlayerCameraSystem();
+        BuildingPlacementHandler handler = new BuildingPlacementHandler(client, cameraSystem);
+
+        World world = new World(new WorldConfigurationBuilder().build());
+        Entity tile = world.createEntity();
+        TileComponent tc = new TileComponent();
+        tc.setX(0);
+        tc.setY(0);
+        tile.edit().add(tc);
+
+        java.util.Map<TilePos, Entity> tileMap = new HashMap<>();
+        tileMap.put(new TilePos(0, 0), tile);
+
+        MapComponent map = mock(MapComponent.class);
+        when(map.getTileMap()).thenReturn(tileMap);
+
+        ((OrthographicCamera) cameraSystem.getCamera()).position.set(
+                GameConstants.TILE_SIZE / 2f,
+                GameConstants.TILE_SIZE / 2f,
+                0f
+        );
+        cameraSystem.getCamera().update();
+
+        Vector2 screen = CameraUtils.worldToScreenCoords(cameraSystem.getViewport(), 0, 0);
+        boolean handled = handler.handleTap(screen.x, screen.y, map, world.getMapper(TileComponent.class));
+
+        assertTrue(handled);
+        verify(client).sendBuildRequest(any());
+        world.dispose();
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/client/input/KeyboardInputHandlerTest.java
+++ b/tests/src/net/lapidist/colony/tests/client/input/KeyboardInputHandlerTest.java
@@ -1,0 +1,54 @@
+package net.lapidist.colony.tests.client.input;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import net.lapidist.colony.client.systems.PlayerCameraSystem;
+import net.lapidist.colony.client.systems.input.KeyboardInputHandler;
+import net.lapidist.colony.settings.KeyAction;
+import net.lapidist.colony.settings.KeyBindings;
+import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(GdxTestRunner.class)
+public class KeyboardInputHandlerTest {
+    private static final float DT = 1f;
+    private static final float TOL = 0.001f;
+    private static final float CAMERA_SPEED = 400f;
+    private static final float OFFSET_X = 10f;
+    private static final float OFFSET_Y = 5f;
+
+    @Test
+    public void movesAndClampsCamera() {
+        PlayerCameraSystem cameraSystem = new PlayerCameraSystem();
+        ((OrthographicCamera) cameraSystem.getCamera()).position.set(0, 0, 0);
+
+        KeyBindings bindings = new KeyBindings();
+        KeyboardInputHandler handler = new KeyboardInputHandler(cameraSystem, bindings);
+
+        Input input = mock(Input.class);
+        Gdx.input = input;
+
+        when(input.isKeyPressed(bindings.getKey(KeyAction.MOVE_RIGHT))).thenReturn(true);
+        handler.handleKeyboardInput(DT);
+
+        assertEquals(CAMERA_SPEED * DT, cameraSystem.getCamera().position.x, TOL);
+        assertEquals(0f, cameraSystem.getCamera().position.y, TOL);
+
+        cameraSystem.getCamera().position.set(
+                GameConstants.MAP_WIDTH * GameConstants.TILE_SIZE + OFFSET_X,
+                GameConstants.MAP_HEIGHT * GameConstants.TILE_SIZE + OFFSET_Y,
+                0f
+        );
+        handler.clampCameraPosition();
+        assertEquals(GameConstants.MAP_WIDTH * GameConstants.TILE_SIZE,
+                cameraSystem.getCamera().position.x, TOL);
+        assertEquals(GameConstants.MAP_HEIGHT * GameConstants.TILE_SIZE,
+                cameraSystem.getCamera().position.y, TOL);
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/client/input/package-info.java
+++ b/tests/src/net/lapidist/colony/tests/client/input/package-info.java
@@ -1,0 +1,2 @@
+/** Tests for input handler classes. */
+package net.lapidist.colony.tests.client.input;


### PR DESCRIPTION
## Summary
- add unit tests for KeyboardInputHandler
- add unit tests for BuildingPlacementHandler

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_6849978b2ea08328b9a24dafcf9eb5f5