### PR TITLE
feat: use enum names for render types

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/render/MapRenderDataBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/render/MapRenderDataBuilder.java
@@ -55,7 +55,7 @@ public final class MapRenderDataBuilder {
         return RenderTile.builder()
                 .x(tc.getX())
                 .y(tc.getY())
-                .tileType(tc.getTileType().toString())
+                .tileType(tc.getTileType().name())
                 .selected(tc.isSelected())
                 .wood(rc.getWood())
                 .stone(rc.getStone())
@@ -67,7 +67,7 @@ public final class MapRenderDataBuilder {
         return RenderBuilding.builder()
                 .x(bc.getX())
                 .y(bc.getY())
-                .buildingType(bc.getBuildingType().toString())
+                .buildingType(bc.getBuildingType().name())
                 .build();
     }
 

--- a/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
@@ -56,7 +56,7 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
                 continue;
             }
 
-            TextureRegion region = buildingRegions.get(building.getBuildingType().toUpperCase(java.util.Locale.ROOT));
+            TextureRegion region = buildingRegions.get(building.getBuildingType());
             if (region != null) {
                 spriteBatch.draw(region, worldCoords.x, worldCoords.y);
             }

--- a/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
@@ -80,7 +80,7 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
                 CameraUtils.tileCoordsToWorldCoords(tile.getX(), tile.getY(), worldCoords);
 
                 if (!overlayOnly) {
-                    TextureRegion region = tileRegions.get(tile.getTileType().toUpperCase(java.util.Locale.ROOT));
+                    TextureRegion region = tileRegions.get(tile.getTileType());
                     if (region != null) {
                         spriteBatch.draw(region, worldCoords.x, worldCoords.y);
                     }

--- a/client/src/main/java/net/lapidist/colony/client/systems/MapRenderDataSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/MapRenderDataSystem.java
@@ -119,7 +119,7 @@ public final class MapRenderDataSystem extends BaseSystem {
     private static boolean tileChanged(final RenderTile old, final TileComponent tc, final ResourceComponent rc) {
         return old.getX() != tc.getX()
                 || old.getY() != tc.getY()
-                || !old.getTileType().equals(tc.getTileType().toString())
+                || !old.getTileType().equals(tc.getTileType().name())
                 || old.isSelected() != tc.isSelected()
                 || old.getWood() != rc.getWood()
                 || old.getStone() != rc.getStone()
@@ -129,7 +129,7 @@ public final class MapRenderDataSystem extends BaseSystem {
     private static boolean buildingChanged(final RenderBuilding old, final BuildingComponent bc) {
         return old.getX() != bc.getX()
                 || old.getY() != bc.getY()
-                || !old.getBuildingType().equals(bc.getBuildingType().toString());
+                || !old.getBuildingType().equals(bc.getBuildingType().name());
     }
 
     private void rebuildSelectedIndices() {

--- a/tests/src/test/java/net/lapidist/colony/tests/client/render/data/MapRenderDataBuilderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/render/data/MapRenderDataBuilderTest.java
@@ -41,7 +41,7 @@ public class MapRenderDataBuilderTest {
         assertEquals(1, data.getBuildings().size);
 
         var tile = data.getTiles().first();
-        assertEquals("grass", tile.getTileType());
+        assertEquals("GRASS", tile.getTileType());
         assertEquals(1, tile.getWood());
         assertEquals(BUILDING_X, data.getBuildings().first().getX());
         assertEquals(tile, data.getTile(TILE_X, TILE_Y));


### PR DESCRIPTION
## Summary
- keep tile/building types uppercase when building render data
- drop casing conversions in `TileRenderer` and `BuildingRenderer`
- update update detection to compare enum names
- fix MapRenderDataBuilderTest expectation

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test check`
- `./gradlew :tests:jmh -Djmh.include=SpriteBatchRendererBenchmark`

------
https://chatgpt.com/codex/tasks/task_e_684abd34c94c832898f020d9504e1543