### PR TITLE
fix: simplify tile rendering bounds

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
@@ -3,7 +3,6 @@ package net.lapidist.colony.client.renderers;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Vector2;
-import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.math.Rectangle;
 import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.client.systems.CameraProvider;
@@ -53,7 +52,6 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
         int endY = Math.min(GameConstants.MAP_HEIGHT - 1, (int) end.y + 1);
 
         Vector2 worldCoords = new Vector2();
-        Vector3 tmp = new Vector3();
 
         for (int x = startX; x <= endX; x++) {
             for (int y = startY; y <= endY; y++) {
@@ -63,9 +61,6 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
                 }
 
                 CameraUtils.tileCoordsToWorldCoords(tile.getX(), tile.getY(), worldCoords);
-                if (!CameraUtils.withinCameraView(cameraSystem.getViewport(), worldCoords, tmp)) {
-                    continue;
-                }
 
                 String ref = resolver.tileAsset(tile.getTileType());
                 TextureRegion region = resourceLoader.findRegion(ref);

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/TileRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/TileRendererTest.java
@@ -51,12 +51,25 @@ public class TileRendererTest {
                 .build();
         tiles.add(tile);
 
+        RenderTile tile2 = RenderTile.builder()
+                .x(1)
+                .y(1)
+                .tileType("GRASS")
+                .selected(false)
+                .wood(0)
+                .stone(0)
+                .food(0)
+                .build();
+        tiles.add(tile2);
+
         RenderTile[][] grid = new RenderTile[GameConstants.MAP_WIDTH][GameConstants.MAP_HEIGHT];
         grid[0][0] = tile;
+        grid[1][1] = tile2;
         MapRenderData map = new SimpleMapRenderData(tiles, new Array<RenderBuilding>(), grid);
 
         renderer.render(map);
 
-        verify(batch, times(2)).draw(any(TextureRegion.class), anyFloat(), anyFloat());
+        int expectedDraws = tiles.size + 1;
+        verify(batch, times(expectedDraws)).draw(any(TextureRegion.class), anyFloat(), anyFloat());
     }
 }


### PR DESCRIPTION
## Summary
- remove withinCameraView from TileRenderer
- update TileRendererTest for new draw behavior

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684a0e84057483289400fcf9c9a79faf