### PR TITLE
feat: use enum for gather request type

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/systems/InputSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/InputSystem.java
@@ -114,7 +114,7 @@ public final class InputSystem extends BaseSystem {
                 ResourceType type = getResourceType(rc);
                 if (type != null) {
                     ResourceGatherRequestData msg = new ResourceGatherRequestData(
-                            tc.getX(), tc.getY(), type.name());
+                            tc.getX(), tc.getY(), type);
                     client.sendGatherRequest(msg);
                 }
             }
@@ -143,7 +143,7 @@ public final class InputSystem extends BaseSystem {
                         ResourceType type = getResourceType(rc);
                         if (type != null) {
                             ResourceGatherRequestData msg = new ResourceGatherRequestData(
-                                    tc.getX(), tc.getY(), type.name());
+                                    tc.getX(), tc.getY(), type);
                             client.sendGatherRequest(msg);
                         }
                     });

--- a/client/src/main/java/net/lapidist/colony/client/systems/SelectionSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/SelectionSystem.java
@@ -80,7 +80,7 @@ public final class SelectionSystem extends BaseSystem {
                 var tile = selectedTiles.get(i);
                 TileComponent tc = tileMapper.get(tile);
                 ResourceGatherRequestData msg = new ResourceGatherRequestData(
-                        tc.getX(), tc.getY(), ResourceType.WOOD.name());
+                        tc.getX(), tc.getY(), ResourceType.WOOD);
                 client.sendGatherRequest(msg);
             }
         }
@@ -104,7 +104,7 @@ public final class SelectionSystem extends BaseSystem {
                     ResourceComponent rc = resourceMapper.get(tile);
                     if (rc.getWood() > 0) {
                         ResourceGatherRequestData msg = new ResourceGatherRequestData(
-                                tc.getX(), tc.getY(), ResourceType.WOOD.name());
+                                tc.getX(), tc.getY(), ResourceType.WOOD);
                         client.sendGatherRequest(msg);
                     }
                 });

--- a/core/src/main/java/net/lapidist/colony/components/state/ResourceGatherRequestData.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/ResourceGatherRequestData.java
@@ -1,6 +1,7 @@
 package net.lapidist.colony.components.state;
 
 import net.lapidist.colony.serialization.KryoType;
+import net.lapidist.colony.components.resources.ResourceType;
 
 /**
  * Request message for gathering resources from a tile.
@@ -10,4 +11,4 @@ import net.lapidist.colony.serialization.KryoType;
  * @param resourceType type of resource to gather
  */
 @KryoType
-public record ResourceGatherRequestData(int x, int y, String resourceType) { }
+public record ResourceGatherRequestData(int x, int y, ResourceType resourceType) { }

--- a/core/src/main/java/net/lapidist/colony/serialization/SerializationRegistrar.java
+++ b/core/src/main/java/net/lapidist/colony/serialization/SerializationRegistrar.java
@@ -59,6 +59,7 @@ public final class SerializationRegistrar {
             BuildingData.class,
             BuildingPlacementData.class,
             ResourceData.class,
+            net.lapidist.colony.components.resources.ResourceType.class,
             ResourceGatherRequestData.class,
             ResourceUpdateData.class,
             MapMetadata.class,

--- a/server/src/main/java/net/lapidist/colony/server/commands/GatherCommand.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/GatherCommand.java
@@ -1,5 +1,7 @@
 package net.lapidist.colony.server.commands;
 
+import net.lapidist.colony.components.resources.ResourceType;
+
 /**
  * Command representing a resource gather request.
  *
@@ -7,5 +9,5 @@ package net.lapidist.colony.server.commands;
  * @param y            tile y coordinate
  * @param resourceType type of resource to gather
  */
-public record GatherCommand(int x, int y, String resourceType) implements ServerCommand {
+public record GatherCommand(int x, int y, ResourceType resourceType) implements ServerCommand {
 }

--- a/server/src/main/java/net/lapidist/colony/server/commands/GatherCommandHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/GatherCommandHandler.java
@@ -39,9 +39,9 @@ public final class GatherCommandHandler implements CommandHandler<GatherCommand>
         ResourceData res = tile.resources();
         ResourceData updated;
         switch (command.resourceType()) {
-            case "WOOD" -> updated = new ResourceData(Math.max(res.wood() - 1, 0), res.stone(), res.food());
-            case "STONE" -> updated = new ResourceData(res.wood(), Math.max(res.stone() - 1, 0), res.food());
-            case "FOOD" -> updated = new ResourceData(res.wood(), res.stone(), Math.max(res.food() - 1, 0));
+            case WOOD -> updated = new ResourceData(Math.max(res.wood() - 1, 0), res.stone(), res.food());
+            case STONE -> updated = new ResourceData(res.wood(), Math.max(res.stone() - 1, 0), res.food());
+            case FOOD -> updated = new ResourceData(res.wood(), res.stone(), Math.max(res.food() - 1, 0));
             default -> updated = res;
         }
         TileData newTile = tile.toBuilder().resources(updated).build();

--- a/tests/src/test/java/net/lapidist/colony/tests/network/GameServerGatherBroadcastTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/network/GameServerGatherBroadcastTest.java
@@ -3,6 +3,7 @@ package net.lapidist.colony.tests.network;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.components.state.ResourceGatherRequestData;
 import net.lapidist.colony.components.state.ResourceUpdateData;
+import net.lapidist.colony.components.resources.ResourceType;
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.server.GameServerConfig;
 import org.junit.Test;
@@ -35,7 +36,7 @@ public class GameServerGatherBroadcastTest {
         latchA.await(1, TimeUnit.SECONDS);
         latchB.await(1, TimeUnit.SECONDS);
 
-        ResourceGatherRequestData data = new ResourceGatherRequestData(0, 0, "WOOD");
+        ResourceGatherRequestData data = new ResourceGatherRequestData(0, 0, ResourceType.WOOD);
         clientA.sendGatherRequest(data);
 
         Thread.sleep(WAIT_MS);

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationPlayerResourcesTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationPlayerResourcesTest.java
@@ -4,6 +4,7 @@ import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.ResourceGatherRequestData;
 import net.lapidist.colony.components.resources.PlayerResourceComponent;
+import net.lapidist.colony.components.resources.ResourceType;
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.server.GameServerConfig;
 import net.lapidist.colony.tests.GdxTestRunner;
@@ -41,7 +42,7 @@ public class GameSimulationPlayerResourcesTest {
         MapState state = receiver.getMapState();
         GameSimulation sim = new GameSimulation(state, receiver);
 
-        ResourceGatherRequestData data = new ResourceGatherRequestData(0, 0, "WOOD");
+        ResourceGatherRequestData data = new ResourceGatherRequestData(0, 0, ResourceType.WOOD);
         sender.sendGatherRequest(data);
 
         Thread.sleep(WAIT_MS);

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationResourceUpdateTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationResourceUpdateTest.java
@@ -4,6 +4,7 @@ import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.ResourceGatherRequestData;
 import net.lapidist.colony.components.resources.ResourceComponent;
+import net.lapidist.colony.components.resources.ResourceType;
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.server.GameServerConfig;
 import net.lapidist.colony.tests.GdxTestRunner;
@@ -42,7 +43,7 @@ public class GameSimulationResourceUpdateTest {
         MapState state = receiver.getMapState();
         GameSimulation sim = new GameSimulation(state, receiver);
 
-        ResourceGatherRequestData data = new ResourceGatherRequestData(0, 0, "WOOD");
+        ResourceGatherRequestData data = new ResourceGatherRequestData(0, 0, ResourceType.WOOD);
         sender.sendGatherRequest(data);
 
         Thread.sleep(WAIT_MS);

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerPlayerResourceSaveTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerPlayerResourceSaveTest.java
@@ -2,6 +2,7 @@ package net.lapidist.colony.tests.server;
 
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.components.state.ResourceGatherRequestData;
+import net.lapidist.colony.components.resources.ResourceType;
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.server.GameServerConfig;
 import net.lapidist.colony.io.Paths;
@@ -31,7 +32,7 @@ public class GameServerPlayerResourceSaveTest {
         client.start(state -> latch.countDown());
         latch.await(1, TimeUnit.SECONDS);
 
-        client.sendGatherRequest(new ResourceGatherRequestData(0, 0, "WOOD"));
+        client.sendGatherRequest(new ResourceGatherRequestData(0, 0, ResourceType.WOOD));
         Thread.sleep(WAIT_MS);
 
         client.stop();

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/InputSystemResourceTypeTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/InputSystemResourceTypeTest.java
@@ -61,7 +61,7 @@ public class InputSystemResourceTypeTest {
         ArgumentCaptor<ResourceGatherRequestData> captor =
                 ArgumentCaptor.forClass(ResourceGatherRequestData.class);
         verify(client).sendGatherRequest(captor.capture());
-        assertEquals(ResourceType.STONE.name(), captor.getValue().resourceType());
+        assertEquals(ResourceType.STONE, captor.getValue().resourceType());
     }
 
     @Test
@@ -100,6 +100,6 @@ public class InputSystemResourceTypeTest {
         ArgumentCaptor<ResourceGatherRequestData> captor =
                 ArgumentCaptor.forClass(ResourceGatherRequestData.class);
         verify(client).sendGatherRequest(captor.capture());
-        assertEquals(ResourceType.WOOD.name(), captor.getValue().resourceType());
+        assertEquals(ResourceType.WOOD, captor.getValue().resourceType());
     }
 }


### PR DESCRIPTION
## Summary
- move ResourceGatherRequestData to hold ResourceType instead of String
- register ResourceType with Kryo
- pass ResourceType through gather requests in client and server
- adjust tests for new enum property

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_6849f77dbba883288efebfe665636678