### PR TITLE
feat(client): simplify asset resolver

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/renderers/DefaultAssetResolver.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/DefaultAssetResolver.java
@@ -1,25 +1,33 @@
 package net.lapidist.colony.client.renderers;
 
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 import net.lapidist.colony.components.entities.BuildingComponent;
 import net.lapidist.colony.components.maps.TileComponent;
 
 /** Default implementation returning built-in asset references. */
 public final class DefaultAssetResolver implements AssetResolver {
+
+    private static final Map<String, String> TILE_ASSETS = new HashMap<>();
+    private static final Map<String, String> BUILDING_ASSETS = new HashMap<>();
+
+    static {
+        TILE_ASSETS.put(TileComponent.TileType.EMPTY.name(), "dirt0");
+        TILE_ASSETS.put(TileComponent.TileType.DIRT.name(), "dirt0");
+        TILE_ASSETS.put(TileComponent.TileType.GRASS.name(), "grass0");
+
+        BUILDING_ASSETS.put(BuildingComponent.BuildingType.HOUSE.name(), "house0");
+        BUILDING_ASSETS.put(BuildingComponent.BuildingType.MARKET.name(), "house0");
+        BUILDING_ASSETS.put(BuildingComponent.BuildingType.FACTORY.name(), "house0");
+    }
     @Override
     public String tileAsset(final String type) {
         if (type == null) {
             return "dirt0";
         }
-        try {
-            TileComponent.TileType tile = TileComponent.TileType
-                    .valueOf(type.toUpperCase(java.util.Locale.ROOT));
-            return switch (tile) {
-                case EMPTY, DIRT -> "dirt0";
-                case GRASS -> "grass0";
-            };
-        } catch (IllegalArgumentException ex) {
-            return "dirt0";
-        }
+        String asset = TILE_ASSETS.get(type.toUpperCase(Locale.ROOT));
+        return asset != null ? asset : "dirt0";
     }
 
     @Override
@@ -27,16 +35,7 @@ public final class DefaultAssetResolver implements AssetResolver {
         if (type == null) {
             return "house0";
         }
-        try {
-            BuildingComponent.BuildingType building = BuildingComponent.BuildingType
-                    .valueOf(type.toUpperCase(java.util.Locale.ROOT));
-            return switch (building) {
-                case HOUSE -> "house0";
-                case MARKET -> "house0";
-                case FACTORY -> "house0";
-            };
-        } catch (IllegalArgumentException ex) {
-            return "house0";
-        }
+        String asset = BUILDING_ASSETS.get(type.toUpperCase(Locale.ROOT));
+        return asset != null ? asset : "house0";
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/DefaultAssetResolverAssetsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/DefaultAssetResolverAssetsTest.java
@@ -1,0 +1,25 @@
+package net.lapidist.colony.tests.client.renderers;
+
+import net.lapidist.colony.client.renderers.DefaultAssetResolver;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class DefaultAssetResolverAssetsTest {
+    @Test
+    public void returnsSpriteReferences() {
+        DefaultAssetResolver resolver = new DefaultAssetResolver();
+        assertEquals("grass0", resolver.tileAsset("GRASS"));
+        assertEquals("grass0", resolver.tileAsset("grass"));
+        assertEquals("dirt0", resolver.tileAsset("DIRT"));
+        assertEquals("dirt0", resolver.tileAsset("EMPTY"));
+        assertEquals("dirt0", resolver.tileAsset(null));
+        assertEquals("dirt0", resolver.tileAsset("invalid"));
+        assertEquals("house0", resolver.buildingAsset("HOUSE"));
+        assertEquals("house0", resolver.buildingAsset("house"));
+        assertEquals("house0", resolver.buildingAsset("MARKET"));
+        assertEquals("house0", resolver.buildingAsset("FACTORY"));
+        assertEquals("house0", resolver.buildingAsset(null));
+        assertEquals("house0", resolver.buildingAsset("invalid"));
+    }
+}


### PR DESCRIPTION
## Summary
- streamline asset lookup in DefaultAssetResolver using static maps
- verify resolver assets in renderer tests

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684a0e9039c883288e3926e2c03c29b4