### PR TITLE
feat: support incremental map rendering

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/render/MapRenderDataBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/render/MapRenderDataBuilder.java
@@ -29,15 +29,7 @@ public final class MapRenderDataBuilder {
             Entity entity = mapTiles.get(i);
             TileComponent tc = tileMapper.get(entity);
             ResourceComponent rc = resourceMapper.get(entity);
-            RenderTile tile = RenderTile.builder()
-                    .x(tc.getX())
-                    .y(tc.getY())
-                    .tileType(tc.getTileType().toString())
-                    .selected(tc.isSelected())
-                    .wood(rc.getWood())
-                    .stone(rc.getStone())
-                    .food(rc.getFood())
-                    .build();
+            RenderTile tile = toTile(tc, rc);
             tiles.add(tile);
             if (tc.getX() >= 0 && tc.getX() < GameConstants.MAP_WIDTH
                     && tc.getY() >= 0 && tc.getY() < GameConstants.MAP_HEIGHT) {
@@ -50,14 +42,59 @@ public final class MapRenderDataBuilder {
         for (int i = 0; i < mapEntities.size; i++) {
             Entity entity = mapEntities.get(i);
             BuildingComponent bc = buildingMapper.get(entity);
-            RenderBuilding building = RenderBuilding.builder()
-                    .x(bc.getX())
-                    .y(bc.getY())
-                    .buildingType(bc.getBuildingType().toString())
-                    .build();
+            RenderBuilding building = toBuilding(bc);
             buildings.add(building);
         }
 
         return new SimpleMapRenderData(tiles, buildings, grid);
+    }
+
+    public static RenderTile toTile(final TileComponent tc, final ResourceComponent rc) {
+        return RenderTile.builder()
+                .x(tc.getX())
+                .y(tc.getY())
+                .tileType(tc.getTileType().toString())
+                .selected(tc.isSelected())
+                .wood(rc.getWood())
+                .stone(rc.getStone())
+                .food(rc.getFood())
+                .build();
+    }
+
+    public static RenderBuilding toBuilding(final BuildingComponent bc) {
+        return RenderBuilding.builder()
+                .x(bc.getX())
+                .y(bc.getY())
+                .buildingType(bc.getBuildingType().toString())
+                .build();
+    }
+
+    /**
+     * Update an existing {@link SimpleMapRenderData} instance using the current state of the map.
+     * This avoids creating a new object every frame.
+     */
+    public static void update(final MapComponent map, final World world, final SimpleMapRenderData data) {
+        ComponentMapper<TileComponent> tileMapper = world.getMapper(TileComponent.class);
+        ComponentMapper<ResourceComponent> resourceMapper = world.getMapper(ResourceComponent.class);
+        ComponentMapper<BuildingComponent> buildingMapper = world.getMapper(BuildingComponent.class);
+
+        Array<Entity> mapTiles = map.getTiles();
+        for (int i = 0; i < mapTiles.size; i++) {
+            Entity entity = mapTiles.get(i);
+            TileComponent tc = tileMapper.get(entity);
+            ResourceComponent rc = resourceMapper.get(entity);
+            RenderTile tile = toTile(tc, rc);
+            data.updateTile(i, tile);
+        }
+
+        Array<Entity> mapEntities = map.getEntities();
+        Array<RenderBuilding> buildings = data.getBuildings();
+        buildings.clear();
+        for (int i = 0; i < mapEntities.size; i++) {
+            Entity entity = mapEntities.get(i);
+            BuildingComponent bc = buildingMapper.get(entity);
+            RenderBuilding building = toBuilding(bc);
+            buildings.add(building);
+        }
     }
 }

--- a/client/src/main/java/net/lapidist/colony/client/render/SimpleMapRenderData.java
+++ b/client/src/main/java/net/lapidist/colony/client/render/SimpleMapRenderData.java
@@ -39,4 +39,21 @@ public final class SimpleMapRenderData implements MapRenderData {
         }
         return tileGrid[x][y];
     }
+
+    /**
+     * Update the tile at the given index and adjust the grid reference.
+     */
+    public void updateTile(final int index, final RenderTile tile) {
+        RenderTile old = tiles.get(index);
+        if (old != null
+                && old.getX() >= 0 && old.getY() >= 0
+                && old.getX() < tileGrid.length && old.getY() < tileGrid[0].length) {
+            tileGrid[old.getX()][old.getY()] = null;
+        }
+        tiles.set(index, tile);
+        if (tile.getX() >= 0 && tile.getY() >= 0
+                && tile.getX() < tileGrid.length && tile.getY() < tileGrid[0].length) {
+            tileGrid[tile.getX()][tile.getY()] = tile;
+        }
+    }
 }

--- a/client/src/main/java/net/lapidist/colony/client/systems/MapRenderDataSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/MapRenderDataSystem.java
@@ -1,9 +1,18 @@
 package net.lapidist.colony.client.systems;
 
 import com.artemis.BaseSystem;
+import com.artemis.ComponentMapper;
+import com.artemis.Entity;
+import com.badlogic.gdx.utils.Array;
 import net.lapidist.colony.client.render.MapRenderData;
 import net.lapidist.colony.client.render.MapRenderDataBuilder;
+import net.lapidist.colony.client.render.SimpleMapRenderData;
+import net.lapidist.colony.client.render.data.RenderBuilding;
+import net.lapidist.colony.client.render.data.RenderTile;
 import net.lapidist.colony.components.maps.MapComponent;
+import net.lapidist.colony.components.maps.TileComponent;
+import net.lapidist.colony.components.resources.ResourceComponent;
+import net.lapidist.colony.components.entities.BuildingComponent;
 import net.lapidist.colony.map.MapUtils;
 
 /**
@@ -13,6 +22,9 @@ public final class MapRenderDataSystem extends BaseSystem {
     private MapRenderData renderData;
     private MapComponent map;
     private int lastVersion;
+    private ComponentMapper<TileComponent> tileMapper;
+    private ComponentMapper<ResourceComponent> resourceMapper;
+    private ComponentMapper<BuildingComponent> buildingMapper;
 
     public MapRenderData getRenderData() {
         return renderData;
@@ -20,6 +32,9 @@ public final class MapRenderDataSystem extends BaseSystem {
 
     @Override
     public void initialize() {
+        tileMapper = world.getMapper(TileComponent.class);
+        resourceMapper = world.getMapper(ResourceComponent.class);
+        buildingMapper = world.getMapper(BuildingComponent.class);
         map = MapUtils.findMap(world).orElse(null);
         if (map != null) {
             renderData = MapRenderDataBuilder.fromMap(map, world);
@@ -35,9 +50,66 @@ public final class MapRenderDataSystem extends BaseSystem {
                 return;
             }
         }
-        if (map.getVersion() != lastVersion) {
+        if (renderData == null) {
             renderData = MapRenderDataBuilder.fromMap(map, world);
             lastVersion = map.getVersion();
+            return;
         }
+        if (map.getVersion() != lastVersion) {
+            updateIncremental();
+            lastVersion = map.getVersion();
+        }
+    }
+
+    private void updateIncremental() {
+        SimpleMapRenderData data = (SimpleMapRenderData) renderData;
+
+        Array<Entity> mapTiles = map.getTiles();
+        for (int i = 0; i < mapTiles.size; i++) {
+            Entity entity = mapTiles.get(i);
+            TileComponent tc = tileMapper.get(entity);
+            ResourceComponent rc = resourceMapper.get(entity);
+            RenderTile old = data.getTiles().get(i);
+            if (old == null || tileChanged(old, tc, rc)) {
+                RenderTile tile = MapRenderDataBuilder.toTile(tc, rc);
+                data.updateTile(i, tile);
+            }
+        }
+
+        Array<Entity> mapEntities = map.getEntities();
+        Array<RenderBuilding> buildings = data.getBuildings();
+        if (mapEntities.size != buildings.size) {
+            buildings.clear();
+            for (int i = 0; i < mapEntities.size; i++) {
+                Entity e = mapEntities.get(i);
+                BuildingComponent bc = buildingMapper.get(e);
+                buildings.add(MapRenderDataBuilder.toBuilding(bc));
+            }
+        } else {
+            for (int i = 0; i < mapEntities.size; i++) {
+                Entity e = mapEntities.get(i);
+                BuildingComponent bc = buildingMapper.get(e);
+                RenderBuilding old = buildings.get(i);
+                if (old == null || buildingChanged(old, bc)) {
+                    buildings.set(i, MapRenderDataBuilder.toBuilding(bc));
+                }
+            }
+        }
+    }
+
+    private static boolean tileChanged(final RenderTile old, final TileComponent tc, final ResourceComponent rc) {
+        return old.getX() != tc.getX()
+                || old.getY() != tc.getY()
+                || !old.getTileType().equals(tc.getTileType().toString())
+                || old.isSelected() != tc.isSelected()
+                || old.getWood() != rc.getWood()
+                || old.getStone() != rc.getStone()
+                || old.getFood() != rc.getFood();
+    }
+
+    private static boolean buildingChanged(final RenderBuilding old, final BuildingComponent bc) {
+        return old.getX() != bc.getX()
+                || old.getY() != bc.getY()
+                || !old.getBuildingType().equals(bc.getBuildingType().toString());
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/render/data/MapRenderDataBuilderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/render/data/MapRenderDataBuilderTest.java
@@ -5,6 +5,7 @@ import com.artemis.WorldConfigurationBuilder;
 import net.lapidist.colony.map.MapFactory;
 import net.lapidist.colony.client.render.MapRenderData;
 import net.lapidist.colony.client.render.MapRenderDataBuilder;
+import net.lapidist.colony.client.render.SimpleMapRenderData;
 import net.lapidist.colony.components.maps.MapComponent;
 import net.lapidist.colony.components.state.BuildingData;
 import net.lapidist.colony.components.state.MapState;
@@ -44,5 +45,26 @@ public class MapRenderDataBuilderTest {
         assertEquals(1, tile.getWood());
         assertEquals(BUILDING_X, data.getBuildings().first().getX());
         assertEquals(tile, data.getTile(TILE_X, TILE_Y));
+    }
+
+    @Test
+    public void updatesExistingRenderData() {
+        MapState state = new MapState();
+        state.tiles().put(new TilePos(0, 0), TileData.builder()
+                .x(0).y(0).tileType("GRASS").passable(true)
+                .build());
+
+        World world = new World(new WorldConfigurationBuilder().build());
+        MapComponent map = MapFactory.create(world, state).getComponent(MapComponent.class);
+
+        SimpleMapRenderData data = (SimpleMapRenderData) MapRenderDataBuilder.fromMap(map, world);
+
+        var tileEntity = map.getTiles().first();
+        world.getMapper(net.lapidist.colony.components.maps.TileComponent.class)
+                .get(tileEntity).setSelected(true);
+
+        MapRenderDataBuilder.update(map, world, data);
+
+        assertTrue(data.getTiles().first().isSelected());
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/MapRenderDataSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/MapRenderDataSystemTest.java
@@ -58,13 +58,15 @@ public class MapRenderDataSystemTest {
                 .build());
         world.process();
         MapRenderDataSystem system = world.getSystem(MapRenderDataSystem.class);
-        assertFalse(system.getRenderData().getTiles().first().isSelected());
+        var firstData = system.getRenderData();
+        assertFalse(firstData.getTiles().first().isSelected());
         var map = net.lapidist.colony.map.MapUtils.findMap(world).orElseThrow();
         var tile = map.getTiles().first();
         world.getMapper(net.lapidist.colony.components.maps.TileComponent.class)
                 .get(tile).setSelected(true);
         map.incrementVersion();
         world.process();
+        assertSame(firstData, system.getRenderData());
         assertTrue(system.getRenderData().getTiles().first().isSelected());
         world.dispose();
     }

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/MapRenderSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/MapRenderSystemTest.java
@@ -7,6 +7,7 @@ import net.lapidist.colony.client.systems.MapRenderSystem;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
 import net.lapidist.colony.client.systems.MapInitSystem;
 import net.lapidist.colony.client.systems.MapRenderDataSystem;
+import net.lapidist.colony.client.render.MapRenderData;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.TilePos;
@@ -137,7 +138,8 @@ public class MapRenderSystemTest {
         MapRenderSystem system = world.getSystem(MapRenderSystem.class);
         Field mapField = MapRenderSystem.class.getDeclaredField("mapData");
         mapField.setAccessible(true);
-        Object first = mapField.get(system);
+        MapRenderData first = (MapRenderData) mapField.get(system);
+        assertFalse(first.getTiles().first().isSelected());
 
         var map = net.lapidist.colony.map.MapUtils.findMap(world).orElseThrow();
         var entity = map.getTiles().first();
@@ -148,8 +150,9 @@ public class MapRenderSystemTest {
         world.process();
         world.process();
 
-        Object second = mapField.get(system);
-        assertNotSame(first, second);
+        MapRenderData second = (MapRenderData) mapField.get(system);
+        assertSame(first, second);
+        assertTrue(second.getTiles().first().isSelected());
         world.dispose();
     }
 }


### PR DESCRIPTION
## Summary
- allow `MapRenderDataBuilder` to update an existing render data instance
- expose `updateTile` in `SimpleMapRenderData`
- track changed tiles in `MapRenderDataSystem`
- adjust render system tests for incremental updates
- verify builder update behaviour via new tests

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684a8224335c83289ad0e94bda237670