### PR TITLE
feat(config): enlarge default map size

### DIFF
--- a/core/src/main/resources/game.conf
+++ b/core/src/main/resources/game.conf
@@ -1,6 +1,6 @@
 game {
-  mapWidth = 30
-  mapHeight = 30
+  mapWidth = 8192
+  mapHeight = 8192
   tileSize = 32
   autosaveInterval = 600000
   defaultSaveName = "autosave"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,8 +5,8 @@ controls the initial map size, autosave interval and server ports:
 
 ```hocon
 game {
-  mapWidth = 30
-  mapHeight = 30
+  mapWidth = 8192
+  mapHeight = 8192
   tileSize = 32
   autosaveInterval = 600000
   defaultSaveName = "autosave"

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -19,6 +19,8 @@ test {
     testLogging {
         events "PASSED", "STARTED", "FAILED", "SKIPPED"
     }
+    systemProperty 'game.mapWidth', '30'
+    systemProperty 'game.mapHeight', '30'
 }
 
 tasks.register('copyAssets', Copy) {


### PR DESCRIPTION
## Summary
- update default map dimensions to 8192x8192
- document new defaults
- keep tests fast by overriding map size in test config

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_6849d2bc16f88328a16f49565fded0e6