### PR TITLE
feat: add loading screen

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/Colony.java
+++ b/client/src/main/java/net/lapidist/colony/client/Colony.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.Gdx;
 import net.lapidist.colony.io.Paths;
 import net.lapidist.colony.client.screens.MapScreen;
 import net.lapidist.colony.client.screens.MainMenuScreen;
+import net.lapidist.colony.client.screens.LoadingScreen;
 import net.lapidist.colony.i18n.I18n;
 import net.lapidist.colony.settings.Settings;
 import net.lapidist.colony.client.network.GameClient;
@@ -44,6 +45,8 @@ public final class Colony extends Game {
             );
             server.start();
             client = new GameClient();
+            LoadingScreen loading = new LoadingScreen(client);
+            setScreen(loading);
             client.start(state ->
                     Gdx.app.postRunnable(() -> setScreen(new MapScreen(this, state, client))));
         } catch (IOException | InterruptedException e) {

--- a/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
+++ b/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
@@ -139,6 +139,16 @@ public final class GameClient extends AbstractMessageEndpoint {
     }
 
     /**
+     * Returns loading progress from 0 to 1 based on received map chunks.
+     */
+    public float getLoadProgress() {
+        if (expectedChunks <= 0) {
+            return 0f;
+        }
+        return Math.min(1f, receivedChunks / (float) expectedChunks);
+    }
+
+    /**
      * Returns true if the underlying network client is connected to the server.
      */
     public boolean isConnected() {

--- a/client/src/main/java/net/lapidist/colony/client/screens/LoadingScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/LoadingScreen.java
@@ -1,0 +1,42 @@
+package net.lapidist.colony.client.screens;
+
+import com.badlogic.gdx.scenes.scene2d.Action;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.ProgressBar;
+import com.badlogic.gdx.utils.viewport.ScreenViewport;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.i18n.I18n;
+
+/**
+ * Simple loading screen showing progress while the map and resources load.
+ */
+public final class LoadingScreen extends BaseScreen {
+    private static final float STEP = 0.01f;
+    private static final float PADDING = 10f;
+    private static final float BAR_WIDTH = 300f;
+    private final GameClient client;
+    private final ProgressBar bar;
+
+    public LoadingScreen(final GameClient gameClient) {
+        this(gameClient, new Stage(new ScreenViewport()));
+    }
+
+    public LoadingScreen(final GameClient gameClient, final Stage stage) {
+        super(stage);
+        this.client = gameClient;
+        Label label = new Label(I18n.get("loading.title"), getSkin());
+        bar = new ProgressBar(0f, 1f, STEP, false, getSkin());
+
+        bar.addAction(new Action() {
+            @Override
+            public boolean act(final float delta) {
+                bar.setValue(client.getLoadProgress());
+                return false;
+            }
+        });
+
+        getRoot().add(label).pad(PADDING).row();
+        getRoot().add(bar).width(BAR_WIDTH).pad(PADDING).row();
+    }
+}

--- a/client/src/main/resources/assets/skin/default.json
+++ b/client/src/main/resources/assets/skin/default.json
@@ -241,12 +241,19 @@
       knobBefore: scrubber_vertical_primary,
       knobAfter: scrubber_vertical_secondary
     },
-    down-vertical: {
+  down-vertical: {
       background: scrubber_vertical_track,
       knob: scrubber_control_normal,
       knobBefore: scrubber_vertical_secondary,
       knobAfter: scrubber_vertical_primary
     },
+  },
+  ProgressBarStyle: {
+    default-horizontal: {
+      background: scrubber_track,
+      knob: scrubber_control_normal,
+      knobBefore: scrubber_primary
+    }
   },
   LabelStyle: {
     default: {

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -35,3 +35,4 @@ ui.resources=Resources
 building.house=House
 building.market=Market
 building.factory=Factory
+loading.title=Loading...

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -34,3 +34,4 @@ ui.resources=Rohstoffe
 building.house=Haus
 building.market=Markt
 building.factory=Fabrik
+loading.title=Laden...

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -34,3 +34,4 @@ ui.resources=Recursos
 building.house=Casa
 building.market=Mercado
 building.factory=Fábrica
+loading.title=Cargando...

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -34,3 +34,4 @@ ui.resources=Ressources
 building.house=Maison
 building.market=Marché
 building.factory=Usine
+loading.title=Chargement...

--- a/tests/src/test/java/net/lapidist/colony/tests/client/ColonyTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/ColonyTest.java
@@ -3,6 +3,7 @@ package net.lapidist.colony.tests.client;
 import net.lapidist.colony.client.Colony;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.client.screens.MainMenuScreen;
+import net.lapidist.colony.client.screens.LoadingScreen;
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.tests.GdxTestRunner;
 import net.lapidist.colony.client.events.GameInitEvent;
@@ -27,7 +28,8 @@ public class ColonyTest {
     public void startGameLaunchesServerAndClient() throws Exception {
         Colony colony = new Colony();
         try (MockedConstruction<GameServer> serverCons = mockConstruction(GameServer.class);
-             MockedConstruction<GameClient> clientCons = mockConstruction(GameClient.class)) {
+             MockedConstruction<GameClient> clientCons = mockConstruction(GameClient.class);
+             MockedConstruction<LoadingScreen> loadCons = mockConstruction(LoadingScreen.class)) {
             colony.startGame("test");
 
             GameServer server = serverCons.constructed().get(0);
@@ -42,7 +44,8 @@ public class ColonyTest {
         Colony colony = new Colony();
         try (MockedConstruction<GameServer> serverCons = mockConstruction(GameServer.class);
              MockedConstruction<GameClient> clientCons = mockConstruction(GameClient.class);
-             MockedConstruction<MainMenuScreen> menuCons = mockConstruction(MainMenuScreen.class)) {
+             MockedConstruction<MainMenuScreen> menuCons = mockConstruction(MainMenuScreen.class);
+             MockedConstruction<LoadingScreen> loadCons = mockConstruction(LoadingScreen.class)) {
             colony.startGame("test");
             GameServer server = serverCons.constructed().get(0);
             GameClient client = clientCons.constructed().get(0);
@@ -92,7 +95,8 @@ public class ColonyTest {
     public void disposeStopsActiveConnectionsAndEvents() throws Exception {
         Colony colony = new Colony();
         try (MockedConstruction<GameServer> serverCons = mockConstruction(GameServer.class);
-             MockedConstruction<GameClient> clientCons = mockConstruction(GameClient.class)) {
+             MockedConstruction<GameClient> clientCons = mockConstruction(GameClient.class);
+             MockedConstruction<LoadingScreen> loadCons = mockConstruction(LoadingScreen.class)) {
             colony.startGame("test");
             GameServer server = serverCons.constructed().get(0);
             GameClient client = clientCons.constructed().get(0);

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/LoadingScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/LoadingScreenTest.java
@@ -1,0 +1,55 @@
+package net.lapidist.colony.tests.screens;
+
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.math.Matrix4;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.ui.ProgressBar;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.client.screens.LoadingScreen;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedConstruction;
+
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+@RunWith(GdxTestRunner.class)
+public class LoadingScreenTest {
+
+    private static Table getRoot(final LoadingScreen screen) throws Exception {
+        Field f = screen.getClass().getSuperclass().getDeclaredField("root");
+        f.setAccessible(true);
+        return (Table) f.get(screen);
+    }
+
+    private static Stage getStage(final LoadingScreen screen) throws Exception {
+        Field f = screen.getClass().getSuperclass().getDeclaredField("stage");
+        f.setAccessible(true);
+        return (Stage) f.get(screen);
+    }
+
+    @Test
+    public void updatesProgressBarFromClient() throws Exception {
+        GameClient client = mock(GameClient.class);
+        final float progress = 0.5f;
+        when(client.getLoadProgress()).thenReturn(progress);
+
+        try (MockedConstruction<SpriteBatch> cons = mockConstruction(SpriteBatch.class,
+                (mock, ctx) -> {
+                    when(mock.getProjectionMatrix()).thenReturn(new Matrix4());
+                })) {
+            LoadingScreen screen = new LoadingScreen(client);
+            Stage s = getStage(screen);
+            ProgressBar bar = (ProgressBar) getRoot(screen).getChildren().get(1);
+            s.act(0f);
+            final float epsilon = 0.01f;
+            assertEquals(progress, bar.getValue(), epsilon);
+            screen.dispose();
+        }
+
+    }
+}


### PR DESCRIPTION
## Summary
- add a LoadingScreen to show asynchronous load progress
- inject the loading screen when starting the game
- expose load progress from GameClient
- add progress bar style to default skin
- provide translations for loading screen
- test LoadingScreen behaviour

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684b3480ae288328af54c8b839718db0