### PR TITLE
fix: log autosave errors

### DIFF
--- a/server/src/main/java/net/lapidist/colony/server/services/AutosaveService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/AutosaveService.java
@@ -80,7 +80,7 @@ public final class AutosaveService {
             Events.update();
             LOGGER.info(log, file, size);
         } catch (IOException e) {
-            e.printStackTrace();
+            LOGGER.error("Failed to save game state", e);
         }
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/server/AutosaveServiceTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/AutosaveServiceTest.java
@@ -1,0 +1,46 @@
+package net.lapidist.colony.tests.server;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.io.Paths;
+import net.lapidist.colony.io.TestPathService;
+import net.lapidist.colony.server.services.AutosaveService;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+
+public class AutosaveServiceTest {
+
+    @Test
+    public void logsErrorWhenSaveFails() throws Exception {
+        Path temp = Files.createTempDirectory("autosave-test");
+        Paths paths = new Paths(new TestPathService(temp));
+        Path autosave = paths.getAutosave("err");
+        Files.createDirectories(autosave); // create directory to trigger failure
+
+        Logger logger = (Logger) LoggerFactory.getLogger(AutosaveService.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        try (MockedStatic<Paths> mock = Mockito.mockStatic(Paths.class)) {
+            mock.when(Paths::get).thenReturn(paths);
+            AutosaveService service = new AutosaveService(0, "err", MapState::new);
+            service.stop();
+        }
+
+        logger.detachAppender(appender);
+        assertEquals(1, appender.list.size());
+        ILoggingEvent event = appender.list.get(0);
+        assertEquals(Level.ERROR, event.getLevel());
+    }
+}


### PR DESCRIPTION
## Summary
- log exceptions with `LOGGER.error` in `AutosaveService`
- test that `AutosaveService` logs errors

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684b45c008308328b6c1d9773a211c7f