### PR TITLE
fix: prioritize UI input over build placement

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/systems/BuildPlacementSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/BuildPlacementSystem.java
@@ -39,7 +39,7 @@ public final class BuildPlacementSystem extends BaseSystem {
         tileMapper = world.getMapper(TileComponent.class);
         map = MapUtils.findMap(world).orElse(null);
         buildingPlacementHandler = new BuildingPlacementHandler(client, cameraSystem);
-        cameraInputSystem.addProcessor(0, new GestureDetector(new BuildGestureListener()));
+        cameraInputSystem.addProcessor(1, new GestureDetector(new BuildGestureListener()));
     }
 
     @Override


### PR DESCRIPTION
## Summary
- ensure UI stage is processed before build placement input so menu buttons remain clickable

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684b41aedd1883289ffc3d5ae6b87dc0