### PR TITLE
feat: queue dirty tile indices in MapRenderDataSystem

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/systems/network/ResourceUpdateSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/network/ResourceUpdateSystem.java
@@ -55,6 +55,11 @@ public final class ResourceUpdateSystem extends BaseSystem {
                         rc.setStone(data.stone());
                         rc.setFood(data.food());
                         rc.setDirty(true);
+                        int index = mapComponent.getTiles().indexOf(tile, true);
+                        var ds = world.getSystem(net.lapidist.colony.client.systems.MapRenderDataSystem.class);
+                        if (ds != null) {
+                            ds.addDirtyIndex(index);
+                        }
                         if (player != null) {
                             var pr = playerMapper.get(player);
                             if (deltaWood > 0) {

--- a/client/src/main/java/net/lapidist/colony/client/systems/network/TileUpdateSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/network/TileUpdateSystem.java
@@ -41,6 +41,11 @@ public final class TileUpdateSystem extends BaseSystem {
                         var tc = tileMapper.get(t);
                         tc.setSelected(data.selected());
                         tc.setDirty(true);
+                        int index = mapComponent.getTiles().indexOf(t, true);
+                        var ds = world.getSystem(net.lapidist.colony.client.systems.MapRenderDataSystem.class);
+                        if (ds != null) {
+                            ds.addDirtyIndex(index);
+                        }
                         mapComponent.incrementVersion();
                     });
         }

--- a/tests/src/jmh/java/net/lapidist/colony/client/systems/MapRenderDataSystemBenchmark.java
+++ b/tests/src/jmh/java/net/lapidist/colony/client/systems/MapRenderDataSystemBenchmark.java
@@ -74,6 +74,7 @@ public class MapRenderDataSystemBenchmark {
             TileComponent tc = tileMapper.get(e);
             tc.setSelected(!tc.isSelected());
             tc.setDirty(true);
+            system.addDirtyIndex(0);
             map.incrementVersion();
         }
         update.invoke(system);

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/MapRenderDataSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/MapRenderDataSystemTest.java
@@ -89,6 +89,7 @@ public class MapRenderDataSystemTest {
                 .get(tile);
         tc.setSelected(true);
         tc.setDirty(true);
+        system.addDirtyIndex(0);
         map.incrementVersion();
         world.process();
         assertSame(firstData, system.getRenderData());
@@ -127,6 +128,7 @@ public class MapRenderDataSystemTest {
                 .get(entity);
         tc.setSelected(true);
         tc.setDirty(true);
+        system.addDirtyIndex(0);
         map.incrementVersion();
 
         world.process();

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/MapRenderSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/MapRenderSystemTest.java
@@ -147,6 +147,7 @@ public class MapRenderSystemTest {
                 .get(entity);
         tc.setSelected(true);
         tc.setDirty(true);
+        dataSystem.addDirtyIndex(0);
         map.incrementVersion();
 
         world.process();

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/ResourceUpdateSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/ResourceUpdateSystemTest.java
@@ -8,6 +8,7 @@ import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.client.systems.PlayerInitSystem;
 import net.lapidist.colony.client.systems.network.MapLoadSystem;
 import net.lapidist.colony.client.systems.network.ResourceUpdateSystem;
+import net.lapidist.colony.client.systems.MapRenderDataSystem;
 import net.lapidist.colony.components.maps.MapComponent;
 import net.lapidist.colony.components.resources.PlayerResourceComponent;
 import net.lapidist.colony.components.resources.ResourceComponent;
@@ -44,11 +45,13 @@ public class ResourceUpdateSystemTest {
 
         GameClient client = new GameClient();
         World world = new World(new WorldConfigurationBuilder()
-                .with(new MapLoadSystem(state), new PlayerInitSystem(), new ResourceUpdateSystem(client))
+                .with(new MapLoadSystem(state), new PlayerInitSystem(), new MapRenderDataSystem(),
+                        new ResourceUpdateSystem(client))
                 .build());
         world.process();
 
         client.injectResourceUpdate(new ResourceUpdateData(0, 0, UPDATED_WOOD, 0, 0));
+        world.process();
         world.process();
 
         com.artemis.utils.IntBag maps = world.getAspectSubscriptionManager()

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/TileUpdateSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/TileUpdateSystemTest.java
@@ -8,6 +8,7 @@ import com.artemis.utils.IntBag;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.client.systems.network.MapLoadSystem;
 import net.lapidist.colony.client.systems.network.TileUpdateSystem;
+import net.lapidist.colony.client.systems.MapRenderDataSystem;
 import net.lapidist.colony.components.maps.MapComponent;
 import net.lapidist.colony.components.maps.TileComponent;
 import net.lapidist.colony.components.state.MapState;
@@ -36,7 +37,7 @@ public class TileUpdateSystemTest {
 
         GameClient client = new GameClient();
         World world = new World(new WorldConfigurationBuilder()
-                .with(new MapLoadSystem(state), new TileUpdateSystem(client))
+                .with(new MapLoadSystem(state), new MapRenderDataSystem(), new TileUpdateSystem(client))
                 .build());
 
         world.process();
@@ -44,6 +45,7 @@ public class TileUpdateSystemTest {
         TileSelectionData data = new TileSelectionData(0, 0, true);
         client.injectTileSelectionUpdate(data);
 
+        world.process();
         world.process();
 
         IntBag maps = world.getAspectSubscriptionManager()


### PR DESCRIPTION
## Summary
- keep a queue of dirty tile indices in `MapRenderDataSystem`
- enqueue index when `TileUpdateSystem` and `ResourceUpdateSystem` mark tiles dirty
- update incremental render logic to only rebuild queued indices
- adjust tests for the new mechanism

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684af383fec883289d3b1a0190e5c416