### PR TITLE
feat: selective tile cache rebuilds

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/renderers/SpriteBatchMapRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/SpriteBatchMapRenderer.java
@@ -36,6 +36,13 @@ public final class SpriteBatchMapRenderer implements MapRenderer, Disposable {
         this.cacheEnabled = cacheEnabledToSet;
     }
 
+    /** Invalidate cache segments for the given tile indices. */
+    public void invalidateTiles(final com.badlogic.gdx.utils.IntArray indices) {
+        if (cacheEnabled) {
+            tileCache.invalidateTiles(indices);
+        }
+    }
+
     @Override
     public void render(final MapRenderData map, final CameraProvider camera) {
         spriteBatch.setProjectionMatrix(camera.getCamera().combined);

--- a/client/src/main/java/net/lapidist/colony/client/systems/MapRenderDataSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/MapRenderDataSystem.java
@@ -27,6 +27,7 @@ public final class MapRenderDataSystem extends BaseSystem {
     private ComponentMapper<BuildingComponent> buildingMapper;
     private final IntArray selectedTileIndices = new IntArray();
     private final IntArray dirtyIndices = new IntArray();
+    private final IntArray updatedIndices = new IntArray();
 
     public MapRenderData getRenderData() {
         return renderData;
@@ -40,6 +41,13 @@ public final class MapRenderDataSystem extends BaseSystem {
     /** Queues a tile index to be refreshed on the next update. */
     public void addDirtyIndex(final int index) {
         dirtyIndices.add(index);
+    }
+
+    /** Returns and clears the indices updated in the last tick. */
+    public IntArray consumeUpdatedIndices() {
+        IntArray copy = new IntArray(updatedIndices);
+        updatedIndices.clear();
+        return copy;
     }
 
     @Override
@@ -102,6 +110,8 @@ public final class MapRenderDataSystem extends BaseSystem {
 
         if (dirtyIndices.size > 0) {
             MapRenderDataBuilder.updateTiles(map, world, data, dirtyIndices);
+            updatedIndices.clear();
+            updatedIndices.addAll(dirtyIndices);
         }
         dirtyIndices.clear();
 

--- a/client/src/main/java/net/lapidist/colony/client/systems/MapRenderSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/MapRenderSystem.java
@@ -3,6 +3,8 @@ package net.lapidist.colony.client.systems;
 import com.artemis.BaseSystem;
 import net.lapidist.colony.client.render.MapRenderData;
 import net.lapidist.colony.client.renderers.MapRenderer;
+import net.lapidist.colony.client.renderers.SpriteBatchMapRenderer;
+import com.badlogic.gdx.utils.IntArray;
 
 public final class MapRenderSystem extends BaseSystem {
 
@@ -34,6 +36,10 @@ public final class MapRenderSystem extends BaseSystem {
     protected void processSystem() {
         MapRenderDataSystem dataSystem = world.getSystem(MapRenderDataSystem.class);
         if (dataSystem != null) {
+            IntArray updated = dataSystem.consumeUpdatedIndices();
+            if (updated.size > 0 && mapRenderer instanceof SpriteBatchMapRenderer sb) {
+                sb.invalidateTiles(updated);
+            }
             mapData = dataSystem.getRenderData();
         }
         if (mapData == null) {

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -62,7 +62,8 @@ they can run without a display.
 
 | Benchmark | Score (ops/s) |
 |-----------|---------------|
-| MapTileCacheBenchmark.rebuildCache | ~45 |
+| MapTileCacheBenchmark.rebuildCache | ~3.9 |
+| MapTileCacheBenchmark.updateTile | ~3.8 |
 | MapRenderDataSystemBenchmark.updateIncremental (30) | ~138,000 |
 | MapRenderDataSystemBenchmark.updateIncremental (60) | ~31,000 |
 | MapRenderDataSystemBenchmark.updateIncremental (90) | ~10,700 |

--- a/tests/src/jmh/java/net/lapidist/colony/client/renderers/MapTileCacheBenchmark.java
+++ b/tests/src/jmh/java/net/lapidist/colony/client/renderers/MapTileCacheBenchmark.java
@@ -35,13 +35,14 @@ import static org.mockito.Mockito.*;
 @State(Scope.Thread)
 public class MapTileCacheBenchmark {
 
-    private static final int MAP_SIZE = 30;
+    private static final int MAP_SIZE = 120;
 
     private MapTileCache cache;
     private MapRenderData data;
     private ResourceLoader loader;
     private CameraProvider camera;
     private AssetResolver resolver;
+    private com.badlogic.gdx.utils.IntArray updateIndices;
     private MockedConstruction<SpriteCache> construction;
 
     @Setup(Level.Trial)
@@ -53,6 +54,7 @@ public class MapTileCacheBenchmark {
         cache = new MapTileCache();
         camera = createCamera();
         data = createData(MAP_SIZE, MAP_SIZE);
+        updateIndices = new com.badlogic.gdx.utils.IntArray(new int[] {0});
         construction = mockConstruction(SpriteCache.class, (mock, ctx) -> {
             when(mock.getProjectionMatrix()).thenReturn(new Matrix4());
             when(mock.endCache()).thenReturn(0);
@@ -105,6 +107,14 @@ public class MapTileCacheBenchmark {
     @Benchmark
     public final void rebuildCache() {
         cache.invalidate();
+        cache.ensureCache(loader, data, resolver, camera);
+    }
+
+    @Benchmark
+    public final void updateTile() {
+        cache.invalidateTiles(updateIndices);
+        ((net.lapidist.colony.client.render.SimpleMapRenderData) data)
+                .setVersion(((net.lapidist.colony.client.render.SimpleMapRenderData) data).getVersion() + 1);
         cache.ensureCache(loader, data, resolver, camera);
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/client/renderers/MapTileCacheTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/renderers/MapTileCacheTest.java
@@ -34,12 +34,29 @@ public class MapTileCacheTest {
 
     private static final float VIEW_SIZE = 64f;
     private static final float FAR_POS = 100f;
+    private static final int LARGE_TILE_COUNT = 8200;
+    private static final int EXPECTED_CACHE_COUNT_AFTER_UPDATE = 3;
 
     private MapRenderData createData() {
         MapState state = new MapState();
         state.tiles().put(new TilePos(0, 0), TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true)
                 .build());
+        World world = new World(new WorldConfigurationBuilder().build());
+        Entity map = MapFactory.create(world, state);
+        ComponentMapper<MapComponent> mapMapper = world.getMapper(MapComponent.class);
+        world.process();
+        return MapRenderDataBuilder.fromMap(mapMapper.get(map), world);
+    }
+
+    private MapRenderData createLargeData() {
+        MapState state = new MapState();
+        int total = LARGE_TILE_COUNT;
+        for (int i = 0; i < total; i++) {
+            state.tiles().put(new TilePos(i, 0), TileData.builder()
+                    .x(i).y(0).tileType("GRASS").passable(true)
+                    .build());
+        }
         World world = new World(new WorldConfigurationBuilder().build());
         Entity map = MapFactory.create(world, state);
         ComponentMapper<MapComponent> mapMapper = world.getMapper(MapComponent.class);
@@ -153,7 +170,30 @@ public class MapTileCacheTest {
             assertEquals(1, cons.constructed().size());
             data.setVersion(data.getVersion() + 1);
             cache.ensureCache(loader, data, new DefaultAssetResolver(), cam);
+            assertEquals(1, cons.constructed().size());
+        }
+    }
+
+    @Test
+    public void rebuildsOnlyInvalidSegments() {
+        SimpleMapRenderData data = (SimpleMapRenderData) createLargeData();
+        CameraProvider cam = mock(CameraProvider.class);
+        when(cam.getCamera()).thenReturn(new OrthographicCamera());
+        ResourceLoader loader = mock(ResourceLoader.class);
+        when(loader.findRegion(any())).thenReturn(new TextureRegion());
+        try (MockedConstruction<SpriteCache> cons = mockConstruction(SpriteCache.class,
+                (mock, ctx) -> {
+                    when(mock.getProjectionMatrix()).thenReturn(new Matrix4());
+                    when(mock.endCache()).thenReturn(0);
+                })) {
+            MapTileCache cache = new MapTileCache();
+            cache.ensureCache(loader, data, new DefaultAssetResolver(), cam);
             assertEquals(2, cons.constructed().size());
+            com.badlogic.gdx.utils.IntArray indices = new com.badlogic.gdx.utils.IntArray(new int[] {0});
+            cache.invalidateTiles(indices);
+            data.setVersion(data.getVersion() + 1);
+            cache.ensureCache(loader, data, new DefaultAssetResolver(), cam);
+            assertEquals(EXPECTED_CACHE_COUNT_AFTER_UPDATE, cons.constructed().size());
         }
     }
 }


### PR DESCRIPTION
## Summary
- update `MapTileCache` to track cache segments and invalidate only affected tiles
- expose `invalidateTiles()` on `SpriteBatchMapRenderer`
- rebuild segments when map data changes in `MapRenderSystem`
- surface updated indices from `MapRenderDataSystem`
- benchmark partial cache rebuild and document results
- cover new behaviour with unit tests

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew :tests:jmh -Djmh.include=MapTileCacheBenchmark -Djmh.iterations=1 -Djmh.warmupIterations=1 -Djmh.timeOnIteration=1s`

------
https://chatgpt.com/codex/tasks/task_e_684afd6ee6f08328987e218ed92350b1