### PR TITLE
feat(client): prioritize build input

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/systems/BuildPlacementSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/BuildPlacementSystem.java
@@ -39,7 +39,7 @@ public final class BuildPlacementSystem extends BaseSystem {
         tileMapper = world.getMapper(TileComponent.class);
         map = MapUtils.findMap(world).orElse(null);
         buildingPlacementHandler = new BuildingPlacementHandler(client, cameraSystem);
-        cameraInputSystem.addProcessor(new GestureDetector(new BuildGestureListener()));
+        cameraInputSystem.addProcessor(0, new GestureDetector(new BuildGestureListener()));
     }
 
     @Override

--- a/client/src/main/java/net/lapidist/colony/client/systems/CameraInputSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/CameraInputSystem.java
@@ -30,6 +30,10 @@ public final class CameraInputSystem extends BaseSystem {
         multiplexer.addProcessor(processor);
     }
 
+    public void addProcessor(final int index, final InputProcessor processor) {
+        multiplexer.addProcessor(index, processor);
+    }
+
     @Override
     public void initialize() {
         cameraSystem = world.getSystem(PlayerCameraSystem.class);

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/BuildPlacementWithSelectionSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/BuildPlacementWithSelectionSystemTest.java
@@ -1,0 +1,65 @@
+package net.lapidist.colony.tests.systems;
+
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import com.badlogic.gdx.math.Vector2;
+import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.client.systems.CameraInputSystem;
+import net.lapidist.colony.client.systems.BuildPlacementSystem;
+import net.lapidist.colony.client.systems.PlayerCameraSystem;
+import net.lapidist.colony.client.systems.SelectionSystem;
+import net.lapidist.colony.client.systems.network.MapLoadSystem;
+import net.lapidist.colony.client.util.CameraUtils;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.TileData;
+import net.lapidist.colony.components.state.TilePos;
+import net.lapidist.colony.map.MapUtils;
+import net.lapidist.colony.settings.KeyBindings;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+
+@RunWith(GdxTestRunner.class)
+public class BuildPlacementWithSelectionSystemTest {
+
+    @Test
+    public void tapPlacesBuildingWhenSelectionSystemPresent() {
+        MapState state = new MapState();
+        TileData tile = TileData.builder()
+                .x(0).y(0).tileType("GRASS").passable(true)
+                .build();
+        state.tiles().put(new TilePos(0, 0), tile);
+
+        GameClient client = mock(GameClient.class);
+        KeyBindings keys = new KeyBindings();
+        CameraInputSystem cameraInput = new CameraInputSystem(keys);
+        SelectionSystem selectionSystem = new SelectionSystem(client, keys);
+        BuildPlacementSystem buildSystem = new BuildPlacementSystem(client, keys);
+        World world = new World(new WorldConfigurationBuilder()
+                .with(new MapLoadSystem(state), new PlayerCameraSystem(), cameraInput,
+                        selectionSystem, buildSystem)
+                .build());
+        world.process();
+
+        buildSystem.setBuildMode(true);
+
+        PlayerCameraSystem camera = world.getSystem(PlayerCameraSystem.class);
+        ((com.badlogic.gdx.graphics.OrthographicCamera) camera.getCamera()).position.set(
+                GameConstants.TILE_SIZE / 2f,
+                GameConstants.TILE_SIZE / 2f,
+                0f
+        );
+        camera.getCamera().update();
+
+        Vector2 screen = CameraUtils.worldToScreenCoords(camera.getViewport(), 0, 0);
+        buildSystem.tap(screen.x, screen.y);
+
+        verify(client).sendBuildRequest(any());
+        assertFalse(world.getMapper(net.lapidist.colony.components.maps.TileComponent.class)
+                .get(MapUtils.findMap(world).get().getTiles().get(0)).isSelected());
+    }
+}


### PR DESCRIPTION
## Summary
- expose method to insert `InputProcessor` by index
- initialize `BuildPlacementSystem` with priority input
- test building placement when combined with selection system

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684b3f49d7d88328b1447e8377dd3efa