### PR TITLE
fix: enable headless render benchmark

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -43,3 +43,9 @@ To execute a specific benchmark use the `jmh.include` property:
 ```bash
 ./gradlew :tests:jmh -Djmh.include=SpriteBatchRendererBenchmark
 ```
+
+## Rendering pipeline benchmark
+
+`SpriteBatchRendererBenchmark` measures the render system with and without tile
+caching enabled. Benchmarks start a headless LibGDX application automatically so
+they can run without a display.

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -38,4 +38,10 @@ tasks.register('copyAssets', Copy) {
     into file(".")
 }
 
+jmh {
+    iterations = 1
+    warmupIterations = 1
+    fork = 1
+}
+
 eclipse.project.name = "$appName-tests"

--- a/tests/src/jmh/java/net/lapidist/colony/client/renderers/MapTileCacheBenchmark.java
+++ b/tests/src/jmh/java/net/lapidist/colony/client/renderers/MapTileCacheBenchmark.java
@@ -18,6 +18,7 @@ import net.lapidist.colony.client.systems.CameraProvider;
 import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.components.maps.MapComponent;
 import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.tests.GdxBenchmarkEnvironment;
 import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.map.MapFactory;
@@ -32,7 +33,7 @@ import org.mockito.MockedConstruction;
 import static org.mockito.Mockito.*;
 
 @State(Scope.Thread)
-public final class MapTileCacheBenchmark {
+public class MapTileCacheBenchmark {
 
     private static final int MAP_SIZE = 30;
 
@@ -44,7 +45,8 @@ public final class MapTileCacheBenchmark {
     private MockedConstruction<SpriteCache> construction;
 
     @Setup(Level.Trial)
-    public void setUp() {
+    public final void setUp() {
+        GdxBenchmarkEnvironment.init();
         loader = mock(ResourceLoader.class);
         when(loader.findRegion(any())).thenReturn(new TextureRegion());
         resolver = new DefaultAssetResolver();
@@ -58,7 +60,7 @@ public final class MapTileCacheBenchmark {
     }
 
     @TearDown(Level.Trial)
-    public void tearDown() {
+    public final void tearDown() {
         construction.close();
     }
 
@@ -101,7 +103,7 @@ public final class MapTileCacheBenchmark {
     }
 
     @Benchmark
-    public void rebuildCache() {
+    public final void rebuildCache() {
         cache.invalidate();
         cache.ensureCache(loader, data, resolver, camera);
     }

--- a/tests/src/jmh/java/net/lapidist/colony/tests/GdxBenchmarkEnvironment.java
+++ b/tests/src/jmh/java/net/lapidist/colony/tests/GdxBenchmarkEnvironment.java
@@ -1,0 +1,58 @@
+package net.lapidist.colony.tests;
+
+import com.badlogic.gdx.ApplicationAdapter;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.backends.headless.HeadlessApplication;
+import com.badlogic.gdx.backends.headless.HeadlessApplicationConfiguration;
+import com.badlogic.gdx.graphics.GL20;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Initializes a LibGDX headless application for JMH benchmarks.
+ */
+public final class GdxBenchmarkEnvironment {
+
+    private static boolean initialized;
+
+    private GdxBenchmarkEnvironment() {
+    }
+
+    /**
+     * Boot LibGDX in headless mode and mock the GL20 context.
+     */
+    public static synchronized void init() {
+        if (initialized) {
+            return;
+        }
+        HeadlessApplicationConfiguration config = new HeadlessApplicationConfiguration();
+        new HeadlessApplication(new ApplicationAdapter() { }, config);
+        Gdx.gl = mock(GL20.class);
+        Gdx.gl20 = Gdx.gl;
+
+        when(Gdx.gl20.glCreateShader(anyInt())).thenReturn(1);
+        when(Gdx.gl20.glCreateProgram()).thenReturn(1);
+        doAnswer(inv -> {
+            java.nio.IntBuffer buf = (java.nio.IntBuffer) inv.getArguments()[2];
+            buf.put(0, 1);
+            return null;
+        }).when(Gdx.gl20).glGetShaderiv(anyInt(), anyInt(), any());
+        doAnswer(inv -> {
+            java.nio.IntBuffer buf = (java.nio.IntBuffer) inv.getArguments()[2];
+            buf.put(0, 1);
+            return null;
+        }).when(Gdx.gl20).glGetProgramiv(anyInt(), anyInt(), any());
+        when(Gdx.gl20.glGetShaderInfoLog(anyInt())).thenReturn("");
+        when(Gdx.gl20.glGetProgramInfoLog(anyInt())).thenReturn("");
+        doNothing().when(Gdx.gl20).glShaderSource(anyInt(), any());
+        doNothing().when(Gdx.gl20).glCompileShader(anyInt());
+        doNothing().when(Gdx.gl20).glAttachShader(anyInt(), anyInt());
+        doNothing().when(Gdx.gl20).glLinkProgram(anyInt());
+        when(Gdx.gl20.glGetAttribLocation(anyInt(), any())).thenReturn(0);
+        when(Gdx.gl20.glGetUniformLocation(anyInt(), any())).thenReturn(0);
+        doNothing().when(Gdx.gl20).glUseProgram(anyInt());
+        doNothing().when(Gdx.gl20).glDeleteShader(anyInt());
+        doNothing().when(Gdx.gl20).glDeleteProgram(anyInt());
+        initialized = true;
+    }
+}

--- a/tests/src/jmh/java/net/lapidist/colony/tests/benchmarks/SpriteBatchRendererBenchmark.java
+++ b/tests/src/jmh/java/net/lapidist/colony/tests/benchmarks/SpriteBatchRendererBenchmark.java
@@ -28,6 +28,7 @@ import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.map.MapFactory;
+import net.lapidist.colony.tests.GdxBenchmarkEnvironment;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Scope;
@@ -39,7 +40,7 @@ import org.mockito.MockedConstruction;
 import static org.mockito.Mockito.*;
 
 @State(Scope.Thread)
-public final class SpriteBatchRendererBenchmark {
+public class SpriteBatchRendererBenchmark {
 
     private static final int MAP_SIZE = 30;
 
@@ -52,7 +53,8 @@ public final class SpriteBatchRendererBenchmark {
     private MockedConstruction<SpriteCache> construction;
 
     @Setup(Level.Trial)
-    public void setUp() {
+    public final void setUp() {
+        GdxBenchmarkEnvironment.init();
         loader = mock(ResourceLoader.class);
         when(loader.findRegion(any())).thenReturn(new TextureRegion());
         resolver = new DefaultAssetResolver();
@@ -73,7 +75,7 @@ public final class SpriteBatchRendererBenchmark {
     }
 
     @TearDown(Level.Trial)
-    public void tearDown() {
+    public final void tearDown() {
         construction.close();
     }
 
@@ -116,12 +118,12 @@ public final class SpriteBatchRendererBenchmark {
     }
 
     @Benchmark
-    public void renderWithCache() {
+    public final void renderWithCache() {
         cachedRenderer.render(data, camera);
     }
 
     @Benchmark
-    public void renderWithoutCache() {
+    public final void renderWithoutCache() {
         plainRenderer.render(data, camera);
     }
 }

--- a/tests/src/jmh/java/net/lapidist/colony/tests/package-info.java
+++ b/tests/src/jmh/java/net/lapidist/colony/tests/package-info.java
@@ -1,0 +1,2 @@
+/** Utilities for JMH benchmarks. */
+package net.lapidist.colony.tests;


### PR DESCRIPTION
## Summary
- start a headless LibGDX context for JMH benchmarks
- allow quick JMH runs by default
- document running SpriteBatchRendererBenchmark

## Testing
- `./scripts/check.sh`
- `./gradlew :tests:jmh -Djmh.include=SpriteBatchRendererBenchmark`

------
https://chatgpt.com/codex/tasks/task_e_684aadcc522c8328b41b5358f53f6844