### PR TITLE
fix: handle large minimap tile counts

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/ui/MinimapCache.java
+++ b/client/src/main/java/net/lapidist/colony/client/ui/MinimapCache.java
@@ -53,12 +53,12 @@ final class MinimapCache implements Disposable {
         if (spriteCache != null) {
             spriteCache.dispose();
         }
-        spriteCache = new SpriteCache();
+        Array<Entity> tiles = mapMapper.get(map).getTiles();
+        spriteCache = new SpriteCache(tiles.size, true);
         spriteCache.setProjectionMatrix(new Matrix4().setToOrtho2D(0, 0, viewportWidth, viewportHeight));
         spriteCache.beginCache();
 
         AssetResolver resolver = new DefaultAssetResolver();
-        Array<Entity> tiles = mapMapper.get(map).getTiles();
         for (int i = 0; i < tiles.size; i++) {
             Entity tile = tiles.get(i);
             TileComponent tileComponent = tileMapper.get(tile);


### PR DESCRIPTION
## Summary
- size `SpriteCache` according to tile count in `MinimapCache`
- add regression test for large maps

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6849d9520c2883288cf08e503a72a605