### PR TITLE
docs: clarify benchmark updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,10 +32,10 @@ Each module contains its own `AGENTS.md` with extra notes.
 ## Testing and Coverage
 - Achieve **at least 80% line coverage** on new or modified code.
 - Run `./gradlew codeCoverageReport` and inspect `build/reports/jacoco` before opening a PR.
-- For new gameplay mechanisms, add a scenario test using `GameSimulation` in the `tests` module.
+ - For new gameplay mechanisms, add a scenario test using `GameSimulation` in the `tests` module.
  - When modifying the rendering system, rerun the benchmarks described in `docs/performance.md` and compare the results
-   to the previous run. If rendering becomes slower you should rethink your changes. When accepting a slower result,
-   update the recorded numbers in `docs/performance.md` so future runs have an accurate baseline.
+    to the previous run. Avoid introducing changes that make benchmarks slower. Whenever results change, update
+    `docs/performance.md` with the new numbers so future runs have an accurate baseline.
 
 ## Save Format and Serialization
 When changing save formats or Kryo serialization:

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,4 +13,5 @@ This directory contains all guides for the Colony project. References are groupe
 - [Localization Guide](i18n.md)
 - [Configuration Guide](configuration.md)
 - [Contributing Guide](../CONTRIBUTING.md) – coding conventions and contribution process.
- - [Performance Notes](performance.md) – benchmarking of data structures and renderer performance. Update the numbers if reruns produce slower results.
+ - [Performance Notes](performance.md) – benchmarking of data structures and renderer performance.
+   Update the numbers whenever benchmarks change and strive to keep them from increasing.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -64,4 +64,6 @@ they can run without a display.
 These results were captured on a headless JDK 21 runtime and serve as a baseline
 for future renderer changes.
 When rerunning these benchmarks, record any updated scores here. If your new
-baseline is lower, update the table so performance regressions are visible.
+baseline is higher or lower, update the table so the current performance
+expectations remain accurate. Avoid shipping slower results without a strong
+reason.


### PR DESCRIPTION
## Summary
- clarify instructions in `AGENTS.md` to always update performance benchmarks
- note in docs that faster or slower benchmarks should update numbers and avoid slowdowns

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684acb2f045c832887edaeb06eae13a4