### PR TITLE
feat: reuse vectors in rendering helpers

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
@@ -3,6 +3,7 @@ package net.lapidist.colony.client.renderers;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Array;
 import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.client.systems.CameraProvider;
@@ -33,14 +34,13 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
 
     @Override
     public void render(final Array<RenderBuilding> entities) {
+        Vector2 worldCoords = new Vector2();
+        Vector3 tmp = new Vector3();
         for (int i = 0; i < entities.size; i++) {
             RenderBuilding building = entities.get(i);
-            Vector2 worldCoords = CameraUtils.tileCoordsToWorldCoords(
-                    building.getX(),
-                    building.getY()
-            );
+            CameraUtils.tileCoordsToWorldCoords(building.getX(), building.getY(), worldCoords);
 
-            if (!CameraUtils.withinCameraView(cameraSystem.getViewport(), worldCoords)) {
+            if (!CameraUtils.withinCameraView(cameraSystem.getViewport(), worldCoords, tmp)) {
                 continue;
             }
 

--- a/client/src/main/java/net/lapidist/colony/client/renderers/ResourceRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/ResourceRenderer.java
@@ -3,6 +3,7 @@ package net.lapidist.colony.client.renderers;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Array;
 import net.lapidist.colony.client.systems.CameraProvider;
 import net.lapidist.colony.client.util.CameraUtils;
@@ -26,10 +27,12 @@ public final class ResourceRenderer implements EntityRenderer<RenderTile>, Dispo
 
     @Override
     public void render(final Array<RenderTile> entities) {
+        Vector2 worldCoords = new Vector2();
+        Vector3 tmp = new Vector3();
         for (int i = 0; i < entities.size; i++) {
             RenderTile tile = entities.get(i);
-            Vector2 worldCoords = CameraUtils.tileCoordsToWorldCoords(tile.getX(), tile.getY());
-            if (!CameraUtils.withinCameraView(cameraSystem.getViewport(), worldCoords)) {
+            CameraUtils.tileCoordsToWorldCoords(tile.getX(), tile.getY(), worldCoords);
+            if (!CameraUtils.withinCameraView(cameraSystem.getViewport(), worldCoords, tmp)) {
                 continue;
             }
             String text = tile.getWood() + "/" + tile.getStone() + "/" + tile.getFood();

--- a/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
@@ -3,6 +3,7 @@ package net.lapidist.colony.client.renderers;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Array;
 import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.client.systems.CameraProvider;
@@ -33,14 +34,13 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
 
     @Override
     public void render(final Array<RenderTile> entities) {
+        Vector2 worldCoords = new Vector2();
+        Vector3 tmp = new Vector3();
         for (int i = 0; i < entities.size; i++) {
             RenderTile tile = entities.get(i);
-            Vector2 worldCoords = CameraUtils.tileCoordsToWorldCoords(
-                    tile.getX(),
-                    tile.getY()
-            );
+            CameraUtils.tileCoordsToWorldCoords(tile.getX(), tile.getY(), worldCoords);
 
-            if (!CameraUtils.withinCameraView(cameraSystem.getViewport(), worldCoords)) {
+            if (!CameraUtils.withinCameraView(cameraSystem.getViewport(), worldCoords, tmp)) {
                 continue;
             }
 

--- a/client/src/main/java/net/lapidist/colony/client/systems/PlayerCameraSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/PlayerCameraSystem.java
@@ -44,34 +44,70 @@ public final class PlayerCameraSystem extends BaseSystem implements CameraProvid
             final float worldX,
             final float worldY
     ) {
-        return CameraUtils.worldToScreenCoords(viewport, worldX, worldY);
+        return CameraUtils.worldToScreenCoords(viewport, worldX, worldY, new Vector2());
+    }
+
+    public Vector2 cameraCoordsFromWorldCoords(
+            final float worldX,
+            final float worldY,
+            final Vector2 out
+    ) {
+        return CameraUtils.worldToScreenCoords(viewport, worldX, worldY, out);
     }
 
     public Vector2 worldCoordsFromCameraCoords(
             final float screenX,
             final float screenY
     ) {
-        return CameraUtils.screenToWorldCoords(viewport, screenX, screenY);
+        return CameraUtils.screenToWorldCoords(viewport, screenX, screenY, new Vector2());
+    }
+
+    public Vector2 worldCoordsFromCameraCoords(
+            final float screenX,
+            final float screenY,
+            final Vector2 out
+    ) {
+        return CameraUtils.screenToWorldCoords(viewport, screenX, screenY, out);
     }
 
     public Vector2 screenCoordsToWorldCoords(final float screenX, final float screenY) {
-        return CameraUtils.screenToWorldCoords(viewport, screenX, screenY);
+        return CameraUtils.screenToWorldCoords(viewport, screenX, screenY, new Vector2());
+    }
+
+    public Vector2 screenCoordsToWorldCoords(final float screenX, final float screenY, final Vector2 out) {
+        return CameraUtils.screenToWorldCoords(viewport, screenX, screenY, out);
     }
 
     public Vector2 tileCoordsToWorldCoords(final int x, final int y) {
-        return CameraUtils.tileCoordsToWorldCoords(x, y);
+        return CameraUtils.tileCoordsToWorldCoords(x, y, new Vector2());
     }
 
     public Vector2 tileCoordsToWorldCoords(final Vector2 coords) {
-        return CameraUtils.tileCoordsToWorldCoords(coords);
+        return CameraUtils.tileCoordsToWorldCoords(coords, new Vector2());
+    }
+
+    public Vector2 tileCoordsToWorldCoords(final int x, final int y, final Vector2 out) {
+        return CameraUtils.tileCoordsToWorldCoords(x, y, out);
+    }
+
+    public Vector2 tileCoordsToWorldCoords(final Vector2 coords, final Vector2 out) {
+        return CameraUtils.tileCoordsToWorldCoords(coords, out);
     }
 
     public Vector2 worldCoordsToTileCoords(final int x, final int y) {
-        return CameraUtils.worldCoordsToTileCoords(x, y);
+        return CameraUtils.worldCoordsToTileCoords(x, y, new Vector2());
     }
 
     public Vector2 worldCoordsToTileCoords(final Vector2 coords) {
-        return CameraUtils.worldCoordsToTileCoords(coords);
+        return CameraUtils.worldCoordsToTileCoords(coords, new Vector2());
+    }
+
+    public Vector2 worldCoordsToTileCoords(final int x, final int y, final Vector2 out) {
+        return CameraUtils.worldCoordsToTileCoords(x, y, out);
+    }
+
+    public Vector2 worldCoordsToTileCoords(final Vector2 coords, final Vector2 out) {
+        return CameraUtils.worldCoordsToTileCoords(coords, out);
     }
 
     @Override

--- a/client/src/main/java/net/lapidist/colony/client/util/CameraUtils.java
+++ b/client/src/main/java/net/lapidist/colony/client/util/CameraUtils.java
@@ -18,22 +18,40 @@ public final class CameraUtils {
     }
 
     public static Vector2 tileCoordsToWorldCoords(final int x, final int y) {
-        return new Vector2(x * GameConstants.TILE_SIZE, y * GameConstants.TILE_SIZE);
+        return tileCoordsToWorldCoords(x, y, new Vector2());
     }
 
     public static Vector2 tileCoordsToWorldCoords(final Vector2 coords) {
-        return tileCoordsToWorldCoords((int) coords.x, (int) coords.y);
+        return tileCoordsToWorldCoords((int) coords.x, (int) coords.y, new Vector2());
+    }
+
+    public static Vector2 tileCoordsToWorldCoords(final int x, final int y, final Vector2 out) {
+        out.set(x * GameConstants.TILE_SIZE, y * GameConstants.TILE_SIZE);
+        return out;
+    }
+
+    public static Vector2 tileCoordsToWorldCoords(final Vector2 coords, final Vector2 out) {
+        return tileCoordsToWorldCoords((int) coords.x, (int) coords.y, out);
     }
 
     public static Vector2 worldCoordsToTileCoords(final int x, final int y) {
-        return new Vector2(
-                Math.floorDiv(x, GameConstants.TILE_SIZE),
-                Math.floorDiv(y, GameConstants.TILE_SIZE)
-        );
+        return worldCoordsToTileCoords(x, y, new Vector2());
     }
 
     public static Vector2 worldCoordsToTileCoords(final Vector2 coords) {
-        return worldCoordsToTileCoords((int) coords.x, (int) coords.y);
+        return worldCoordsToTileCoords((int) coords.x, (int) coords.y, new Vector2());
+    }
+
+    public static Vector2 worldCoordsToTileCoords(final int x, final int y, final Vector2 out) {
+        out.set(
+                Math.floorDiv(x, GameConstants.TILE_SIZE),
+                Math.floorDiv(y, GameConstants.TILE_SIZE)
+        );
+        return out;
+    }
+
+    public static Vector2 worldCoordsToTileCoords(final Vector2 coords, final Vector2 out) {
+        return worldCoordsToTileCoords((int) coords.x, (int) coords.y, out);
     }
 
     public static Vector2 screenToWorldCoords(
@@ -41,7 +59,18 @@ public final class CameraUtils {
             final float screenX,
             final float screenY
     ) {
-        return viewport.unproject(new Vector2(screenX, screenY));
+        return screenToWorldCoords(viewport, screenX, screenY, new Vector2());
+    }
+
+    public static Vector2 screenToWorldCoords(
+            final Viewport viewport,
+            final float screenX,
+            final float screenY,
+            final Vector2 out
+    ) {
+        out.set(screenX, screenY);
+        viewport.unproject(out);
+        return out;
     }
 
     public static Vector2 worldToScreenCoords(
@@ -49,8 +78,29 @@ public final class CameraUtils {
             final float worldX,
             final float worldY
     ) {
-        Vector3 tmp = viewport.project(new Vector3(worldX, worldY, 0));
-        return new Vector2(tmp.x, tmp.y);
+        return worldToScreenCoords(viewport, worldX, worldY, new Vector2());
+    }
+
+    public static Vector2 worldToScreenCoords(
+            final Viewport viewport,
+            final float worldX,
+            final float worldY,
+            final Vector2 out
+    ) {
+        return worldToScreenCoords(viewport, worldX, worldY, out, new Vector3());
+    }
+
+    public static Vector2 worldToScreenCoords(
+            final Viewport viewport,
+            final float worldX,
+            final float worldY,
+            final Vector2 out,
+            final Vector3 tmp
+    ) {
+        tmp.set(worldX, worldY, 0);
+        viewport.project(tmp);
+        out.set(tmp.x, tmp.y);
+        return out;
     }
 
     public static Vector3 worldToScreenCoords3D(
@@ -73,7 +123,16 @@ public final class CameraUtils {
             final Viewport viewport,
             final Vector2 worldCoords
     ) {
-        Vector3 tmp = viewport.project(new Vector3(worldCoords.x, worldCoords.y, 0));
+        return withinCameraView(viewport, worldCoords, new Vector3());
+    }
+
+    public static boolean withinCameraView(
+            final Viewport viewport,
+            final Vector2 worldCoords,
+            final Vector3 tmp
+    ) {
+        tmp.set(worldCoords.x, worldCoords.y, 0);
+        viewport.project(tmp);
         return !(tmp.x > Gdx.graphics.getWidth() || tmp.y > Gdx.graphics.getHeight());
     }
 

--- a/tests/src/test/java/net/lapidist/colony/tests/client/systems/PlayerCameraSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/systems/PlayerCameraSystemTest.java
@@ -1,0 +1,40 @@
+package net.lapidist.colony.tests.client.systems;
+
+import com.badlogic.gdx.math.Vector2;
+import net.lapidist.colony.client.systems.PlayerCameraSystem;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertSame;
+
+@RunWith(GdxTestRunner.class)
+public class PlayerCameraSystemTest {
+
+    @Test
+    public void reuseVectorConversions() {
+        PlayerCameraSystem cameraSystem = new PlayerCameraSystem();
+        Vector2 out = new Vector2();
+
+        Vector2 result = cameraSystem.cameraCoordsFromWorldCoords(0f, 0f, out);
+        assertSame(out, result);
+
+        result = cameraSystem.worldCoordsFromCameraCoords(0f, 0f, out);
+        assertSame(out, result);
+
+        result = cameraSystem.screenCoordsToWorldCoords(0f, 0f, out);
+        assertSame(out, result);
+
+        result = cameraSystem.tileCoordsToWorldCoords(0, 0, out);
+        assertSame(out, result);
+
+        result = cameraSystem.tileCoordsToWorldCoords(new Vector2(), out);
+        assertSame(out, result);
+
+        result = cameraSystem.worldCoordsToTileCoords(0, 0, out);
+        assertSame(out, result);
+
+        result = cameraSystem.worldCoordsToTileCoords(new Vector2(), out);
+        assertSame(out, result);
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/client/systems/package-info.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/systems/package-info.java
@@ -1,0 +1,2 @@
+/** Tests for client systems. */
+package net.lapidist.colony.tests.client.systems;

--- a/tests/src/test/java/net/lapidist/colony/tests/client/util/CameraUtilsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/util/CameraUtilsTest.java
@@ -3,6 +3,7 @@ package net.lapidist.colony.tests.client.util;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.viewport.ExtendViewport;
 import net.lapidist.colony.client.util.CameraUtils;
 import net.lapidist.colony.components.GameConstants;
@@ -27,6 +28,13 @@ public class CameraUtilsTest {
         assertEquals(new Vector2(TILE_X * GameConstants.TILE_SIZE, TILE_Y * GameConstants.TILE_SIZE), world);
         Vector2 tile = CameraUtils.worldCoordsToTileCoords(world);
         assertEquals(new Vector2(TILE_X, TILE_Y), tile);
+
+        Vector2 out = new Vector2();
+        CameraUtils.tileCoordsToWorldCoords(TILE_X, TILE_Y, out);
+        assertEquals(world, out);
+        Vector2 back = new Vector2();
+        CameraUtils.worldCoordsToTileCoords((int) out.x, (int) out.y, back);
+        assertEquals(tile, back);
     }
 
     @Test
@@ -39,5 +47,21 @@ public class CameraUtilsTest {
         CameraUtils.getViewBounds(cam, vp, out);
         assertEquals(POS - vp.getWorldWidth() / 2f, out.x, TOL);
         assertEquals(POS - vp.getWorldHeight() / 2f, out.y, TOL);
+    }
+
+    @Test
+    public void screenWorldConversionsReuseVectors() {
+        OrthographicCamera cam = new OrthographicCamera();
+        ExtendViewport vp = new ExtendViewport(VIEW_WIDTH, VIEW_HEIGHT, cam);
+        Vector2 out = new Vector2();
+        Vector3 tmp = new Vector3();
+
+        Vector2 result = CameraUtils.screenToWorldCoords(vp, 0f, 0f, out);
+        assertSame(out, result);
+
+        result = CameraUtils.worldToScreenCoords(vp, 0f, 0f, out, tmp);
+        assertSame(out, result);
+
+        assertTrue(CameraUtils.withinCameraView(vp, out, tmp));
     }
 }


### PR DESCRIPTION
## Summary
- optimize CameraUtils conversion helpers by reusing caller-provided vectors
- stop per-frame allocations in tile, building, and resource renderers
- expose additional overloads in PlayerCameraSystem for vector reuse
- test new CameraUtils overloads

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test check`


------
https://chatgpt.com/codex/tasks/task_e_6849e7f9bd4c832896938ccf0db0332d