### PR TITLE
fix: remove duplicate test causing build failure

### DIFF
--- a/tests/src/test/java/net/lapidist/colony/tests/systems/MapRenderDataSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/MapRenderDataSystemTest.java
@@ -96,41 +96,6 @@ public class MapRenderDataSystemTest {
         world.dispose();
     }
 
-    @Test
-    public void onlyChangedTilesAreReplaced() {
-        MapState state = new MapState();
-        state.tiles().put(new TilePos(0, 0), TileData.builder()
-                .x(0).y(0).tileType("GRASS").passable(true)
-                .build());
-        state.tiles().put(new TilePos(1, 0), TileData.builder()
-                .x(1).y(0).tileType("GRASS").passable(true)
-                .build());
-
-        World world = new World(new WorldConfigurationBuilder()
-                .with(new MapInitSystem(new ProvidedMapStateProvider(state)),
-                        new MapRenderDataSystem())
-                .build());
-        world.process();
-
-        MapRenderDataSystem system = world.getSystem(MapRenderDataSystem.class);
-        var data = (net.lapidist.colony.client.render.SimpleMapRenderData) system.getRenderData();
-        var firstTile = data.getTiles().get(0);
-        var secondTile = data.getTiles().get(1);
-
-        var map = net.lapidist.colony.map.MapUtils.findMap(world).orElseThrow();
-        var entity = map.getTiles().first();
-        world.getMapper(net.lapidist.colony.components.maps.TileComponent.class)
-                .get(entity).setSelected(true);
-        map.incrementVersion();
-
-        world.process();
-
-        var updated = (net.lapidist.colony.client.render.SimpleMapRenderData) system.getRenderData();
-        assertNotSame(firstTile, updated.getTiles().get(0));
-        assertSame(secondTile, updated.getTiles().get(1));
-        assertTrue(updated.getTiles().get(0).isSelected());
-        world.dispose();
-    }
 
     @Test
     public void onlyChangedTilesAreReplaced() {


### PR DESCRIPTION
## Summary
- remove duplicate `onlyChangedTilesAreReplaced` test

## Testing
- `./gradlew clean test`
- `./gradlew check`
- `./scripts/check.sh`


------
https://chatgpt.com/codex/tasks/task_e_684aa6266040832895b5650950dd54a9