### PR TITLE
feat(i18n): translate building names

### DIFF
--- a/core/src/main/java/net/lapidist/colony/components/entities/BuildingComponent.java
+++ b/core/src/main/java/net/lapidist/colony/components/entities/BuildingComponent.java
@@ -1,23 +1,24 @@
 package net.lapidist.colony.components.entities;
 
 import net.lapidist.colony.components.AbstractBoundedComponent;
+import net.lapidist.colony.i18n.I18n;
 
 public class BuildingComponent extends AbstractBoundedComponent {
 
     public enum BuildingType {
-        HOUSE("House"),
-        MARKET("Market"),
-        FACTORY("Factory");
+        HOUSE("building.house"),
+        MARKET("building.market"),
+        FACTORY("building.factory");
 
-        private final String type;
+        private final String key;
 
-        BuildingType(final String typeToSet) {
-            this.type = typeToSet;
+        BuildingType(final String keyToSet) {
+            this.key = keyToSet;
         }
 
         @Override
         public String toString() {
-            return type;
+            return I18n.get(key);
         }
     }
     private BuildingType buildingType;

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -31,3 +31,6 @@ keybind.gather=Gather
 keybind.chat=Chat
 common.reset=Reset
 ui.resources=Resources
+building.house=House
+building.market=Market
+building.factory=Factory

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -30,3 +30,6 @@ keybind.gather=Sammeln
 keybind.chat=Chat
 common.reset=Zurücksetzen
 ui.resources=Rohstoffe
+building.house=Haus
+building.market=Markt
+building.factory=Fabrik

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -30,3 +30,6 @@ keybind.gather=Recolectar
 keybind.chat=Chat
 common.reset=Restablecer
 ui.resources=Recursos
+building.house=Casa
+building.market=Mercado
+building.factory=Fábrica

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -30,3 +30,6 @@ keybind.gather=Récolter
 keybind.chat=Chat
 common.reset=Réinitialiser
 ui.resources=Ressources
+building.house=Maison
+building.market=Marché
+building.factory=Usine

--- a/tests/src/test/java/net/lapidist/colony/tests/components/BuildingTypeTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/components/BuildingTypeTest.java
@@ -1,0 +1,19 @@
+package net.lapidist.colony.tests.components;
+
+import net.lapidist.colony.components.entities.BuildingComponent;
+import net.lapidist.colony.i18n.I18n;
+import org.junit.Test;
+
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+
+public class BuildingTypeTest {
+    @Test
+    public void returnsLocalizedString() {
+        I18n.setLocale(Locale.ENGLISH);
+        assertEquals("House", BuildingComponent.BuildingType.HOUSE.toString());
+        I18n.setLocale(Locale.FRENCH);
+        assertEquals("Maison", BuildingComponent.BuildingType.HOUSE.toString());
+    }
+}


### PR DESCRIPTION
## Summary
- add building translations for EN/DE/ES/FR
- localize `BuildingType` enum using `I18n.get`
- test new `BuildingType` behaviour

## Testing
- `./gradlew spotlessApply`
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_6849c867e8e483289281d0bd329e41bd