### PR TITLE
fix(client): narrow GameClient.start() exception

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
+++ b/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
@@ -140,12 +140,12 @@ public final class GameClient extends AbstractMessageEndpoint {
     }
 
     @Override
-    public void start() throws IOException, InterruptedException {
+    public void start() throws IOException {
         start(ms -> {
         });
     }
 
-    public void start(final Consumer<MapState> callback) throws IOException, InterruptedException {
+    public void start(final Consumer<MapState> callback) throws IOException {
         this.readyCallback = callback;
         connect();
     }


### PR DESCRIPTION
## Summary
- remove InterruptedException from GameClient.start overloads
- run spotless and project checks

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_684bd49a71e48328b72b4b6a9a18c959