### PR TITLE
feat: precompute world coords

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/render/MapRenderDataBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/render/MapRenderDataBuilder.java
@@ -32,6 +32,8 @@ public final class MapRenderDataBuilder {
             RenderTile tile = RenderTile.builder()
                     .x(tc.getX())
                     .y(tc.getY())
+                    .worldX(tc.getX() * GameConstants.TILE_SIZE)
+                    .worldY(tc.getY() * GameConstants.TILE_SIZE)
                     .tileType(tc.getTileType().toString())
                     .selected(tc.isSelected())
                     .wood(rc.getWood())
@@ -53,6 +55,8 @@ public final class MapRenderDataBuilder {
             RenderBuilding building = RenderBuilding.builder()
                     .x(bc.getX())
                     .y(bc.getY())
+                    .worldX(bc.getX() * GameConstants.TILE_SIZE)
+                    .worldY(bc.getY() * GameConstants.TILE_SIZE)
                     .buildingType(bc.getBuildingType().toString())
                     .build();
             buildings.add(building);

--- a/client/src/main/java/net/lapidist/colony/client/render/data/RenderBuilding.java
+++ b/client/src/main/java/net/lapidist/colony/client/render/data/RenderBuilding.java
@@ -4,11 +4,15 @@ package net.lapidist.colony.client.render.data;
 public final class RenderBuilding {
     private final int x;
     private final int y;
+    private final float worldX;
+    private final float worldY;
     private final String buildingType;
 
     private RenderBuilding(final Builder builder) {
         this.x = builder.x;
         this.y = builder.y;
+        this.worldX = builder.worldX;
+        this.worldY = builder.worldY;
         this.buildingType = builder.buildingType;
     }
 
@@ -18,6 +22,14 @@ public final class RenderBuilding {
 
     public int getY() {
         return y;
+    }
+
+    public float getWorldX() {
+        return worldX;
+    }
+
+    public float getWorldY() {
+        return worldY;
     }
 
     public String getBuildingType() {
@@ -32,6 +44,8 @@ public final class RenderBuilding {
     public static final class Builder {
         private int x;
         private int y;
+        private float worldX;
+        private float worldY;
         private String buildingType;
 
         private Builder() { }
@@ -43,6 +57,16 @@ public final class RenderBuilding {
 
         public Builder y(final int newY) {
             this.y = newY;
+            return this;
+        }
+
+        public Builder worldX(final float newWorldX) {
+            this.worldX = newWorldX;
+            return this;
+        }
+
+        public Builder worldY(final float newWorldY) {
+            this.worldY = newWorldY;
             return this;
         }
 

--- a/client/src/main/java/net/lapidist/colony/client/render/data/RenderTile.java
+++ b/client/src/main/java/net/lapidist/colony/client/render/data/RenderTile.java
@@ -4,6 +4,8 @@ package net.lapidist.colony.client.render.data;
 public final class RenderTile {
     private final int x;
     private final int y;
+    private final float worldX;
+    private final float worldY;
     private final String tileType;
     private final boolean selected;
     private final int wood;
@@ -13,6 +15,8 @@ public final class RenderTile {
     private RenderTile(final Builder builder) {
         this.x = builder.x;
         this.y = builder.y;
+        this.worldX = builder.worldX;
+        this.worldY = builder.worldY;
         this.tileType = builder.tileType;
         this.selected = builder.selected;
         this.wood = builder.wood;
@@ -26,6 +30,14 @@ public final class RenderTile {
 
     public int getY() {
         return y;
+    }
+
+    public float getWorldX() {
+        return worldX;
+    }
+
+    public float getWorldY() {
+        return worldY;
     }
 
     public String getTileType() {
@@ -56,6 +68,8 @@ public final class RenderTile {
     public static final class Builder {
         private int x;
         private int y;
+        private float worldX;
+        private float worldY;
         private String tileType;
         private boolean selected;
         private int wood;
@@ -71,6 +85,16 @@ public final class RenderTile {
 
         public Builder y(final int newY) {
             this.y = newY;
+            return this;
+        }
+
+        public Builder worldX(final float newWorldX) {
+            this.worldX = newWorldX;
+            return this;
+        }
+
+        public Builder worldY(final float newWorldY) {
+            this.worldY = newWorldY;
             return this;
         }
 

--- a/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
@@ -40,7 +40,7 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
         Vector3 tmp = new Vector3();
         for (int i = 0; i < entities.size; i++) {
             RenderBuilding building = entities.get(i);
-            CameraUtils.tileCoordsToWorldCoords(building.getX(), building.getY(), worldCoords);
+            worldCoords.set(building.getWorldX(), building.getWorldY());
 
             if (!CameraUtils.withinCameraView(cameraSystem.getViewport(), worldCoords, tmp)) {
                 continue;

--- a/client/src/main/java/net/lapidist/colony/client/renderers/ResourceRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/ResourceRenderer.java
@@ -39,7 +39,7 @@ public final class ResourceRenderer implements EntityRenderer<RenderTile>, Dispo
             if (!tile.isSelected()) {
                 continue;
             }
-            CameraUtils.tileCoordsToWorldCoords(tile.getX(), tile.getY(), worldCoords);
+            worldCoords.set(tile.getWorldX(), tile.getWorldY());
             if (!CameraUtils.withinCameraView(cameraSystem.getViewport(), worldCoords, tmp)) {
                 continue;
             }

--- a/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
@@ -62,7 +62,7 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
                     continue;
                 }
 
-                CameraUtils.tileCoordsToWorldCoords(tile.getX(), tile.getY(), worldCoords);
+                worldCoords.set(tile.getWorldX(), tile.getWorldY());
                 if (!CameraUtils.withinCameraView(cameraSystem.getViewport(), worldCoords, tmp)) {
                     continue;
                 }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/render/data/MapRenderDataBuilderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/render/data/MapRenderDataBuilderTest.java
@@ -44,5 +44,10 @@ public class MapRenderDataBuilderTest {
         assertEquals(1, tile.getWood());
         assertEquals(BUILDING_X, data.getBuildings().first().getX());
         assertEquals(tile, data.getTile(TILE_X, TILE_Y));
+        assertEquals(TILE_X * net.lapidist.colony.components.GameConstants.TILE_SIZE, tile.getWorldX(), 0f);
+        assertEquals(TILE_Y * net.lapidist.colony.components.GameConstants.TILE_SIZE, tile.getWorldY(), 0f);
+        var building = data.getBuildings().first();
+        assertEquals(BUILDING_X * net.lapidist.colony.components.GameConstants.TILE_SIZE, building.getWorldX(), 0f);
+        assertEquals(BUILDING_Y * net.lapidist.colony.components.GameConstants.TILE_SIZE, building.getWorldY(), 0f);
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/render/data/RenderBuildingTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/render/data/RenderBuildingTest.java
@@ -8,17 +8,23 @@ import static org.junit.Assert.*;
 public class RenderBuildingTest {
     private static final int X = 4;
     private static final int Y = 7;
+    private static final float WORLD_X = 12f;
+    private static final float WORLD_Y = 14f;
 
     @Test
     public void builderSetsFields() {
         RenderBuilding building = RenderBuilding.builder()
                 .x(X)
                 .y(Y)
+                .worldX(WORLD_X)
+                .worldY(WORLD_Y)
                 .buildingType("HOUSE")
                 .build();
 
         assertEquals(X, building.getX());
         assertEquals(Y, building.getY());
         assertEquals("HOUSE", building.getBuildingType());
+        assertEquals(WORLD_X, building.getWorldX(), 0f);
+        assertEquals(WORLD_Y, building.getWorldY(), 0f);
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/render/data/RenderTileTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/render/data/RenderTileTest.java
@@ -11,12 +11,16 @@ public class RenderTileTest {
     private static final int WOOD = 5;
     private static final int STONE = 3;
     private static final int FOOD = 2;
+    private static final float WORLD_X = 10f;
+    private static final float WORLD_Y = 20f;
 
     @Test
     public void builderSetsAllFields() {
         RenderTile tile = RenderTile.builder()
                 .x(X)
                 .y(Y)
+                .worldX(WORLD_X)
+                .worldY(WORLD_Y)
                 .tileType("GRASS")
                 .selected(true)
                 .wood(WOOD)
@@ -31,5 +35,7 @@ public class RenderTileTest {
         assertEquals(WOOD, tile.getWood());
         assertEquals(STONE, tile.getStone());
         assertEquals(FOOD, tile.getFood());
+        assertEquals(WORLD_X, tile.getWorldX(), 0f);
+        assertEquals(WORLD_Y, tile.getWorldY(), 0f);
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/BuildingRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/BuildingRendererTest.java
@@ -32,12 +32,22 @@ public class BuildingRendererTest {
         CameraProvider camera = mock(CameraProvider.class);
         Viewport viewport = mock(Viewport.class);
         when(camera.getViewport()).thenReturn(viewport);
-        when(viewport.project(any(Vector3.class))).thenReturn(new Vector3());
+        doAnswer(inv -> {
+            Vector3 v = inv.getArgument(0);
+            v.set(0f, 0f, 0f);
+            return v;
+        }).when(viewport).project(any(Vector3.class));
 
         BuildingRenderer renderer = new BuildingRenderer(batch, loader, camera, new DefaultAssetResolver());
 
         Array<RenderBuilding> buildings = new Array<>();
-        RenderBuilding building = RenderBuilding.builder().x(0).y(0).buildingType("HOUSE").build();
+        RenderBuilding building = RenderBuilding.builder()
+                .x(1)
+                .y(2)
+                .worldX(1 * GameConstants.TILE_SIZE)
+                .worldY(2 * GameConstants.TILE_SIZE)
+                .buildingType("HOUSE")
+                .build();
         buildings.add(building);
 
         MapRenderData map = new SimpleMapRenderData(new Array<RenderTile>(), buildings,
@@ -45,6 +55,10 @@ public class BuildingRendererTest {
 
         renderer.render(map);
 
-        verify(batch).draw(eq(region), anyFloat(), anyFloat());
+        org.mockito.ArgumentCaptor<Float> xCap = org.mockito.ArgumentCaptor.forClass(Float.class);
+        org.mockito.ArgumentCaptor<Float> yCap = org.mockito.ArgumentCaptor.forClass(Float.class);
+        verify(batch).draw(eq(region), xCap.capture(), yCap.capture());
+        org.junit.Assert.assertEquals(building.getWorldX(), xCap.getValue(), 0f);
+        org.junit.Assert.assertEquals(building.getWorldY(), yCap.getValue(), 0f);
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/ResourceRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/ResourceRendererTest.java
@@ -26,6 +26,7 @@ public class ResourceRendererTest {
     private static final int WOOD = 1;
     private static final int STONE = 2;
     private static final int FOOD = 3;
+    private static final float OFFSET_Y = 8f;
 
     @Test
     public void rendersResourceTextWithoutErrors() {
@@ -80,6 +81,8 @@ public class ResourceRendererTest {
         RenderTile tile = RenderTile.builder()
                 .x(0)
                 .y(0)
+                .worldX(0f)
+                .worldY(0f)
                 .tileType("GRASS")
                 .selected(true)
                 .wood(WOOD)
@@ -97,7 +100,11 @@ public class ResourceRendererTest {
         ArgumentCaptor<CharSequence> captor = ArgumentCaptor.forClass(CharSequence.class);
         verify(layout).setText(eq(font), captor.capture());
         assertEquals(WOOD + "/" + STONE + "/" + FOOD, captor.getValue().toString());
-        verify(font).draw(eq(batch), eq(layout), anyFloat(), anyFloat());
+        org.mockito.ArgumentCaptor<Float> xCap = org.mockito.ArgumentCaptor.forClass(Float.class);
+        org.mockito.ArgumentCaptor<Float> yCap = org.mockito.ArgumentCaptor.forClass(Float.class);
+        verify(font).draw(eq(batch), eq(layout), xCap.capture(), yCap.capture());
+        org.junit.Assert.assertEquals(tile.getWorldX(), xCap.getValue(), 0f);
+        org.junit.Assert.assertEquals(tile.getWorldY() + OFFSET_Y, yCap.getValue(), 0f);
         renderer.dispose();
     }
 

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/TileRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/TileRendererTest.java
@@ -43,6 +43,8 @@ public class TileRendererTest {
         RenderTile tile = RenderTile.builder()
                 .x(0)
                 .y(0)
+                .worldX(0f)
+                .worldY(0f)
                 .tileType("GRASS")
                 .selected(true)
                 .wood(0)
@@ -57,6 +59,14 @@ public class TileRendererTest {
 
         renderer.render(map);
 
-        verify(batch, times(2)).draw(any(TextureRegion.class), anyFloat(), anyFloat());
+        org.mockito.ArgumentCaptor<Float> xCap = org.mockito.ArgumentCaptor.forClass(Float.class);
+        org.mockito.ArgumentCaptor<Float> yCap = org.mockito.ArgumentCaptor.forClass(Float.class);
+        verify(batch, times(2)).draw(any(TextureRegion.class), xCap.capture(), yCap.capture());
+        java.util.List<Float> xs = xCap.getAllValues();
+        java.util.List<Float> ys = yCap.getAllValues();
+        org.junit.Assert.assertEquals(tile.getWorldX(), xs.get(0), 0f);
+        org.junit.Assert.assertEquals(tile.getWorldY(), ys.get(0), 0f);
+        org.junit.Assert.assertEquals(tile.getWorldX(), xs.get(1), 0f);
+        org.junit.Assert.assertEquals(tile.getWorldY(), ys.get(1), 0f);
     }
 }


### PR DESCRIPTION
## Summary
- cache world positions inside `RenderTile` and `RenderBuilding`
- compute world coordinates in `MapRenderDataBuilder`
- use cached coordinates in renderers
- verify drawing positions in renderer tests

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684a0e87b1808328805d4207abc3e0d7