### PR TITLE
feat(client): load assets asynchronously

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/core/io/ResourceLoader.java
+++ b/client/src/main/java/net/lapidist/colony/client/core/io/ResourceLoader.java
@@ -74,4 +74,27 @@ public interface ResourceLoader extends Disposable {
      * @return matching model or {@code null}
      */
     Model findModel(String name);
+
+    /**
+     * Progress the asynchronous loading process once.
+     *
+     * @return {@code true} when all assets are loaded
+     */
+    boolean update();
+
+    /**
+     * Current loading progress between 0 and 1.
+     *
+     * @return progress value
+     */
+    float getProgress();
+
+    /**
+     * Block until all queued assets have finished loading.
+     */
+    default void finishLoading() {
+        while (!update()) {
+            Thread.yield();
+        }
+    }
 }

--- a/client/src/main/java/net/lapidist/colony/client/renderers/ModelBatchMapRendererFactory.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/ModelBatchMapRendererFactory.java
@@ -16,9 +16,22 @@ public final class ModelBatchMapRendererFactory implements MapRendererFactory {
     private final FileLocation location;
     private final String modelPath;
     private final ResourceLoader loader;
+    private final java.util.function.Consumer<Float> progressCallback;
 
     public ModelBatchMapRendererFactory() {
-        this(new G3dResourceLoader(), FileLocation.INTERNAL, "models/cube.g3dj");
+        this(new G3dResourceLoader(), FileLocation.INTERNAL, "models/cube.g3dj", null);
+    }
+
+    public ModelBatchMapRendererFactory(
+            final ResourceLoader loaderToSet,
+            final FileLocation locationToSet,
+            final String path,
+            final java.util.function.Consumer<Float> callback
+    ) {
+        this.location = locationToSet;
+        this.modelPath = path;
+        this.loader = loaderToSet;
+        this.progressCallback = callback;
     }
 
     public ModelBatchMapRendererFactory(
@@ -26,9 +39,7 @@ public final class ModelBatchMapRendererFactory implements MapRendererFactory {
             final FileLocation locationToSet,
             final String path
     ) {
-        this.location = locationToSet;
-        this.modelPath = path;
-        this.loader = loaderToSet;
+        this(loaderToSet, locationToSet, path, null);
     }
 
     @Override
@@ -36,6 +47,14 @@ public final class ModelBatchMapRendererFactory implements MapRendererFactory {
         try {
             loader.loadTextures(location, "textures/textures.atlas");
             loader.loadModel(location, modelPath);
+            while (!loader.update()) {
+                if (progressCallback != null) {
+                    progressCallback.accept(loader.getProgress());
+                }
+            }
+            if (progressCallback != null) {
+                progressCallback.accept(1f);
+            }
         } catch (Exception e) {
             // ignore errors in headless tests
         }

--- a/client/src/main/java/net/lapidist/colony/client/ui/MinimapActor.java
+++ b/client/src/main/java/net/lapidist/colony/client/ui/MinimapActor.java
@@ -102,6 +102,7 @@ public final class MinimapActor extends Actor implements Disposable {
         setSize(DEFAULT_SIZE, DEFAULT_SIZE);
         try {
             resourceLoader.loadTextures(FileLocation.INTERNAL, "textures/textures.atlas", graphicsSettings);
+            resourceLoader.finishLoading();
         } catch (IOException e) {
             // ignore loading errors in headless tests
         }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/MapRendererFactoryTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/MapRendererFactoryTest.java
@@ -22,6 +22,7 @@ public class MapRendererFactoryTest {
 
     private static final class DummyLoader implements ResourceLoader {
         private boolean loaded;
+        private boolean updated;
 
         @Override
         public void loadTextures(
@@ -29,12 +30,12 @@ public class MapRendererFactoryTest {
                 final String path,
                 final net.lapidist.colony.settings.GraphicsSettings settings
         ) {
-            loaded = true;
+            // start load
         }
 
         @Override
         public void loadTextures(final FileLocation location, final String path) {
-            loaded = true;
+            // start load
         }
 
         @Override
@@ -62,6 +63,18 @@ public class MapRendererFactoryTest {
         }
 
         @Override
+        public boolean update() {
+            updated = true;
+            loaded = true;
+            return true;
+        }
+
+        @Override
+        public float getProgress() {
+            return 1f;
+        }
+
+        @Override
         public void dispose() {
         }
     }
@@ -74,15 +87,19 @@ public class MapRendererFactoryTest {
                 .build());
         try (MockedConstruction<SpriteBatch> ignored =
                 mockConstruction(SpriteBatch.class)) {
+            java.util.concurrent.atomic.AtomicInteger progressCalls = new java.util.concurrent.atomic.AtomicInteger();
             MapRendererFactory factory = new SpriteMapRendererFactory(
                     loader,
                     FileLocation.INTERNAL,
-                    "textures/textures.atlas"
+                    "textures/textures.atlas",
+                    p -> progressCalls.incrementAndGet()
             );
             MapRenderer renderer = factory.create(world);
 
             assertNotNull(renderer);
             assertTrue(loader.loaded);
+            assertTrue(loader.updated);
+            assertTrue(progressCalls.get() > 0);
         }
         world.dispose();
     }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/MapRendererFactoryTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/MapRendererFactoryTest.java
@@ -103,4 +103,26 @@ public class MapRendererFactoryTest {
         }
         world.dispose();
     }
+
+    @Test
+    public void createWithoutCallback() {
+        DummyLoader loader = new DummyLoader();
+        World world = new World(new WorldConfigurationBuilder()
+                .with(new PlayerCameraSystem())
+                .build());
+        try (MockedConstruction<SpriteBatch> ignored =
+                mockConstruction(SpriteBatch.class)) {
+            MapRendererFactory factory = new SpriteMapRendererFactory(
+                    loader,
+                    FileLocation.INTERNAL,
+                    "textures/textures.atlas"
+            );
+            MapRenderer renderer = factory.create(world);
+
+            assertNotNull(renderer);
+            assertTrue(loader.loaded);
+            assertTrue(loader.updated);
+        }
+        world.dispose();
+    }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/ModelBatchMapRendererFactoryTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/ModelBatchMapRendererFactoryTest.java
@@ -5,16 +5,77 @@ import com.artemis.WorldConfigurationBuilder;
 import com.badlogic.gdx.graphics.g3d.ModelBatch;
 import net.lapidist.colony.client.renderers.MapRenderer;
 import net.lapidist.colony.client.renderers.ModelBatchMapRendererFactory;
+import net.lapidist.colony.client.core.io.FileLocation;
+import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.mockito.MockedConstruction;
 import static org.mockito.Mockito.mockConstruction;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 @RunWith(GdxTestRunner.class)
 public class ModelBatchMapRendererFactoryTest {
+
+    private static final class DummyLoader implements ResourceLoader {
+        private boolean loaded;
+        private boolean updated;
+
+        @Override
+        public void loadTextures(
+                final FileLocation location,
+                final String path,
+                final net.lapidist.colony.settings.GraphicsSettings settings
+        ) {
+            // start load
+        }
+
+        @Override
+        public void loadTextures(final FileLocation location, final String path) {
+            // start load
+        }
+
+        @Override
+        public void loadModel(final FileLocation location, final String path) {
+        }
+
+        @Override
+        public boolean isLoaded() {
+            return loaded;
+        }
+
+        @Override
+        public com.badlogic.gdx.graphics.g2d.TextureAtlas getAtlas() {
+            return null;
+        }
+
+        @Override
+        public com.badlogic.gdx.graphics.g2d.TextureRegion findRegion(final String name) {
+            return null;
+        }
+
+        @Override
+        public com.badlogic.gdx.graphics.g3d.Model findModel(final String name) {
+            return null;
+        }
+
+        @Override
+        public boolean update() {
+            updated = true;
+            loaded = true;
+            return true;
+        }
+
+        @Override
+        public float getProgress() {
+            return 1f;
+        }
+
+        @Override
+        public void dispose() {
+        }
+    }
 
     @Test
     public void createsRendererWithResources() {
@@ -23,6 +84,28 @@ public class ModelBatchMapRendererFactoryTest {
             ModelBatchMapRendererFactory factory = new ModelBatchMapRendererFactory();
             MapRenderer renderer = factory.create(world);
             assertNotNull(renderer);
+        }
+        world.dispose();
+    }
+
+    @Test
+    public void createsRendererWithProgressCallback() {
+        DummyLoader loader = new DummyLoader();
+        World world = new World(new WorldConfigurationBuilder().build());
+        try (MockedConstruction<ModelBatch> ignored = mockConstruction(ModelBatch.class)) {
+            java.util.concurrent.atomic.AtomicInteger progressCalls = new java.util.concurrent.atomic.AtomicInteger();
+            ModelBatchMapRendererFactory factory = new ModelBatchMapRendererFactory(
+                    loader,
+                    FileLocation.INTERNAL,
+                    "models/cube.g3dj",
+                    p -> progressCalls.incrementAndGet()
+            );
+            MapRenderer renderer = factory.create(world);
+
+            assertNotNull(renderer);
+            assertTrue(loader.loaded);
+            assertTrue(loader.updated);
+            assertTrue(progressCalls.get() > 0);
         }
         world.dispose();
     }

--- a/tests/src/test/java/net/lapidist/colony/tests/core/io/G3dResourceLoaderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/io/G3dResourceLoaderTest.java
@@ -19,6 +19,9 @@ public class G3dResourceLoaderTest {
         ResourceLoader loader = new G3dResourceLoader();
         loader.loadTextures(FileLocation.INTERNAL, "textures/textures.atlas");
         loader.loadModel(FileLocation.INTERNAL, "models/cube.g3dj");
+        while (!loader.update()) {
+            assertTrue(loader.getProgress() < 1f);
+        }
 
         assertTrue(loader.isLoaded());
         assertNotNull(loader.getAtlas());

--- a/tests/src/test/java/net/lapidist/colony/tests/core/io/G3dResourceLoaderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/io/G3dResourceLoaderTest.java
@@ -33,4 +33,20 @@ public class G3dResourceLoaderTest {
         ResourceLoader loader = new G3dResourceLoader();
         loader.loadModel(FileLocation.INTERNAL, "models/missing.g3dj");
     }
+
+    @Test
+    public void updateReturnsFalseWhenNotStarted() {
+        ResourceLoader loader = new G3dResourceLoader();
+
+        assertFalse(loader.update());
+        assertEquals(0f, loader.getProgress(), 0f);
+        assertNull(loader.findModel("nothing"));
+    }
+
+    @Test
+    public void findModelBeforeLoadingReturnsNull() {
+        ResourceLoader loader = new G3dResourceLoader();
+
+        assertNull(loader.findModel("models/cube.g3dj"));
+    }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/core/io/ResourceLoaderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/io/ResourceLoaderTest.java
@@ -29,6 +29,9 @@ public class ResourceLoaderTest {
                 "textures/textures.atlas",
                 gs
         );
+        while (!resourceLoader.update()) {
+            assertTrue(resourceLoader.getProgress() < 1f);
+        }
         assertTrue(resourceLoader.isLoaded());
     }
 
@@ -40,6 +43,7 @@ public class ResourceLoaderTest {
         ResourceLoader resourceLoader = new TextureAtlasResourceLoader();
 
         resourceLoader.loadTextures(FileLocation.INTERNAL, "textures/textures.atlas", gs);
+        resourceLoader.finishLoading();
 
         for (Texture texture : resourceLoader.getAtlas().getTextures()) {
             assertEquals(Texture.TextureFilter.MipMapLinearLinear, texture.getMinFilter());

--- a/tests/src/test/java/net/lapidist/colony/tests/core/io/ResourceLoaderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/io/ResourceLoaderTest.java
@@ -50,4 +50,14 @@ public class ResourceLoaderTest {
             assertTrue(texture.getAnisotropicFilter() >= 1f);
         }
     }
+
+    @Test
+    public void updateReturnsFalseWhenNotStarted() {
+        ResourceLoader loader = new TextureAtlasResourceLoader();
+
+        assertFalse(loader.update());
+        assertEquals(0f, loader.getProgress(), 0f);
+        assertFalse(loader.isLoaded());
+        assertNull(loader.findRegion("missing"));
+    }
 }


### PR DESCRIPTION
## Summary
- load textures and models asynchronously via `AssetManager`
- show loading progress when creating map renderers
- wait for minimap textures to load before use
- test async model and texture loading

## Testing
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_6849e837d5308328952a4b64e43c961d