### PR TITLE
test: add MapScreen and Colony lifecycle coverage

### DIFF
--- a/tests/src/net/lapidist/colony/tests/client/ColonyTest.java
+++ b/tests/src/net/lapidist/colony/tests/client/ColonyTest.java
@@ -5,6 +5,14 @@ import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.client.screens.MainMenuScreen;
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.tests.GdxTestRunner;
+import net.lapidist.colony.client.events.GameInitEvent;
+import net.lapidist.colony.core.events.Events;
+import net.mostlyoriginal.api.event.common.EventSystem;
+import net.mostlyoriginal.api.event.common.Subscribe;
+import net.lapidist.colony.settings.Settings;
+import net.lapidist.colony.io.Paths;
+import net.lapidist.colony.i18n.I18n;
+import org.mockito.MockedStatic;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.MockedConstruction;
@@ -44,6 +52,56 @@ public class ColonyTest {
             verify(client).stop();
             verify(server).stop();
             assertSame(menuCons.constructed().get(0), colony.getScreen());
+        }
+    }
+
+    @Test
+    public void createInitialisesSettingsAndDispatchesEvent() throws Exception {
+        Colony colony = new Colony();
+        try (MockedStatic<Paths> pathsStatic = mockStatic(Paths.class);
+             MockedStatic<Settings> settingsStatic = mockStatic(Settings.class);
+             MockedStatic<I18n> i18nStatic = mockStatic(I18n.class);
+             MockedConstruction<MainMenuScreen> menuCons = mockConstruction(MainMenuScreen.class)) {
+            Settings settings = new Settings();
+            settingsStatic.when(Settings::load).thenReturn(settings);
+            Paths paths = mock(Paths.class);
+            pathsStatic.when(Paths::get).thenReturn(paths);
+
+            EventSystem system = new EventSystem();
+            Events.init(system);
+            final boolean[] initEvent = {false};
+            system.registerEvents(new Object() {
+                @Subscribe
+                public void on(final GameInitEvent e) {
+                    initEvent[0] = true;
+                }
+            });
+
+            colony.create();
+
+            settingsStatic.verify(Settings::load);
+            verify(paths).createGameFoldersIfNotExists();
+            i18nStatic.verify(() -> I18n.setLocale(settings.getLocale()));
+            assertSame(settings, colony.getSettings());
+            assertSame(menuCons.constructed().get(0), colony.getScreen());
+            assertTrue(initEvent[0]);
+        }
+    }
+
+    @Test
+    public void disposeStopsActiveConnectionsAndEvents() throws Exception {
+        Colony colony = new Colony();
+        try (MockedConstruction<GameServer> serverCons = mockConstruction(GameServer.class);
+             MockedConstruction<GameClient> clientCons = mockConstruction(GameClient.class)) {
+            colony.startGame("test");
+            GameServer server = serverCons.constructed().get(0);
+            GameClient client = clientCons.constructed().get(0);
+
+            colony.dispose();
+
+            verify(client).stop();
+            verify(server).stop();
+            assertNull(Events.getInstance());
         }
     }
 }

--- a/tests/src/net/lapidist/colony/tests/components/MapStateBuilderTest.java
+++ b/tests/src/net/lapidist/colony/tests/components/MapStateBuilderTest.java
@@ -1,0 +1,31 @@
+package net.lapidist.colony.tests.components;
+
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.ResourceData;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class MapStateBuilderTest {
+    @Test
+    public void builderCopiesValues() {
+        MapState.Builder builder = MapState.builder()
+                .version(2)
+                .name("n")
+                .saveName("s")
+                .autosaveName("a")
+                .description("d")
+                .tiles(new HashMap<>())
+                .buildings(List.of())
+                .playerResources(new ResourceData());
+        MapState state = builder.build();
+        assertEquals(2, state.version());
+        assertEquals("n", state.name());
+        assertEquals("s", state.saveName());
+        assertEquals("a", state.autosaveName());
+        assertEquals("d", state.description());
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/screens/MapScreenTest.java
+++ b/tests/src/net/lapidist/colony/tests/screens/MapScreenTest.java
@@ -1,0 +1,85 @@
+package net.lapidist.colony.tests.screens;
+
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import net.lapidist.colony.client.Colony;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.client.screens.MapScreen;
+import net.lapidist.colony.client.screens.MapScreenEventHandler;
+import net.lapidist.colony.client.screens.MapUi;
+import net.lapidist.colony.client.screens.MapUiBuilder;
+import net.lapidist.colony.client.screens.MapWorldBuilder;
+import net.lapidist.colony.client.ui.MinimapActor;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.settings.Settings;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+
+import java.lang.reflect.Field;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(GdxTestRunner.class)
+public class MapScreenTest {
+    private static final float DELTA = 0.5f;
+    private static final int WIDTH = 800;
+    private static final int HEIGHT = 600;
+
+    @Test
+    public void delegatesLifecycleToHandlerAndProcessesWorld() throws Exception {
+        Colony colony = mock(Colony.class);
+        Settings settings = new Settings();
+        when(colony.getSettings()).thenReturn(settings);
+        MapState state = new MapState();
+        GameClient client = mock(GameClient.class);
+        World world = mock(World.class);
+        MinimapActor minimap = mock(MinimapActor.class);
+
+        try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class);
+             MockedStatic<MapWorldBuilder> worldStatic = mockStatic(MapWorldBuilder.class);
+             MockedStatic<MapUiBuilder> uiStatic = mockStatic(MapUiBuilder.class)) {
+            worldStatic.when(() -> MapWorldBuilder.builder(eq(state), eq(client),
+                    any(Stage.class), eq(settings.getKeyBindings())))
+                    .thenReturn(new WorldConfigurationBuilder());
+            worldStatic.when(() -> MapWorldBuilder.build(any(), isNull(), eq(settings)))
+                    .thenReturn(world);
+            uiStatic.when(() -> MapUiBuilder.build(any(Stage.class), eq(world), eq(client), eq(colony)))
+                    .thenAnswer(inv -> new MapUi(
+                            inv.getArgument(0),
+                            minimap,
+                            mock(net.lapidist.colony.client.ui.ChatBox.class)
+                    ));
+
+            MapScreen screen = new MapScreen(colony, state, client);
+            MapScreenEventHandler handler = mock(MapScreenEventHandler.class);
+            Field f = MapScreen.class.getDeclaredField("events");
+            f.setAccessible(true);
+            f.set(screen, handler);
+
+            screen.render(DELTA);
+            screen.resize(WIDTH, HEIGHT);
+            screen.pause();
+            screen.resume();
+            screen.hide();
+            screen.show();
+            screen.dispose();
+
+            verify(handler).update();
+            verify(world).setDelta(DELTA);
+            verify(world).process();
+            verify(handler).resize(WIDTH, HEIGHT);
+            verify(handler).pause();
+            verify(handler).resume();
+            verify(handler).hide();
+            verify(handler).show();
+            verify(handler).dispose();
+            verify(world).dispose();
+            verify(minimap).dispose();
+        }
+    }
+}

--- a/tests/src/net/lapidist/colony/tests/server/GameServerConfigTest.java
+++ b/tests/src/net/lapidist/colony/tests/server/GameServerConfigTest.java
@@ -1,0 +1,25 @@
+package net.lapidist.colony.tests.server;
+
+import net.lapidist.colony.server.GameServerConfig;
+import net.lapidist.colony.map.MapGenerator;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class GameServerConfigTest {
+    private static final long INTERVAL = 10L;
+
+    @Test
+    public void builderSetsAllValues() {
+        MapGenerator gen = mock(MapGenerator.class);
+        GameServerConfig cfg = GameServerConfig.builder()
+                .saveName("save")
+                .autosaveInterval(INTERVAL)
+                .mapGenerator(gen)
+                .build();
+        assertEquals("save", cfg.getSaveName());
+        assertEquals(INTERVAL, cfg.getAutosaveInterval());
+        assertSame(gen, cfg.getMapGenerator());
+    }
+}


### PR DESCRIPTION
## Summary
- cover MapScreen lifecycle handling and world processing
- extend Colony tests for create/dispose
- test MapState builder and GameServerConfig builder

## Testing
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_68499dd0cc3883288b2a503dc93ac1ff