### PR TITLE
feat: add loading screen with progress bar

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/Colony.java
+++ b/client/src/main/java/net/lapidist/colony/client/Colony.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.Gdx;
 import net.lapidist.colony.io.Paths;
 import net.lapidist.colony.client.screens.MapScreen;
 import net.lapidist.colony.client.screens.MainMenuScreen;
+import net.lapidist.colony.client.screens.LoadingScreen;
 import net.lapidist.colony.i18n.I18n;
 import net.lapidist.colony.settings.Settings;
 import net.lapidist.colony.client.network.GameClient;
@@ -44,6 +45,9 @@ public final class Colony extends Game {
             );
             server.start();
             client = new GameClient();
+            LoadingScreen loading = new LoadingScreen();
+            client.setLoadProgressListener(p -> Gdx.app.postRunnable(() -> loading.setProgress(p)));
+            setScreen(loading);
             client.start(state ->
                     Gdx.app.postRunnable(() -> setScreen(new MapScreen(this, state, client))));
         } catch (IOException | InterruptedException e) {

--- a/client/src/main/java/net/lapidist/colony/client/screens/LoadingScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/LoadingScreen.java
@@ -1,0 +1,49 @@
+package net.lapidist.colony.client.screens;
+
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.ProgressBar;
+import com.badlogic.gdx.scenes.scene2d.ui.ProgressBar.ProgressBarStyle;
+import com.badlogic.gdx.graphics.Color;
+import net.lapidist.colony.i18n.I18n;
+
+/**
+ * Simple loading screen with a progress bar.
+ */
+public final class LoadingScreen extends BaseScreen {
+
+    private static final float STEP = 0.01f;
+    private static final float PADDING = 5f;
+    private static final float BAR_WIDTH = 200f;
+
+    private final Label messageLabel;
+    private final ProgressBar progressBar;
+
+    public LoadingScreen() {
+        messageLabel = new Label(I18n.get("loading.title"), getSkin());
+        ProgressBarStyle style = new ProgressBarStyle();
+        style.background = getSkin().newDrawable("white_pixel", Color.DARK_GRAY);
+        style.knobBefore = getSkin().newDrawable("white_pixel", Color.GREEN);
+        style.knob = getSkin().newDrawable("white_pixel", Color.GREEN);
+        progressBar = new ProgressBar(0f, 1f, STEP, false, style);
+        progressBar.setValue(0f);
+
+        getRoot().add(messageLabel).padBottom(PADDING).row();
+        getRoot().add(progressBar).width(BAR_WIDTH).row();
+    }
+
+    /**
+     * Update the progress bar value.
+     *
+     * @param progress value between 0 and 1
+     */
+    public void setProgress(final float progress) {
+        progressBar.setValue(Math.max(0f, Math.min(1f, progress)));
+    }
+
+    /**
+     * Update the displayed loading message.
+     */
+    public void setMessage(final String message) {
+        messageLabel.setText(message);
+    }
+}

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -35,3 +35,4 @@ ui.resources=Resources
 building.house=House
 building.market=Market
 building.factory=Factory
+loading.title=Loading...

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -34,3 +34,4 @@ ui.resources=Rohstoffe
 building.house=Haus
 building.market=Markt
 building.factory=Fabrik
+loading.title=Laden...

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -34,3 +34,4 @@ ui.resources=Recursos
 building.house=Casa
 building.market=Mercado
 building.factory=Fábrica
+loading.title=Cargando...

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -34,3 +34,4 @@ ui.resources=Ressources
 building.house=Maison
 building.market=Marché
 building.factory=Usine
+loading.title=Chargement...

--- a/tests/src/test/java/net/lapidist/colony/tests/client/ColonyTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/ColonyTest.java
@@ -26,8 +26,12 @@ public class ColonyTest {
     @Test
     public void startGameLaunchesServerAndClient() throws Exception {
         Colony colony = new Colony();
-        try (MockedConstruction<GameServer> serverCons = mockConstruction(GameServer.class);
-             MockedConstruction<GameClient> clientCons = mockConstruction(GameClient.class)) {
+        try (MockedConstruction<GameServer> serverCons =
+                     mockConstruction(GameServer.class);
+             MockedConstruction<GameClient> clientCons =
+                     mockConstruction(GameClient.class);
+             MockedConstruction<com.badlogic.gdx.graphics.g2d.SpriteBatch> batchCons =
+                     mockConstruction(com.badlogic.gdx.graphics.g2d.SpriteBatch.class)) {
             colony.startGame("test");
 
             GameServer server = serverCons.constructed().get(0);
@@ -40,9 +44,14 @@ public class ColonyTest {
     @Test
     public void returnToMainMenuStopsServerAndClientAndShowsMenu() throws Exception {
         Colony colony = new Colony();
-        try (MockedConstruction<GameServer> serverCons = mockConstruction(GameServer.class);
-             MockedConstruction<GameClient> clientCons = mockConstruction(GameClient.class);
-             MockedConstruction<MainMenuScreen> menuCons = mockConstruction(MainMenuScreen.class)) {
+        try (MockedConstruction<GameServer> serverCons =
+                     mockConstruction(GameServer.class);
+             MockedConstruction<GameClient> clientCons =
+                     mockConstruction(GameClient.class);
+             MockedConstruction<MainMenuScreen> menuCons =
+                     mockConstruction(MainMenuScreen.class);
+             MockedConstruction<com.badlogic.gdx.graphics.g2d.SpriteBatch> batchCons =
+                     mockConstruction(com.badlogic.gdx.graphics.g2d.SpriteBatch.class)) {
             colony.startGame("test");
             GameServer server = serverCons.constructed().get(0);
             GameClient client = clientCons.constructed().get(0);
@@ -91,8 +100,12 @@ public class ColonyTest {
     @Test
     public void disposeStopsActiveConnectionsAndEvents() throws Exception {
         Colony colony = new Colony();
-        try (MockedConstruction<GameServer> serverCons = mockConstruction(GameServer.class);
-             MockedConstruction<GameClient> clientCons = mockConstruction(GameClient.class)) {
+        try (MockedConstruction<GameServer> serverCons =
+                     mockConstruction(GameServer.class);
+             MockedConstruction<GameClient> clientCons =
+                     mockConstruction(GameClient.class);
+             MockedConstruction<com.badlogic.gdx.graphics.g2d.SpriteBatch> batchCons =
+                     mockConstruction(com.badlogic.gdx.graphics.g2d.SpriteBatch.class)) {
             colony.startGame("test");
             GameServer server = serverCons.constructed().get(0);
             GameClient client = clientCons.constructed().get(0);


### PR DESCRIPTION
## Summary
- show progress while loading async resources
- update `GameClient` to report loading progress
- start a `LoadingScreen` before the map loads
- translate loading text in all languages
- adjust tests for the new screen

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684b34a7dd608328bf9e45fc3bf204e9