### PR TITLE
fix: synchronize Events singleton usage

### DIFF
--- a/core/src/main/java/net/lapidist/colony/events/Events.java
+++ b/core/src/main/java/net/lapidist/colony/events/Events.java
@@ -7,11 +7,27 @@ import org.slf4j.LoggerFactory;
 
 public final class Events {
 
-    private static EventSystem instance;
+    /**
+     * Shared event system instance.
+     *
+     * <p>The instance is accessed from the network and autosave threads on the
+     * server, so visibility between threads is required. The game server and
+     * client call {@link #init(EventSystem)} during start up before any worker
+     * threads are spawned.</p>
+     */
+    private static volatile EventSystem instance;
     private static final Logger LOGGER = LoggerFactory.getLogger(Events.class);
 
     private Events() { }
 
+    /**
+     * Set the global event system instance.
+     *
+     * <p>Call this before starting any threads that dispatch or process events
+     * (for example the server network thread or autosave scheduler). The
+     * instance is stored in a {@code volatile} field to ensure visibility between
+     * threads.</p>
+     */
     public static void init(final EventSystem system) {
         instance = system;
     }


### PR DESCRIPTION
## Summary
- make `Events` instance `volatile`
- document initialization order so worker threads see the event system

## Testing
- `./scripts/check.sh`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684bd585b8cc83288307e76af4430800