### PR TITLE
feat: include resource type in gather requests

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/systems/InputSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/InputSystem.java
@@ -110,9 +110,13 @@ public final class InputSystem extends BaseSystem {
             for (int i = 0; i < selectedTiles.size; i++) {
                 var tile = selectedTiles.get(i);
                 TileComponent tc = tileMapper.get(tile);
-                ResourceGatherRequestData msg = new ResourceGatherRequestData(
-                        tc.getX(), tc.getY(), ResourceType.WOOD.name());
-                client.sendGatherRequest(msg);
+                var rc = resourceMapper.get(tile);
+                ResourceType type = getResourceType(rc);
+                if (type != null) {
+                    ResourceGatherRequestData msg = new ResourceGatherRequestData(
+                            tc.getX(), tc.getY(), type.name());
+                    client.sendGatherRequest(msg);
+                }
             }
         }
     }
@@ -136,9 +140,10 @@ public final class InputSystem extends BaseSystem {
                     .ifPresent(tile -> {
                         TileComponent tc = tileMapper.get(tile);
                         var rc = resourceMapper.get(tile);
-                        if (rc.getWood() > 0) {
+                        ResourceType type = getResourceType(rc);
+                        if (type != null) {
                             ResourceGatherRequestData msg = new ResourceGatherRequestData(
-                                    tc.getX(), tc.getY(), ResourceType.WOOD.name());
+                                    tc.getX(), tc.getY(), type.name());
                             client.sendGatherRequest(msg);
                         }
                     });
@@ -154,6 +159,17 @@ public final class InputSystem extends BaseSystem {
 
     public boolean zoom(final float initialDistance, final float distance) {
         return gestureHandler.zoom(initialDistance, distance);
+    }
+
+    private ResourceType getResourceType(final net.lapidist.colony.components.resources.ResourceComponent rc) {
+        if (rc.getWood() > 0) {
+            return ResourceType.WOOD;
+        } else if (rc.getStone() > 0) {
+            return ResourceType.STONE;
+        } else if (rc.getFood() > 0) {
+            return ResourceType.FOOD;
+        }
+        return null;
     }
 
     public void setBuildMode(final boolean mode) {

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/InputSystemResourceTypeTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/InputSystemResourceTypeTest.java
@@ -1,0 +1,105 @@
+package net.lapidist.colony.tests.systems;
+
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.math.Vector2;
+import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.client.systems.CameraInputSystem;
+import net.lapidist.colony.client.systems.InputSystem;
+import net.lapidist.colony.client.systems.PlayerCameraSystem;
+import net.lapidist.colony.client.systems.network.MapLoadSystem;
+import net.lapidist.colony.client.util.CameraUtils;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.ResourceData;
+import net.lapidist.colony.components.state.TileData;
+import net.lapidist.colony.components.state.TilePos;
+import net.lapidist.colony.components.resources.ResourceType;
+import net.lapidist.colony.components.state.ResourceGatherRequestData;
+import net.lapidist.colony.settings.KeyAction;
+import net.lapidist.colony.settings.KeyBindings;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+@RunWith(GdxTestRunner.class)
+public class InputSystemResourceTypeTest {
+
+    @Test
+    public void gatherKeyUsesTileResourceType() {
+        MapState state = new MapState();
+        ResourceData res = new ResourceData(0, 2, 1);
+        state.tiles().put(new TilePos(0, 0), TileData.builder()
+                .x(0).y(0).tileType("GRASS").passable(true)
+                .selected(true)
+                .resources(res)
+                .build());
+
+        GameClient client = mock(GameClient.class);
+        KeyBindings keys = new KeyBindings();
+        InputSystem system = new InputSystem(client, keys);
+
+        World world = new World(new WorldConfigurationBuilder()
+                .with(new MapLoadSystem(state), new PlayerCameraSystem(),
+                        new CameraInputSystem(keys), system)
+                .build());
+
+        Input input = mock(Input.class);
+        Gdx.input = input;
+        when(input.isKeyJustPressed(keys.getKey(KeyAction.GATHER)))
+                .thenReturn(false, true);
+
+        world.process();
+        world.process();
+
+        ArgumentCaptor<ResourceGatherRequestData> captor =
+                ArgumentCaptor.forClass(ResourceGatherRequestData.class);
+        verify(client).sendGatherRequest(captor.capture());
+        assertEquals(ResourceType.STONE.name(), captor.getValue().resourceType());
+    }
+
+    @Test
+    public void tapSendsTileResourceType() {
+        MapState state = new MapState();
+        ResourceData res = new ResourceData(1, 1, 0);
+        TileData tile = TileData.builder()
+                .x(0)
+                .y(0)
+                .tileType("GRASS")
+                .passable(true)
+                .resources(res)
+                .build();
+        state.tiles().put(new TilePos(0, 0), tile);
+
+        GameClient client = mock(GameClient.class);
+        KeyBindings keys = new KeyBindings();
+        InputSystem system = new InputSystem(client, keys);
+        World world = new World(new WorldConfigurationBuilder()
+                .with(new MapLoadSystem(state), new PlayerCameraSystem(),
+                        new CameraInputSystem(keys), system)
+                .build());
+        world.process();
+
+        PlayerCameraSystem camera = world.getSystem(PlayerCameraSystem.class);
+        ((com.badlogic.gdx.graphics.OrthographicCamera) camera.getCamera()).position.set(
+                GameConstants.TILE_SIZE / 2f,
+                GameConstants.TILE_SIZE / 2f,
+                0
+        );
+        camera.getCamera().update();
+
+        Vector2 screenCoords = CameraUtils.worldToScreenCoords(camera.getViewport(), 0, 0);
+        system.tap(screenCoords.x, screenCoords.y, 1, 0);
+
+        ArgumentCaptor<ResourceGatherRequestData> captor =
+                ArgumentCaptor.forClass(ResourceGatherRequestData.class);
+        verify(client).sendGatherRequest(captor.capture());
+        assertEquals(ResourceType.WOOD.name(), captor.getValue().resourceType());
+    }
+}


### PR DESCRIPTION
## Summary
- determine resource type when sending gather requests
- add tests for multiple-resource tiles

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test check`
- `./gradlew codeCoverageReport`

------
https://chatgpt.com/codex/tasks/task_e_6849f13471508328a765da72b7d18dfb