### PR TITLE
feat: toggle minimap with m key

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/MapUiBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapUiBuilder.java
@@ -85,6 +85,10 @@ public final class MapUiBuilder {
                     chatBox.showInput();
                     return true;
                 }
+                if (keycode == keyBindings.getKey(KeyAction.MINIMAP)) {
+                    minimapActor.setVisible(!minimapActor.isVisible());
+                    return true;
+                }
                 return false;
             }
         });

--- a/core/src/main/java/net/lapidist/colony/settings/KeyAction.java
+++ b/core/src/main/java/net/lapidist/colony/settings/KeyAction.java
@@ -10,7 +10,8 @@ public enum KeyAction {
     MOVE_RIGHT("moveRight"),
     GATHER("gather"),
     BUILD("build"),
-    CHAT("chat");
+    CHAT("chat"),
+    MINIMAP("minimap");
 
     private final String i18nKey;
 

--- a/core/src/main/java/net/lapidist/colony/settings/KeyBindings.java
+++ b/core/src/main/java/net/lapidist/colony/settings/KeyBindings.java
@@ -19,7 +19,8 @@ public final class KeyBindings {
             KeyAction.MOVE_RIGHT, Input.Keys.D,
             KeyAction.GATHER, Input.Keys.H,
             KeyAction.BUILD, Input.Keys.B,
-            KeyAction.CHAT, Input.Keys.T
+            KeyAction.CHAT, Input.Keys.T,
+            KeyAction.MINIMAP, Input.Keys.M
     );
 
     private final EnumMap<KeyAction, Integer> bindings = new EnumMap<>(KeyAction.class);

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -30,6 +30,7 @@ keybind.moveRight=Move Right
 keybind.gather=Gather
 keybind.build=Build
 keybind.chat=Chat
+keybind.minimap=Minimap
 common.reset=Reset
 ui.resources=Resources
 building.house=House

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -29,6 +29,7 @@ keybind.moveRight=Nach Rechts
 keybind.gather=Sammeln
 keybind.build=Bauen
 keybind.chat=Chat
+keybind.minimap=Minikarte
 common.reset=Zurücksetzen
 ui.resources=Rohstoffe
 building.house=Haus

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -29,6 +29,7 @@ keybind.moveRight=Mover Derecha
 keybind.gather=Recolectar
 keybind.build=Construir
 keybind.chat=Chat
+keybind.minimap=Minimapa
 common.reset=Restablecer
 ui.resources=Recursos
 building.house=Casa

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -29,6 +29,7 @@ keybind.moveRight=Droite
 keybind.gather=Récolter
 keybind.build=Construire
 keybind.chat=Chat
+keybind.minimap=Mini-carte
 common.reset=Réinitialiser
 ui.resources=Ressources
 building.house=Maison

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -13,6 +13,7 @@ This page lists the default keyboard bindings and how to customize them in-game.
 | Gather | **H** | Order selected tiles to gather resources |
 | Build | **B** | Toggle building placement mode |
 | Chat | **T** | Open the chat input box |
+| Toggle Minimap | **M** | Show or hide the minimap |
 
 The defaults are defined in [`KeyBindings.java`](../core/src/main/java/net/lapidist/colony/settings/KeyBindings.java).
 

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MapUiBuilderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MapUiBuilderTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 @RunWith(GdxTestRunner.class)
@@ -34,5 +35,27 @@ public class MapUiBuilderTest {
         stage.keyDown(settings.getKeyBindings().getKey(KeyAction.CHAT));
 
         assertTrue(ui.getChatBox().isInputVisible());
+    }
+
+    @Test
+    public void togglesMinimapVisibility() {
+        Stage stage = new Stage(new ScreenViewport(), mock(Batch.class));
+        World world = new World(new WorldConfigurationBuilder().build());
+        GameClient client = mock(GameClient.class);
+        Colony colony = mock(Colony.class);
+        Settings settings = new Settings();
+        when(colony.getSettings()).thenReturn(settings);
+
+        MapUi ui = MapUiBuilder.build(stage, world, client, colony);
+
+        boolean initial = ui.getMinimapActor().isVisible();
+
+        stage.keyDown(settings.getKeyBindings().getKey(KeyAction.MINIMAP));
+
+        assertEquals(!initial, ui.getMinimapActor().isVisible());
+
+        stage.keyDown(settings.getKeyBindings().getKey(KeyAction.MINIMAP));
+
+        assertEquals(initial, ui.getMinimapActor().isVisible());
     }
 }


### PR DESCRIPTION
## Summary
- bind new MINIMAP action to M by default
- allow stage listener to toggle minimap visibility
- document minimap key in controls guide
- add i18n strings for the new key action

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684b497dc4888328ba49b09435a20729