### PR TITLE
perf: eliminate render allocations

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
@@ -22,6 +22,8 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
     private final CameraProvider cameraSystem;
     private final AssetResolver resolver;
     private final java.util.Map<String, TextureRegion> buildingRegions = new java.util.HashMap<>();
+    private final Vector2 worldCoords = new Vector2();
+    private final Vector3 tmp = new Vector3();
 
     public BuildingRenderer(
             final SpriteBatch spriteBatchToSet,
@@ -46,8 +48,6 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
     @Override
     public void render(final MapRenderData map) {
         Array<RenderBuilding> entities = map.getBuildings();
-        Vector2 worldCoords = new Vector2();
-        Vector3 tmp = new Vector3();
         for (int i = 0; i < entities.size; i++) {
             RenderBuilding building = entities.get(i);
             CameraUtils.tileCoordsToWorldCoords(building.getX(), building.getY(), worldCoords);

--- a/client/src/main/java/net/lapidist/colony/client/renderers/MapTileCache.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/MapTileCache.java
@@ -27,6 +27,8 @@ final class MapTileCache implements Disposable {
     private final Array<SpriteCache> spriteCaches = new Array<>();
     private final IntArray cacheIds = new IntArray();
     private final Array<Rectangle> cacheBounds = new Array<>();
+    private final Matrix4 oldProj = new Matrix4();
+    private final Rectangle viewBounds = new Rectangle();
     private MapRenderData cachedData;
     private int cachedVersion;
     private boolean invalidated = true;
@@ -94,13 +96,13 @@ final class MapTileCache implements Disposable {
         if (spriteCaches.isEmpty()) {
             return;
         }
-        Matrix4 oldProj = spriteCaches.first().getProjectionMatrix().cpy();
+        oldProj.set(spriteCaches.first().getProjectionMatrix());
         batch.end();
 
         Rectangle view = CameraUtils.getViewBounds(
                 (OrthographicCamera) camera.getCamera(),
                 (ExtendViewport) camera.getViewport(),
-                new Rectangle()
+                viewBounds
         );
 
         for (int i = 0; i < spriteCaches.size; i++) {

--- a/client/src/main/java/net/lapidist/colony/client/renderers/ResourceRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/ResourceRenderer.java
@@ -21,6 +21,8 @@ public final class ResourceRenderer implements EntityRenderer<RenderTile>, Dispo
     private final BitmapFont font = new BitmapFont();
     private final GlyphLayout layout = new GlyphLayout();
     private final StringBuilder textBuilder = new StringBuilder();
+    private final Vector2 worldCoords = new Vector2();
+    private final Vector3 tmp = new Vector3();
     private static final float OFFSET_Y = 8f;
 
     public ResourceRenderer(
@@ -36,8 +38,6 @@ public final class ResourceRenderer implements EntityRenderer<RenderTile>, Dispo
     @Override
     public void render(final MapRenderData map) {
         Array<RenderTile> entities = map.getTiles();
-        Vector2 worldCoords = new Vector2();
-        Vector3 tmp = new Vector3();
         com.badlogic.gdx.utils.IntArray indices = dataSystem.getSelectedTileIndices();
         for (int j = 0; j < indices.size; j++) {
             int i = indices.get(j);

--- a/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
@@ -23,6 +23,10 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
     private final AssetResolver resolver;
     private final java.util.Map<String, TextureRegion> tileRegions = new java.util.HashMap<>();
     private final TextureRegion overlayRegion;
+    private final Rectangle viewBounds = new Rectangle();
+    private final Vector2 tmpStart = new Vector2();
+    private final Vector2 tmpEnd = new Vector2();
+    private final Vector2 worldCoords = new Vector2();
     private boolean overlayOnly;
 
     public TileRenderer(
@@ -55,12 +59,13 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
         Rectangle view = CameraUtils.getViewBounds(
                 (com.badlogic.gdx.graphics.OrthographicCamera) cameraSystem.getCamera(),
                 (com.badlogic.gdx.utils.viewport.ExtendViewport) cameraSystem.getViewport(),
-                new Rectangle()
+                viewBounds
         );
-        Vector2 start = CameraUtils.worldCoordsToTileCoords((int) view.x, (int) view.y);
+        Vector2 start = CameraUtils.worldCoordsToTileCoords((int) view.x, (int) view.y, tmpStart);
         Vector2 end = CameraUtils.worldCoordsToTileCoords(
                 (int) (view.x + view.width),
-                (int) (view.y + view.height)
+                (int) (view.y + view.height),
+                tmpEnd
         );
 
         int startX = Math.max(0, (int) start.x - 1);
@@ -68,7 +73,6 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
         int endX = Math.min(GameConstants.MAP_WIDTH - 1, (int) end.x + 1);
         int endY = Math.min(GameConstants.MAP_HEIGHT - 1, (int) end.y + 1);
 
-        Vector2 worldCoords = new Vector2();
 
         for (int x = startX; x <= endX; x++) {
             for (int y = startY; y <= endY; y++) {

--- a/client/src/main/java/net/lapidist/colony/client/systems/MapRenderDataSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/MapRenderDataSystem.java
@@ -27,6 +27,7 @@ public final class MapRenderDataSystem extends BaseSystem {
     private ComponentMapper<ResourceComponent> resourceMapper;
     private ComponentMapper<BuildingComponent> buildingMapper;
     private final IntArray selectedTileIndices = new IntArray();
+    private final IntArray modifiedIndices = new IntArray();
 
     public MapRenderData getRenderData() {
         return renderData;
@@ -73,7 +74,7 @@ public final class MapRenderDataSystem extends BaseSystem {
     private void updateIncremental() {
         SimpleMapRenderData data = (SimpleMapRenderData) renderData;
 
-        IntArray modified = new IntArray();
+        modifiedIndices.clear();
         Array<Entity> mapTiles = map.getTiles();
         selectedTileIndices.clear();
         for (int i = 0; i < mapTiles.size; i++) {
@@ -82,15 +83,15 @@ public final class MapRenderDataSystem extends BaseSystem {
             ResourceComponent rc = resourceMapper.get(entity);
             RenderTile old = data.getTiles().get(i);
             if (old == null || tileChanged(old, tc, rc)) {
-                modified.add(i);
+                modifiedIndices.add(i);
             }
             if (tc.isSelected()) {
                 selectedTileIndices.add(i);
             }
         }
 
-        if (modified.size > 0) {
-            MapRenderDataBuilder.updateTiles(map, world, data, modified);
+        if (modifiedIndices.size > 0) {
+            MapRenderDataBuilder.updateTiles(map, world, data, modifiedIndices);
         }
 
         Array<Entity> mapEntities = map.getEntities();

--- a/client/src/main/java/net/lapidist/colony/client/ui/MinimapCache.java
+++ b/client/src/main/java/net/lapidist/colony/client/ui/MinimapCache.java
@@ -25,6 +25,9 @@ final class MinimapCache implements Disposable {
 
     private final Array<SpriteCache> spriteCaches = new Array<>();
     private final IntArray cacheIds = new IntArray();
+    private final Matrix4 oldProj = new Matrix4();
+    private final Matrix4 oldTrans = new Matrix4();
+    private final Matrix4 transform = new Matrix4();
     private int cacheWidth;
     private int cacheHeight;
     private boolean invalidated = true;
@@ -89,13 +92,14 @@ final class MinimapCache implements Disposable {
         if (spriteCaches.isEmpty()) {
             return;
         }
-        Matrix4 oldProj = spriteCaches.first().getProjectionMatrix().cpy();
-        Matrix4 oldTrans = spriteCaches.first().getTransformMatrix().cpy();
+        oldProj.set(spriteCaches.first().getProjectionMatrix());
+        oldTrans.set(spriteCaches.first().getTransformMatrix());
         batch.end();
         for (int i = 0; i < spriteCaches.size; i++) {
             SpriteCache cache = spriteCaches.get(i);
             cache.setProjectionMatrix(batch.getProjectionMatrix());
-            cache.setTransformMatrix(new Matrix4().setToTranslation(x, y, 0));
+            transform.setToTranslation(x, y, 0);
+            cache.setTransformMatrix(transform);
             cache.begin();
             cache.draw(cacheIds.get(i));
             cache.end();

--- a/client/src/main/java/net/lapidist/colony/client/ui/ViewportOverlayRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/ui/ViewportOverlayRenderer.java
@@ -18,6 +18,9 @@ final class ViewportOverlayRenderer implements Disposable {
 
     private final PlayerCameraSystem cameraSystem;
     private ShapeRenderer shapeRenderer;
+    private final Rectangle viewBounds = new Rectangle();
+    private final Vector2 bottomLeft = new Vector2();
+    private final Vector2 topRight = new Vector2();
 
     ViewportOverlayRenderer(final PlayerCameraSystem system) {
         this.cameraSystem = system;
@@ -41,10 +44,10 @@ final class ViewportOverlayRenderer implements Disposable {
         Rectangle view = CameraUtils.getViewBounds(
                 (com.badlogic.gdx.graphics.OrthographicCamera) cameraSystem.getCamera(),
                 (com.badlogic.gdx.utils.viewport.ExtendViewport) cameraSystem.getViewport(),
-                new Rectangle()
+                viewBounds
         );
-        Vector2 bottomLeft = new Vector2(view.x, view.y);
-        Vector2 topRight = new Vector2(view.x + view.width, view.y + view.height);
+        bottomLeft.set(view.x, view.y);
+        topRight.set(view.x + view.width, view.y + view.height);
 
         float clampedLeft = Math.max(0, bottomLeft.x);
         float clampedBottom = Math.max(0, bottomLeft.y);


### PR DESCRIPTION
## Summary
- reuse IntArray in `MapRenderDataSystem`
- cache view and projection objects in renderers
- avoid per-frame allocations for rendering helpers

## Testing
- `./gradlew spotlessApply`
- `./gradlew tests:copyAssets`
- `./gradlew clean test check`
- `./gradlew codeCoverageReport`
- `./gradlew :tests:jmh -Djmh.include=SpriteBatchRendererBenchmark`


------
https://chatgpt.com/codex/tasks/task_e_684abf81c4e08328a0a97202d221cb28