### PR TITLE
feat: cull sprite caches outside viewport

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/renderers/SpriteBatchMapRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/SpriteBatchMapRenderer.java
@@ -45,7 +45,7 @@ public final class SpriteBatchMapRenderer implements MapRenderer, Disposable {
         spriteBatch.begin();
 
         if (cacheEnabled) {
-            tileCache.draw(spriteBatch);
+            tileCache.draw(spriteBatch, camera);
             tileRenderer.setOverlayOnly(true);
         } else {
             tileRenderer.setOverlayOnly(false);


### PR DESCRIPTION
## Summary
- track bounds for each `SpriteCache`
- skip drawing caches outside the camera view
- update tests for culling logic

## Testing
- `./scripts/check.sh`
- `./gradlew codeCoverageReport`

------
https://chatgpt.com/codex/tasks/task_e_684a97a3779c83289dde29efdea34cee