### PR TITLE
fix(render): handle case-insensitive asset lookup

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/renderers/DefaultAssetResolver.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/DefaultAssetResolver.java
@@ -7,20 +7,36 @@ import net.lapidist.colony.components.maps.TileComponent;
 public final class DefaultAssetResolver implements AssetResolver {
     @Override
     public String tileAsset(final String type) {
-        TileComponent.TileType tile = TileComponent.TileType.valueOf(type);
-        return switch (tile) {
-            case EMPTY -> "dirt0";
-            case GRASS -> "grass0";
-        };
+        if (type == null) {
+            return "dirt0";
+        }
+        try {
+            TileComponent.TileType tile = TileComponent.TileType
+                    .valueOf(type.toUpperCase(java.util.Locale.ROOT));
+            return switch (tile) {
+                case EMPTY -> "dirt0";
+                case GRASS -> "grass0";
+            };
+        } catch (IllegalArgumentException ex) {
+            return "dirt0";
+        }
     }
 
     @Override
     public String buildingAsset(final String type) {
-        BuildingComponent.BuildingType building = BuildingComponent.BuildingType.valueOf(type);
-        return switch (building) {
-            case HOUSE -> "house0";
-            case MARKET -> "house0";
-            case FACTORY -> "house0";
-        };
+        if (type == null) {
+            return "house0";
+        }
+        try {
+            BuildingComponent.BuildingType building = BuildingComponent.BuildingType
+                    .valueOf(type.toUpperCase(java.util.Locale.ROOT));
+            return switch (building) {
+                case HOUSE -> "house0";
+                case MARKET -> "house0";
+                case FACTORY -> "house0";
+            };
+        } catch (IllegalArgumentException ex) {
+            return "house0";
+        }
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/render/data/DefaultAssetResolverTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/render/data/DefaultAssetResolverTest.java
@@ -10,6 +10,8 @@ public class DefaultAssetResolverTest {
     public void returnsSpriteReferences() {
         DefaultAssetResolver resolver = new DefaultAssetResolver();
         assertEquals("grass0", resolver.tileAsset("GRASS"));
+        assertEquals("grass0", resolver.tileAsset("grass"));
         assertEquals("house0", resolver.buildingAsset("HOUSE"));
+        assertEquals("house0", resolver.buildingAsset("house"));
     }
 }


### PR DESCRIPTION
## Summary
- normalise tile and building type strings before lookup
- cover lowercase asset lookup in DefaultAssetResolverTest

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_6849ca89964c832897197d0c441ca0ec