### PR TITLE
feat(client): add decorative outline to minimap

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/ui/MinimapActor.java
+++ b/client/src/main/java/net/lapidist/colony/client/ui/MinimapActor.java
@@ -32,6 +32,7 @@ public final class MinimapActor extends Actor implements Disposable {
     private final World world;
     private final ResourceLoader resourceLoader = new TextureAtlasResourceLoader();
     private ViewportOverlayRenderer overlayRenderer;
+    private MinimapOutlineRenderer outlineRenderer;
     private ComponentMapper<MapComponent> mapMapper;
     private ComponentMapper<TileComponent> tileMapper;
     private Entity map;
@@ -109,6 +110,7 @@ public final class MinimapActor extends Actor implements Disposable {
         mapWidthWorld = -1;
         mapHeightWorld = -1;
         cacheInvalidated = true;
+        outlineRenderer = new MinimapOutlineRenderer();
     }
 
     @Override
@@ -144,6 +146,9 @@ public final class MinimapActor extends Actor implements Disposable {
         if (cameraSystem != null && overlayRenderer != null) {
             overlayRenderer.render(batch, mapWidthWorld, mapHeightWorld, scaleX, scaleY, getX(), getY());
         }
+        if (outlineRenderer != null) {
+            outlineRenderer.render(batch, getX(), getY(), getWidth(), getHeight());
+        }
     }
 
     @Override
@@ -151,6 +156,9 @@ public final class MinimapActor extends Actor implements Disposable {
         resourceLoader.dispose();
         if (overlayRenderer != null) {
             overlayRenderer.dispose();
+        }
+        if (outlineRenderer != null) {
+            outlineRenderer.dispose();
         }
         cache.dispose();
     }

--- a/client/src/main/java/net/lapidist/colony/client/ui/MinimapOutlineRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/ui/MinimapOutlineRenderer.java
@@ -1,0 +1,56 @@
+package net.lapidist.colony.client.ui;
+
+import com.badlogic.gdx.Application;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.utils.Disposable;
+
+/**
+ * Draws a decorative outline around the minimap.
+ */
+final class MinimapOutlineRenderer implements Disposable {
+
+    private static final float INNER_OFFSET = 1f;
+    private static final float OUTER_OFFSET = 2f;
+
+    private ShapeRenderer shapeRenderer;
+
+    MinimapOutlineRenderer() {
+        if (Gdx.app != null && Gdx.app.getType() != Application.ApplicationType.HeadlessDesktop) {
+            shapeRenderer = new ShapeRenderer();
+        }
+    }
+
+    void render(
+            final Batch batch,
+            final float x,
+            final float y,
+            final float width,
+            final float height
+    ) {
+        if (shapeRenderer == null) {
+            return;
+        }
+        batch.end();
+        shapeRenderer.setProjectionMatrix(((SpriteBatch) batch).getProjectionMatrix());
+        shapeRenderer.begin(ShapeRenderer.ShapeType.Line);
+        shapeRenderer.setColor(Color.BLACK);
+        shapeRenderer.rect(x - INNER_OFFSET, y - INNER_OFFSET,
+                width + INNER_OFFSET * 2f, height + INNER_OFFSET * 2f);
+        shapeRenderer.setColor(Color.WHITE);
+        shapeRenderer.rect(x - OUTER_OFFSET, y - OUTER_OFFSET,
+                width + OUTER_OFFSET * 2f, height + OUTER_OFFSET * 2f);
+        shapeRenderer.end();
+        batch.begin();
+    }
+
+    @Override
+    public void dispose() {
+        if (shapeRenderer != null) {
+            shapeRenderer.dispose();
+        }
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/client/ui/MinimapActorTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/ui/MinimapActorTest.java
@@ -71,6 +71,11 @@ public class MinimapActorTest {
             rf.setAccessible(true);
             rf.set(actor, renderer);
 
+            MinimapOutlineRenderer outline = mock(MinimapOutlineRenderer.class);
+            java.lang.reflect.Field of = MinimapActor.class.getDeclaredField("outlineRenderer");
+            of.setAccessible(true);
+            of.set(actor, outline);
+
             SpriteBatch batch = new SpriteBatch();
 
             actor.invalidateCache();
@@ -85,10 +90,13 @@ public class MinimapActorTest {
                     same(batch), anyFloat(), anyFloat(), anyFloat(), anyFloat(),
                     eq(actor.getX()), eq(actor.getY())
             );
+            verify(outline).render(batch, actor.getX(), actor.getY(), actor.getWidth(), actor.getHeight());
 
             actor.dispose();
             batch.dispose();
             stage.dispose();
+
+            verify(outline).dispose();
         }
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/client/ui/MinimapOutlineRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/ui/MinimapOutlineRendererTest.java
@@ -1,0 +1,69 @@
+package net.lapidist.colony.client.ui;
+
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.math.Matrix4;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Field;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link MinimapOutlineRenderer}.
+ */
+@RunWith(GdxTestRunner.class)
+public class MinimapOutlineRendererTest {
+
+    private static final float X = 1f;
+    private static final float Y = 2f;
+    private static final float W = 3f;
+    private static final float H = 4f;
+
+    private static void injectRenderer(
+            final MinimapOutlineRenderer renderer,
+            final ShapeRenderer sr
+    ) throws Exception {
+        Field f = MinimapOutlineRenderer.class.getDeclaredField("shapeRenderer");
+        f.setAccessible(true);
+        f.set(renderer, sr);
+    }
+
+    @Test
+    public void drawsOutlineWhenRendererPresent() throws Exception {
+        MinimapOutlineRenderer renderer = new MinimapOutlineRenderer();
+        ShapeRenderer sr = mock(ShapeRenderer.class);
+        injectRenderer(renderer, sr);
+        SpriteBatch batch = mock(SpriteBatch.class);
+        Matrix4 proj = new Matrix4();
+        when(batch.getProjectionMatrix()).thenReturn(proj);
+
+        renderer.render(batch, X, Y, W, H);
+
+        verify(batch).end();
+        verify(sr).setProjectionMatrix(proj);
+        verify(sr).begin(ShapeRenderer.ShapeType.Line);
+        verify(sr, times(2)).rect(anyFloat(), anyFloat(), anyFloat(), anyFloat());
+        verify(sr).end();
+        verify(batch).begin();
+    }
+
+    @Test
+    public void skipsRenderingWhenNull() {
+        MinimapOutlineRenderer renderer = new MinimapOutlineRenderer();
+        SpriteBatch batch = mock(SpriteBatch.class);
+        renderer.render(batch, X, X, Y, Y);
+        verifyNoInteractions(batch);
+    }
+
+    @Test
+    public void disposesRenderer() throws Exception {
+        MinimapOutlineRenderer renderer = new MinimapOutlineRenderer();
+        ShapeRenderer sr = mock(ShapeRenderer.class);
+        injectRenderer(renderer, sr);
+        renderer.dispose();
+        verify(sr).dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- draw border around minimap
- add `MinimapOutlineRenderer` helper
- test minimap outline rendering
- verify outline usage in `MinimapActor`

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6849f03bac5c832893842df91a589d38