### PR TITLE
fix: camera and input handling

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/systems/CameraInputSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/CameraInputSystem.java
@@ -27,7 +27,7 @@ public final class CameraInputSystem extends BaseSystem {
     }
 
     public void addProcessor(final InputProcessor processor) {
-        multiplexer.addProcessor(0, processor);
+        multiplexer.addProcessor(processor);
     }
 
     @Override

--- a/client/src/main/java/net/lapidist/colony/client/systems/InputSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/InputSystem.java
@@ -54,7 +54,7 @@ public final class InputSystem extends BaseSystem {
     }
 
     public void addProcessor(final InputProcessor processor) {
-        multiplexer.addProcessor(0, processor);
+        multiplexer.addProcessor(processor);
     }
 
     @Override

--- a/client/src/main/java/net/lapidist/colony/client/systems/PlayerCameraSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/PlayerCameraSystem.java
@@ -113,7 +113,11 @@ public final class PlayerCameraSystem extends BaseSystem implements CameraProvid
     @Override
     protected void processSystem() {
         camera.update();
-        viewport.update(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+    }
+
+    @net.mostlyoriginal.api.event.common.Subscribe
+    private void onResize(final net.lapidist.colony.client.events.ResizeEvent event) {
+        viewport.update(event.width(), event.height(), true);
     }
 
     public float getZoom() {


### PR DESCRIPTION
## Summary
- keep camera position when panning by removing viewport update every frame
- update viewport size on resize events
- ensure UI stage receives input before the map by appending processors instead of prepending

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6849f3acb1fc832894eb1eef5b5e5fdb