### PR TITLE
fix: remove duplicate tile update

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/systems/MapRenderDataSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/MapRenderDataSystem.java
@@ -93,10 +93,6 @@ public final class MapRenderDataSystem extends BaseSystem {
             MapRenderDataBuilder.updateTiles(map, world, data, modified);
         }
 
-        if (modified.size > 0) {
-            MapRenderDataBuilder.updateTiles(map, world, data, modified);
-        }
-
         Array<Entity> mapEntities = map.getEntities();
         Array<RenderBuilding> buildings = data.getBuildings();
         if (mapEntities.size != buildings.size) {


### PR DESCRIPTION
## Summary
- avoid running MapRenderDataBuilder.updateTiles twice

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test check`
- `./gradlew :tests:jmh -Djmh.include=SpriteBatchRendererBenchmark`

------
https://chatgpt.com/codex/tasks/task_e_684aba3673748328af01b060763c785a