### PR TITLE
fix: improve camera input and selection overlay

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/systems/CameraInputSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/CameraInputSystem.java
@@ -27,7 +27,7 @@ public final class CameraInputSystem extends BaseSystem {
     }
 
     public void addProcessor(final InputProcessor processor) {
-        multiplexer.addProcessor(0, processor);
+        multiplexer.addProcessor(processor);
     }
 
     @Override

--- a/client/src/main/java/net/lapidist/colony/client/systems/InputSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/InputSystem.java
@@ -54,7 +54,7 @@ public final class InputSystem extends BaseSystem {
     }
 
     public void addProcessor(final InputProcessor processor) {
-        multiplexer.addProcessor(0, processor);
+        multiplexer.addProcessor(processor);
     }
 
     @Override

--- a/client/src/main/java/net/lapidist/colony/client/systems/input/KeyboardInputHandler.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/input/KeyboardInputHandler.java
@@ -54,8 +54,8 @@ public final class KeyboardInputHandler {
         var camera = (OrthographicCamera) cameraSystem.getCamera();
         var viewport = (ExtendViewport) cameraSystem.getViewport();
 
-        float halfWidth = viewport.getWorldWidth() * camera.zoom / 2f;
-        float halfHeight = viewport.getWorldHeight() * camera.zoom / 2f;
+        float halfWidth = Math.min(viewport.getWorldWidth() * camera.zoom / 2f, mapWidth / 2f);
+        float halfHeight = Math.min(viewport.getWorldHeight() * camera.zoom / 2f, mapHeight / 2f);
 
         position.x = MathUtils.clamp(position.x, halfWidth, mapWidth - halfWidth);
         position.y = MathUtils.clamp(position.y, halfHeight, mapHeight - halfHeight);

--- a/client/src/main/java/net/lapidist/colony/client/systems/input/TileSelectionHandler.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/input/TileSelectionHandler.java
@@ -57,6 +57,8 @@ public final class TileSelectionHandler {
                             newState
                     );
                     client.sendTileSelectionRequest(msg);
+                    tileComponent.setSelected(newState);
+                    map.incrementVersion();
                     if (newState) {
                         if (!selectedTiles.contains(tile, true)) {
                             selectedTiles.add(tile);

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationDelayedTileUpdateTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationDelayedTileUpdateTest.java
@@ -19,7 +19,6 @@ import org.junit.runner.RunWith;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -53,9 +52,9 @@ public class GameSimulationDelayedTileUpdateTest {
             );
             sim.getSelection().tap(screen.x, screen.y);
 
-            // Check immediately after tap - tile should not be selected yet
+            // Selection should apply immediately
             TileComponent tile = findTile(sim);
-            assertFalse(tile.isSelected());
+            assertTrue(tile.isSelected());
 
             // Wait for server broadcast then process queued update
             Thread.sleep(WAIT_MS);

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/InputSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/InputSystemTest.java
@@ -67,7 +67,7 @@ public class InputSystemTest {
         TileComponent tileComponent = world.getMapper(TileComponent.class)
                 .get(mapComponent.getTiles().get(0));
 
-        assertFalse(tileComponent.isSelected());
+        assertTrue(tileComponent.isSelected());
         verify(client).sendTileSelectionRequest(any());
     }
 }


### PR DESCRIPTION
## Summary
- keep UI processors at the start of the multiplexer
- clamp camera position correctly when map is smaller than the viewport
- update tile selection locally so overlays render immediately
- adjust related tests

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6849f851f1c88328bb4855f8603b4017