### PR TITLE
feat(client): optimize resource rendering

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/renderers/ResourceRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/ResourceRenderer.java
@@ -2,6 +2,7 @@ package net.lapidist.colony.client.renderers;
 
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.g2d.GlyphLayout;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Array;
@@ -15,6 +16,8 @@ public final class ResourceRenderer implements EntityRenderer<RenderTile>, Dispo
     private final SpriteBatch spriteBatch;
     private final CameraProvider cameraSystem;
     private final BitmapFont font = new BitmapFont();
+    private final GlyphLayout layout = new GlyphLayout();
+    private final StringBuilder textBuilder = new StringBuilder();
     private static final float OFFSET_Y = 8f;
 
     public ResourceRenderer(
@@ -31,12 +34,22 @@ public final class ResourceRenderer implements EntityRenderer<RenderTile>, Dispo
         Vector3 tmp = new Vector3();
         for (int i = 0; i < entities.size; i++) {
             RenderTile tile = entities.get(i);
+            if (!tile.isSelected()) {
+                continue;
+            }
             CameraUtils.tileCoordsToWorldCoords(tile.getX(), tile.getY(), worldCoords);
             if (!CameraUtils.withinCameraView(cameraSystem.getViewport(), worldCoords, tmp)) {
                 continue;
             }
-            String text = tile.getWood() + "/" + tile.getStone() + "/" + tile.getFood();
-            font.draw(spriteBatch, text, worldCoords.x, worldCoords.y + OFFSET_Y);
+            textBuilder.setLength(0);
+            textBuilder
+                    .append(tile.getWood())
+                    .append('/')
+                    .append(tile.getStone())
+                    .append('/')
+                    .append(tile.getFood());
+            layout.setText(font, textBuilder);
+            font.draw(spriteBatch, layout, worldCoords.x, worldCoords.y + OFFSET_Y);
         }
     }
 

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/ResourceRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/ResourceRendererTest.java
@@ -2,6 +2,9 @@ package net.lapidist.colony.tests.client.renderers;
 
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.GlyphLayout;
+import org.mockito.ArgumentCaptor;
 import com.badlogic.gdx.utils.viewport.Viewport;
 import com.badlogic.gdx.math.Vector3;
 import net.lapidist.colony.client.renderers.ResourceRenderer;
@@ -11,6 +14,7 @@ import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
 
 @RunWith(GdxTestRunner.class)
 public class ResourceRendererTest {
@@ -41,6 +45,77 @@ public class ResourceRendererTest {
                 .build());
 
         renderer.render(tiles);
+        renderer.dispose();
+    }
+
+    @Test
+    public void drawsResourceTextForSelectedTile() throws Exception {
+        SpriteBatch batch = mock(SpriteBatch.class);
+        CameraProvider camera = mock(CameraProvider.class);
+        Viewport viewport = mock(Viewport.class);
+        when(camera.getViewport()).thenReturn(viewport);
+        when(viewport.project(any(Vector3.class))).thenReturn(new Vector3());
+
+        ResourceRenderer renderer = new ResourceRenderer(batch, camera);
+
+        BitmapFont font = spy(new BitmapFont());
+        GlyphLayout layout = spy(new GlyphLayout());
+        java.lang.reflect.Field fontField = ResourceRenderer.class.getDeclaredField("font");
+        fontField.setAccessible(true);
+        fontField.set(renderer, font);
+        java.lang.reflect.Field layoutField = ResourceRenderer.class.getDeclaredField("layout");
+        layoutField.setAccessible(true);
+        layoutField.set(renderer, layout);
+
+        Array<RenderTile> tiles = new Array<>();
+        tiles.add(RenderTile.builder()
+                .x(0)
+                .y(0)
+                .tileType("GRASS")
+                .selected(true)
+                .wood(WOOD)
+                .stone(STONE)
+                .food(FOOD)
+                .build());
+
+        renderer.render(tiles);
+
+        ArgumentCaptor<CharSequence> captor = ArgumentCaptor.forClass(CharSequence.class);
+        verify(layout).setText(eq(font), captor.capture());
+        assertEquals(WOOD + "/" + STONE + "/" + FOOD, captor.getValue().toString());
+        verify(font).draw(eq(batch), eq(layout), anyFloat(), anyFloat());
+        renderer.dispose();
+    }
+
+    @Test
+    public void skipsUnselectedTiles() throws Exception {
+        SpriteBatch batch = mock(SpriteBatch.class);
+        CameraProvider camera = mock(CameraProvider.class);
+        Viewport viewport = mock(Viewport.class);
+        when(camera.getViewport()).thenReturn(viewport);
+        when(viewport.project(any(Vector3.class))).thenReturn(new Vector3());
+
+        ResourceRenderer renderer = new ResourceRenderer(batch, camera);
+
+        BitmapFont font = spy(new BitmapFont());
+        java.lang.reflect.Field fontField = ResourceRenderer.class.getDeclaredField("font");
+        fontField.setAccessible(true);
+        fontField.set(renderer, font);
+
+        Array<RenderTile> tiles = new Array<>();
+        tiles.add(RenderTile.builder()
+                .x(0)
+                .y(0)
+                .tileType("GRASS")
+                .selected(false)
+                .wood(WOOD)
+                .stone(STONE)
+                .food(FOOD)
+                .build());
+
+        renderer.render(tiles);
+
+        verify(font, never()).draw(any(SpriteBatch.class), any(GlyphLayout.class), anyFloat(), anyFloat());
         renderer.dispose();
     }
 }


### PR DESCRIPTION
## Summary
- use `GlyphLayout` and `StringBuilder` to avoid string allocations
- render resource text only for selected tiles
- verify rendering logic through new tests

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6849ee1ec6d48328acf4229647ff395e