### PR TITLE
fix(client): block resource loader

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/core/io/ResourceLoader.java
+++ b/client/src/main/java/net/lapidist/colony/client/core/io/ResourceLoader.java
@@ -12,6 +12,8 @@ import java.io.IOException;
  */
 public interface ResourceLoader extends Disposable {
 
+    int POLL_MILLIS = 10;
+
     /**
      * Load texture regions from the given atlas.
      *
@@ -78,7 +80,12 @@ public interface ResourceLoader extends Disposable {
      */
     default void finishLoading() {
         while (!update()) {
-            Thread.yield();
+            try {
+                Thread.sleep(POLL_MILLIS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
         }
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/core/io/ResourceLoaderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/io/ResourceLoaderTest.java
@@ -16,6 +16,62 @@ import static org.junit.Assert.*;
 @RunWith(GdxTestRunner.class)
 public class ResourceLoaderTest {
 
+    private static final int LOADER_CALLS = 3;
+    private static final float HALF_PROGRESS = 0.5f;
+
+    private static final class DummyBlockingLoader implements ResourceLoader {
+        private int calls;
+        private boolean loaded;
+
+        @Override
+        public void loadTextures(
+                final FileLocation location,
+                final String path,
+                final GraphicsSettings settings
+        ) {
+            // start load
+        }
+
+        @Override
+        public void loadTextures(final FileLocation location, final String path) {
+            // start load
+        }
+
+        @Override
+        public boolean isLoaded() {
+            return loaded;
+        }
+
+        @Override
+        public com.badlogic.gdx.graphics.g2d.TextureAtlas getAtlas() {
+            return null;
+        }
+
+        @Override
+        public com.badlogic.gdx.graphics.g2d.TextureRegion findRegion(final String name) {
+            return null;
+        }
+
+        @Override
+        public boolean update() {
+            calls++;
+            if (calls < LOADER_CALLS) {
+                return false;
+            }
+            loaded = true;
+            return true;
+        }
+
+        @Override
+        public float getProgress() {
+            return loaded ? 1f : HALF_PROGRESS;
+        }
+
+        @Override
+        public void dispose() {
+        }
+    }
+
     @Test
     public final void testLoadsResources() throws IOException {
         ResourceLoader resourceLoader = new TextureAtlasResourceLoader();
@@ -59,5 +115,15 @@ public class ResourceLoaderTest {
         assertEquals(0f, loader.getProgress(), 0f);
         assertFalse(loader.isLoaded());
         assertNull(loader.findRegion("missing"));
+    }
+
+    @Test
+    public void finishLoadingWaitsUntilReady() {
+        DummyBlockingLoader loader = new DummyBlockingLoader();
+
+        loader.finishLoading();
+
+        assertTrue(loader.isLoaded());
+        assertEquals(LOADER_CALLS, loader.calls);
     }
 }


### PR DESCRIPTION
## Summary
- avoid busy waiting in `ResourceLoader.finishLoading`
- verify blocking behaviour with a unit test

## Testing
- `./gradlew clean test check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684bd49bf9f48328804c318749f51269