### PR TITLE
fix: refresh map data each frame

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/systems/MapRenderSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/MapRenderSystem.java
@@ -32,14 +32,12 @@ public final class MapRenderSystem extends BaseSystem {
 
     @Override
     protected void processSystem() {
+        MapRenderDataSystem dataSystem = world.getSystem(MapRenderDataSystem.class);
+        if (dataSystem != null) {
+            mapData = dataSystem.getRenderData();
+        }
         if (mapData == null) {
-            MapRenderDataSystem dataSystem = world.getSystem(MapRenderDataSystem.class);
-            if (dataSystem != null) {
-                mapData = dataSystem.getRenderData();
-            }
-            if (mapData == null) {
-                return;
-            }
+            return;
         }
 
         if (mapRenderer != null) {


### PR DESCRIPTION
## Summary
- always refresh MapRenderSystem mapData every frame
- test MapRenderSystem reacts to MapRenderDataSystem updates

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684a0cf3b7b4832899ba65e4742792e2