### PR TITLE
fix: remove chat log border

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/ui/ChatBox.java
+++ b/client/src/main/java/net/lapidist/colony/client/ui/ChatBox.java
@@ -25,6 +25,12 @@ public final class ChatBox extends Table {
         log = new TextArea("", skin);
         log.setDisabled(true);
         log.setPrefRows(PREF_ROWS);
+        // Remove background graphics to avoid drawing a border line
+        TextField.TextFieldStyle logStyle = new TextField.TextFieldStyle(log.getStyle());
+        logStyle.background = null;
+        logStyle.disabledBackground = null;
+        logStyle.focusedBackground = null;
+        log.setStyle(logStyle);
         input = new TextField("", skin);
         input.setVisible(false);
         input.setMessageText(I18n.get("chat.placeholder"));


### PR DESCRIPTION
## Summary
- update ChatBox to clear TextArea background

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684b5e8cc3488328a7d8e1c90ead091e