### PR TITLE
feat: generate grass and dirt terrain with Perlin noise

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/renderers/DefaultAssetResolver.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/DefaultAssetResolver.java
@@ -14,7 +14,7 @@ public final class DefaultAssetResolver implements AssetResolver {
             TileComponent.TileType tile = TileComponent.TileType
                     .valueOf(type.toUpperCase(java.util.Locale.ROOT));
             return switch (tile) {
-                case EMPTY -> "dirt0";
+                case EMPTY, DIRT -> "dirt0";
                 case GRASS -> "grass0";
             };
         } catch (IllegalArgumentException ex) {

--- a/core/src/main/java/net/lapidist/colony/components/maps/TileComponent.java
+++ b/core/src/main/java/net/lapidist/colony/components/maps/TileComponent.java
@@ -6,6 +6,7 @@ public class TileComponent extends AbstractBoundedComponent {
 
     public enum TileType {
         EMPTY("empty"),
+        DIRT("dirt"),
         GRASS("grass");
 
         private final String type;

--- a/core/src/main/java/net/lapidist/colony/map/DefaultMapGenerator.java
+++ b/core/src/main/java/net/lapidist/colony/map/DefaultMapGenerator.java
@@ -18,11 +18,13 @@ public final class DefaultMapGenerator implements MapGenerator {
     private static final int DEFAULT_WOOD = 10;
     private static final int DEFAULT_STONE = 5;
     private static final int DEFAULT_FOOD = 3;
+    private static final double NOISE_SCALE = 0.1;
 
     @Override
     public MapState generate(final int width, final int height) {
         MapState state = new MapState();
         Random random = new Random();
+        PerlinNoise noise = new PerlinNoise(random.nextLong());
         state = state.toBuilder()
                 .name("map-" + random.nextInt(NAME_RANGE))
                 .description(I18n.get("generator.generatedMap"))
@@ -30,7 +32,8 @@ public final class DefaultMapGenerator implements MapGenerator {
 
         for (int x = 0; x < width; x++) {
             for (int y = 0; y < height; y++) {
-                state.tiles().put(new TilePos(x, y), createTile(x, y));
+                String type = noise.noise(x * NOISE_SCALE, y * NOISE_SCALE) > 0 ? "GRASS" : "DIRT";
+                state.tiles().put(new TilePos(x, y), createTile(x, y, type));
             }
         }
 
@@ -44,11 +47,11 @@ public final class DefaultMapGenerator implements MapGenerator {
         return state;
     }
 
-    private static TileData createTile(final int x, final int y) {
+    private static TileData createTile(final int x, final int y, final String type) {
         return TileData.builder()
                 .x(x)
                 .y(y)
-                .tileType("GRASS")
+                .tileType(type)
                 .passable(true)
                 .selected(false)
                 .resources(new ResourceData(DEFAULT_WOOD, DEFAULT_STONE, DEFAULT_FOOD))

--- a/tests/src/test/java/net/lapidist/colony/tests/client/render/data/DefaultAssetResolverTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/render/data/DefaultAssetResolverTest.java
@@ -11,6 +11,7 @@ public class DefaultAssetResolverTest {
         DefaultAssetResolver resolver = new DefaultAssetResolver();
         assertEquals("grass0", resolver.tileAsset("GRASS"));
         assertEquals("grass0", resolver.tileAsset("grass"));
+        assertEquals("dirt0", resolver.tileAsset("DIRT"));
         assertEquals("dirt0", resolver.tileAsset("EMPTY"));
         assertEquals("dirt0", resolver.tileAsset(null));
         assertEquals("dirt0", resolver.tileAsset("invalid"));

--- a/tests/src/test/java/net/lapidist/colony/tests/map/DefaultMapGeneratorTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/map/DefaultMapGeneratorTest.java
@@ -5,6 +5,7 @@ import net.lapidist.colony.map.DefaultMapGenerator;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class DefaultMapGeneratorTest {
 
@@ -15,5 +16,21 @@ public class DefaultMapGeneratorTest {
         final int height = 3;
         MapState state = generator.generate(width, height);
         assertEquals(width * height, state.tiles().size());
+    }
+
+    @Test
+    public void generatesMixedTerrain() {
+        DefaultMapGenerator generator = new DefaultMapGenerator();
+        final int width = 10;
+        final int height = 10;
+        MapState state = generator.generate(width, height);
+        long grass = state.tiles().values().stream()
+                .filter(t -> "GRASS".equals(t.tileType()))
+                .count();
+        long dirt = state.tiles().values().stream()
+                .filter(t -> "DIRT".equals(t.tileType()))
+                .count();
+        assertTrue(grass > 0);
+        assertTrue(dirt > 0);
     }
 }


### PR DESCRIPTION
## Summary
- smoothly vary terrain with Perlin noise in `DefaultMapGenerator`
- support `DIRT` tile type
- map `DIRT` to the existing dirt texture
- cover Perlin-based generator in tests

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6849f976f7a883288857b6b115c0900c