### PR TITLE
feat: optimize resource rendering

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/renderers/ResourceRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/ResourceRenderer.java
@@ -10,12 +10,14 @@ import net.lapidist.colony.client.systems.CameraProvider;
 import net.lapidist.colony.client.util.CameraUtils;
 import net.lapidist.colony.client.render.data.RenderTile;
 import net.lapidist.colony.client.render.MapRenderData;
+import net.lapidist.colony.client.systems.MapRenderDataSystem;
 import com.badlogic.gdx.utils.Disposable;
 
 /** Draws resource amounts on tiles. */
 public final class ResourceRenderer implements EntityRenderer<RenderTile>, Disposable {
     private final SpriteBatch spriteBatch;
     private final CameraProvider cameraSystem;
+    private final MapRenderDataSystem dataSystem;
     private final BitmapFont font = new BitmapFont();
     private final GlyphLayout layout = new GlyphLayout();
     private final StringBuilder textBuilder = new StringBuilder();
@@ -23,10 +25,12 @@ public final class ResourceRenderer implements EntityRenderer<RenderTile>, Dispo
 
     public ResourceRenderer(
             final SpriteBatch spriteBatchToUse,
-            final CameraProvider cameraSystemToUse
+            final CameraProvider cameraSystemToUse,
+            final MapRenderDataSystem dataSystemToUse
     ) {
         this.spriteBatch = spriteBatchToUse;
         this.cameraSystem = cameraSystemToUse;
+        this.dataSystem = dataSystemToUse;
     }
 
     @Override
@@ -34,11 +38,13 @@ public final class ResourceRenderer implements EntityRenderer<RenderTile>, Dispo
         Array<RenderTile> entities = map.getTiles();
         Vector2 worldCoords = new Vector2();
         Vector3 tmp = new Vector3();
-        for (int i = 0; i < entities.size; i++) {
-            RenderTile tile = entities.get(i);
-            if (!tile.isSelected()) {
+        com.badlogic.gdx.utils.IntArray indices = dataSystem.getSelectedTileIndices();
+        for (int j = 0; j < indices.size; j++) {
+            int i = indices.get(j);
+            if (i < 0 || i >= entities.size) {
                 continue;
             }
+            RenderTile tile = entities.get(i);
             CameraUtils.tileCoordsToWorldCoords(tile.getX(), tile.getY(), worldCoords);
             if (!CameraUtils.withinCameraView(cameraSystem.getViewport(), worldCoords, tmp)) {
                 continue;

--- a/client/src/main/java/net/lapidist/colony/client/renderers/SpriteMapRendererFactory.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/SpriteMapRendererFactory.java
@@ -7,6 +7,7 @@ import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.client.core.io.TextureAtlasResourceLoader;
 import net.lapidist.colony.client.systems.CameraProvider;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
+import net.lapidist.colony.client.systems.MapRenderDataSystem;
 import net.lapidist.colony.settings.GraphicsSettings;
 import net.lapidist.colony.settings.Settings;
 import net.lapidist.colony.components.maps.MapComponent;
@@ -83,7 +84,8 @@ public final class SpriteMapRendererFactory implements MapRendererFactory {
         );
         ResourceRenderer resourceRenderer = new ResourceRenderer(
                 batch,
-                cameraSystem
+                cameraSystem,
+                world.getSystem(MapRenderDataSystem.class)
         );
 
         // trigger map mapper initialization so MapRenderSystem can use it immediately

--- a/client/src/main/java/net/lapidist/colony/client/systems/MapRenderDataSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/MapRenderDataSystem.java
@@ -26,9 +26,15 @@ public final class MapRenderDataSystem extends BaseSystem {
     private ComponentMapper<TileComponent> tileMapper;
     private ComponentMapper<ResourceComponent> resourceMapper;
     private ComponentMapper<BuildingComponent> buildingMapper;
+    private final IntArray selectedTileIndices = new IntArray();
 
     public MapRenderData getRenderData() {
         return renderData;
+    }
+
+    /** Returns the indices of currently selected tiles. */
+    public IntArray getSelectedTileIndices() {
+        return selectedTileIndices;
     }
 
     @Override
@@ -40,6 +46,7 @@ public final class MapRenderDataSystem extends BaseSystem {
         if (map != null) {
             renderData = MapRenderDataBuilder.fromMap(map, world);
             lastVersion = map.getVersion();
+            rebuildSelectedIndices();
         }
     }
 
@@ -54,6 +61,7 @@ public final class MapRenderDataSystem extends BaseSystem {
         if (renderData == null) {
             renderData = MapRenderDataBuilder.fromMap(map, world);
             lastVersion = map.getVersion();
+            rebuildSelectedIndices();
             return;
         }
         if (map.getVersion() != lastVersion) {
@@ -67,6 +75,7 @@ public final class MapRenderDataSystem extends BaseSystem {
 
         IntArray modified = new IntArray();
         Array<Entity> mapTiles = map.getTiles();
+        selectedTileIndices.clear();
         for (int i = 0; i < mapTiles.size; i++) {
             Entity entity = mapTiles.get(i);
             TileComponent tc = tileMapper.get(entity);
@@ -74,6 +83,9 @@ public final class MapRenderDataSystem extends BaseSystem {
             RenderTile old = data.getTiles().get(i);
             if (old == null || tileChanged(old, tc, rc)) {
                 modified.add(i);
+            }
+            if (tc.isSelected()) {
+                selectedTileIndices.add(i);
             }
         }
 
@@ -118,5 +130,20 @@ public final class MapRenderDataSystem extends BaseSystem {
         return old.getX() != bc.getX()
                 || old.getY() != bc.getY()
                 || !old.getBuildingType().equals(bc.getBuildingType().toString());
+    }
+
+    private void rebuildSelectedIndices() {
+        if (map == null) {
+            selectedTileIndices.clear();
+            return;
+        }
+        selectedTileIndices.clear();
+        Array<Entity> mapTiles = map.getTiles();
+        for (int i = 0; i < mapTiles.size; i++) {
+            TileComponent tc = tileMapper.get(mapTiles.get(i));
+            if (tc.isSelected()) {
+                selectedTileIndices.add(i);
+            }
+        }
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/MapRenderDataSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/MapRenderDataSystemTest.java
@@ -47,6 +47,29 @@ public class MapRenderDataSystemTest {
     }
 
     @Test
+    public void tracksSelectedTileIndices() {
+        MapState state = new MapState();
+        state.tiles().put(new TilePos(0, 0), TileData.builder()
+                .x(0).y(0).tileType("GRASS").passable(true).selected(true)
+                .build());
+        state.tiles().put(new TilePos(1, 0), TileData.builder()
+                .x(1).y(0).tileType("GRASS").passable(true)
+                .build());
+
+        World world = new World(new WorldConfigurationBuilder()
+                .with(new MapInitSystem(new ProvidedMapStateProvider(state)),
+                        new MapRenderDataSystem())
+                .build());
+        world.process();
+
+        MapRenderDataSystem system = world.getSystem(MapRenderDataSystem.class);
+        assertEquals(1, system.getSelectedTileIndices().size);
+        assertEquals(0, system.getSelectedTileIndices().first());
+
+        world.dispose();
+    }
+
+    @Test
     public void updatesWhenMapChanges() {
         MapState state = new MapState();
         state.tiles().put(new TilePos(0, 0), TileData.builder()
@@ -68,6 +91,8 @@ public class MapRenderDataSystemTest {
         world.process();
         assertSame(firstData, system.getRenderData());
         assertTrue(system.getRenderData().getTiles().first().isSelected());
+        assertEquals(1, system.getSelectedTileIndices().size);
+        assertEquals(0, system.getSelectedTileIndices().first());
         world.dispose();
     }
 


### PR DESCRIPTION
## Summary
- track selected tile indices in `MapRenderDataSystem`
- render resources only for selected tiles using `ResourceRenderer`
- adjust factory to supply the data system
- test selected tile tracking and limited iteration

## Testing
- `./gradlew spotlessApply`
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_684a9d9b8fd8832891751be22ba383c5