### PR TITLE
feat(core): load prototypes from mod files

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/entities/factories/BuildingFactory.java
+++ b/client/src/main/java/net/lapidist/colony/client/entities/factories/BuildingFactory.java
@@ -25,7 +25,7 @@ public final class BuildingFactory {
      */
     public static Entity create(
             final World world,
-            final BuildingComponent.BuildingType buildingType,
+            final String buildingType,
             final Vector2 coords
     ) {
         BuildingComponent buildingComponent = new BuildingComponent();

--- a/client/src/main/java/net/lapidist/colony/client/render/MapRenderDataBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/render/MapRenderDataBuilder.java
@@ -67,7 +67,7 @@ public final class MapRenderDataBuilder {
         return RenderBuilding.builder()
                 .x(bc.getX())
                 .y(bc.getY())
-                .buildingType(bc.getBuildingType().name())
+                .buildingType(bc.getBuildingType())
                 .build();
     }
 

--- a/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
@@ -10,7 +10,7 @@ import net.lapidist.colony.client.systems.CameraProvider;
 import net.lapidist.colony.client.util.CameraUtils;
 import net.lapidist.colony.client.render.data.RenderBuilding;
 import net.lapidist.colony.client.render.MapRenderData;
-import net.lapidist.colony.components.entities.BuildingComponent;
+import net.lapidist.colony.mod.PrototypeManager;
 
 /**
  * Renders building entities.
@@ -21,8 +21,7 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
     private final ResourceLoader resourceLoader;
     private final CameraProvider cameraSystem;
     private final AssetResolver resolver;
-    private final java.util.EnumMap<BuildingComponent.BuildingType, TextureRegion> buildingRegions =
-            new java.util.EnumMap<>(BuildingComponent.BuildingType.class);
+    private final java.util.HashMap<String, TextureRegion> buildingRegions = new java.util.HashMap<>();
     private final Rectangle viewBounds = new Rectangle();
     private final Vector2 worldCoords = new Vector2();
 
@@ -37,11 +36,11 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
         this.cameraSystem = cameraSystemToSet;
         this.resolver = resolverToSet;
 
-        for (BuildingComponent.BuildingType type : BuildingComponent.BuildingType.values()) {
-            String ref = resolver.buildingAsset(type.name());
+        for (var type : PrototypeManager.buildings()) {
+            String ref = resolver.buildingAsset(type.id());
             TextureRegion region = resourceLoader.findRegion(ref);
             if (region != null) {
-                buildingRegions.put(type, region);
+                buildingRegions.put(type.id(), region);
             }
         }
     }
@@ -62,9 +61,7 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
                 continue;
             }
 
-            BuildingComponent.BuildingType type =
-                    BuildingComponent.BuildingType.valueOf(building.getBuildingType());
-            TextureRegion region = buildingRegions.get(type);
+            TextureRegion region = buildingRegions.get(building.getBuildingType());
             if (region != null) {
                 spriteBatch.draw(region, worldCoords.x, worldCoords.y);
             }

--- a/client/src/main/java/net/lapidist/colony/client/renderers/DefaultAssetResolver.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/DefaultAssetResolver.java
@@ -3,7 +3,6 @@ package net.lapidist.colony.client.renderers;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import net.lapidist.colony.components.entities.BuildingComponent;
 import net.lapidist.colony.components.maps.TileComponent;
 
 /** Default implementation returning built-in asset references. */
@@ -17,9 +16,9 @@ public final class DefaultAssetResolver implements AssetResolver {
         TILE_ASSETS.put(TileComponent.TileType.DIRT.name(), "dirt0");
         TILE_ASSETS.put(TileComponent.TileType.GRASS.name(), "grass0");
 
-        BUILDING_ASSETS.put(BuildingComponent.BuildingType.HOUSE.name(), "house0");
-        BUILDING_ASSETS.put(BuildingComponent.BuildingType.MARKET.name(), "house0");
-        BUILDING_ASSETS.put(BuildingComponent.BuildingType.FACTORY.name(), "house0");
+        BUILDING_ASSETS.put("HOUSE", "house0");
+        BUILDING_ASSETS.put("MARKET", "house0");
+        BUILDING_ASSETS.put("FACTORY", "house0");
     }
     @Override
     public String tileAsset(final String type) {

--- a/client/src/main/java/net/lapidist/colony/client/systems/InputSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/InputSystem.java
@@ -18,7 +18,6 @@ import net.lapidist.colony.client.systems.input.ScrollInputProcessor;
 import net.lapidist.colony.components.maps.MapComponent;
 import net.lapidist.colony.components.maps.TileComponent;
 import net.lapidist.colony.components.state.ResourceGatherRequestData;
-import net.lapidist.colony.components.resources.ResourceType;
 import net.lapidist.colony.client.util.CameraUtils;
 import net.lapidist.colony.map.MapUtils;
 import com.artemis.ComponentMapper;
@@ -111,7 +110,7 @@ public final class InputSystem extends BaseSystem {
                 var tile = selectedTiles.get(i);
                 TileComponent tc = tileMapper.get(tile);
                 var rc = resourceMapper.get(tile);
-                ResourceType type = getResourceType(rc);
+                String type = getResourceType(rc);
                 if (type != null) {
                     ResourceGatherRequestData msg = new ResourceGatherRequestData(
                             tc.getX(), tc.getY(), type);
@@ -140,7 +139,7 @@ public final class InputSystem extends BaseSystem {
                     .ifPresent(tile -> {
                         TileComponent tc = tileMapper.get(tile);
                         var rc = resourceMapper.get(tile);
-                        ResourceType type = getResourceType(rc);
+                        String type = getResourceType(rc);
                         if (type != null) {
                             ResourceGatherRequestData msg = new ResourceGatherRequestData(
                                     tc.getX(), tc.getY(), type);
@@ -161,13 +160,13 @@ public final class InputSystem extends BaseSystem {
         return gestureHandler.zoom(initialDistance, distance);
     }
 
-    private ResourceType getResourceType(final net.lapidist.colony.components.resources.ResourceComponent rc) {
+    private String getResourceType(final net.lapidist.colony.components.resources.ResourceComponent rc) {
         if (rc.getWood() > 0) {
-            return ResourceType.WOOD;
+            return "WOOD";
         } else if (rc.getStone() > 0) {
-            return ResourceType.STONE;
+            return "STONE";
         } else if (rc.getFood() > 0) {
-            return ResourceType.FOOD;
+            return "FOOD";
         }
         return null;
     }

--- a/client/src/main/java/net/lapidist/colony/client/systems/SelectionSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/SelectionSystem.java
@@ -12,7 +12,6 @@ import net.lapidist.colony.client.util.CameraUtils;
 import net.lapidist.colony.components.maps.MapComponent;
 import net.lapidist.colony.components.maps.TileComponent;
 import net.lapidist.colony.components.resources.ResourceComponent;
-import net.lapidist.colony.components.resources.ResourceType;
 import net.lapidist.colony.components.state.ResourceGatherRequestData;
 import net.lapidist.colony.map.MapUtils;
 import net.lapidist.colony.settings.KeyAction;
@@ -80,7 +79,7 @@ public final class SelectionSystem extends BaseSystem {
                 var tile = selectedTiles.get(i);
                 TileComponent tc = tileMapper.get(tile);
                 ResourceGatherRequestData msg = new ResourceGatherRequestData(
-                        tc.getX(), tc.getY(), ResourceType.WOOD);
+                        tc.getX(), tc.getY(), "WOOD");
                 client.sendGatherRequest(msg);
             }
         }
@@ -104,7 +103,7 @@ public final class SelectionSystem extends BaseSystem {
                     ResourceComponent rc = resourceMapper.get(tile);
                     if (rc.getWood() > 0) {
                         ResourceGatherRequestData msg = new ResourceGatherRequestData(
-                                tc.getX(), tc.getY(), ResourceType.WOOD);
+                                tc.getX(), tc.getY(), "WOOD");
                         client.sendGatherRequest(msg);
                     }
                 });

--- a/client/src/main/java/net/lapidist/colony/client/systems/input/BuildingPlacementHandler.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/input/BuildingPlacementHandler.java
@@ -6,7 +6,6 @@ import net.lapidist.colony.map.MapUtils;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
 import net.lapidist.colony.client.util.CameraUtils;
-import net.lapidist.colony.components.entities.BuildingComponent;
 import net.lapidist.colony.components.maps.MapComponent;
 import net.lapidist.colony.components.maps.TileComponent;
 import net.lapidist.colony.components.state.BuildingPlacementData;
@@ -43,7 +42,7 @@ public final class BuildingPlacementHandler {
                     BuildingPlacementData msg = new BuildingPlacementData(
                             tc.getX(),
                             tc.getY(),
-                            BuildingComponent.BuildingType.HOUSE.name()
+                            "HOUSE"
                     );
                     client.sendBuildRequest(msg);
                     return true;

--- a/client/src/main/java/net/lapidist/colony/client/systems/network/BuildingUpdateSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/network/BuildingUpdateSystem.java
@@ -36,7 +36,7 @@ public final class BuildingUpdateSystem extends BaseSystem {
             world.createEntity();
             var entity = BuildingFactory.create(
                     world,
-                    BuildingComponent.BuildingType.valueOf(update.buildingType()),
+                    update.buildingType(),
                     new Vector2(update.x(), update.y())
             );
             buildingMapper.get(entity).setDirty(true);

--- a/core/src/main/java/net/lapidist/colony/components/entities/BuildingComponent.java
+++ b/core/src/main/java/net/lapidist/colony/components/entities/BuildingComponent.java
@@ -1,30 +1,13 @@
 package net.lapidist.colony.components.entities;
 
 import net.lapidist.colony.components.AbstractBoundedComponent;
-import net.lapidist.colony.i18n.I18n;
 
+/** Component storing the id of a building type. */
 public final class BuildingComponent extends AbstractBoundedComponent {
-
-    public enum BuildingType {
-        HOUSE("building.house"),
-        MARKET("building.market"),
-        FACTORY("building.factory");
-
-        private final String key;
-
-        BuildingType(final String keyToSet) {
-            this.key = keyToSet;
-        }
-
-        @Override
-        public String toString() {
-            return I18n.get(key);
-        }
-    }
-    private BuildingType buildingType;
+    private String buildingType;
     private boolean dirty;
 
-    public BuildingType getBuildingType() {
+    public String getBuildingType() {
         return buildingType;
     }
 
@@ -36,7 +19,7 @@ public final class BuildingComponent extends AbstractBoundedComponent {
         this.dirty = dirtyToSet;
     }
 
-    public void setBuildingType(final BuildingType buildingTypeToSet) {
+    public void setBuildingType(final String buildingTypeToSet) {
         this.buildingType = buildingTypeToSet;
     }
 }

--- a/core/src/main/java/net/lapidist/colony/components/entities/BuildingType.java
+++ b/core/src/main/java/net/lapidist/colony/components/entities/BuildingType.java
@@ -1,0 +1,11 @@
+package net.lapidist.colony.components.entities;
+
+import net.lapidist.colony.i18n.I18n;
+
+/** Prototype describing a building type loaded from mods. */
+public record BuildingType(String id, String key) {
+    @Override
+    public String toString() {
+        return I18n.get(key);
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/components/resources/ResourceType.java
+++ b/core/src/main/java/net/lapidist/colony/components/resources/ResourceType.java
@@ -1,10 +1,4 @@
 package net.lapidist.colony.components.resources;
 
-/**
- * Enumerates supported resource types.
- */
-public enum ResourceType {
-    WOOD,
-    STONE,
-    FOOD
-}
+/** Prototype describing a resource type loaded from mods. */
+public record ResourceType(String id) { }

--- a/core/src/main/java/net/lapidist/colony/components/state/ResourceGatherRequestData.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/ResourceGatherRequestData.java
@@ -1,7 +1,6 @@
 package net.lapidist.colony.components.state;
 
 import net.lapidist.colony.serialization.KryoType;
-import net.lapidist.colony.components.resources.ResourceType;
 
 /**
  * Request message for gathering resources from a tile.
@@ -11,4 +10,4 @@ import net.lapidist.colony.components.resources.ResourceType;
  * @param resourceType type of resource to gather
  */
 @KryoType
-public record ResourceGatherRequestData(int x, int y, ResourceType resourceType) { }
+public record ResourceGatherRequestData(int x, int y, String resourceType) { }

--- a/core/src/main/java/net/lapidist/colony/map/MapFactory.java
+++ b/core/src/main/java/net/lapidist/colony/map/MapFactory.java
@@ -65,7 +65,7 @@ public final class MapFactory {
         for (BuildingData bd : state.buildings()) {
             Entity building = world.createEntity();
             BuildingComponent component = new BuildingComponent();
-            component.setBuildingType(BuildingComponent.BuildingType.valueOf(bd.buildingType()));
+            component.setBuildingType(bd.buildingType());
             component.setHeight(GameConstants.TILE_SIZE);
             component.setWidth(GameConstants.TILE_SIZE);
             component.setX(bd.x());

--- a/core/src/main/java/net/lapidist/colony/mod/PrototypeManager.java
+++ b/core/src/main/java/net/lapidist/colony/mod/PrototypeManager.java
@@ -1,0 +1,49 @@
+package net.lapidist.colony.mod;
+
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.utils.JsonReader;
+import com.badlogic.gdx.utils.JsonValue;
+import net.lapidist.colony.components.entities.BuildingType;
+import net.lapidist.colony.components.resources.ResourceType;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Loads building and resource prototypes from a JSON descriptor. */
+public final class PrototypeManager {
+    private static final Map<String, BuildingType> BUILDINGS = new HashMap<>();
+    private static final Map<String, ResourceType> RESOURCES = new HashMap<>();
+
+    private PrototypeManager() { }
+
+    public static void load(final FileHandle file) {
+        JsonValue root = new JsonReader().parse(file);
+        BUILDINGS.clear();
+        RESOURCES.clear();
+        if (root.has("buildings")) {
+            for (JsonValue val : root.get("buildings")) {
+                BuildingType type = new BuildingType(val.getString("id"), val.getString("key"));
+                BUILDINGS.put(type.id(), type);
+            }
+        }
+        if (root.has("resources")) {
+            for (JsonValue val : root.get("resources")) {
+                ResourceType type = new ResourceType(val.getString("id"));
+                RESOURCES.put(type.id(), type);
+            }
+        }
+    }
+
+    public static BuildingType building(final String id) {
+        return BUILDINGS.get(id);
+    }
+
+    public static ResourceType resource(final String id) {
+        return RESOURCES.get(id);
+    }
+
+    public static Collection<BuildingType> buildings() {
+        return BUILDINGS.values();
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/mod/package-info.java
+++ b/core/src/main/java/net/lapidist/colony/mod/package-info.java
@@ -1,0 +1,2 @@
+/** Mod prototype loading utilities. */
+package net.lapidist.colony.mod;

--- a/core/src/main/java/net/lapidist/colony/serialization/SerializationRegistrar.java
+++ b/core/src/main/java/net/lapidist/colony/serialization/SerializationRegistrar.java
@@ -59,7 +59,6 @@ public final class SerializationRegistrar {
             BuildingData.class,
             BuildingPlacementData.class,
             ResourceData.class,
-            net.lapidist.colony.components.resources.ResourceType.class,
             ResourceGatherRequestData.class,
             ResourceUpdateData.class,
             MapMetadata.class,

--- a/server/src/main/java/net/lapidist/colony/server/commands/BuildCommand.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/BuildCommand.java
@@ -1,13 +1,11 @@
 package net.lapidist.colony.server.commands;
 
-import net.lapidist.colony.components.entities.BuildingComponent;
-
 /**
  * Command representing a building placement request.
  *
  * @param x    tile x coordinate
  * @param y    tile y coordinate
- * @param type building type
+ * @param type building type identifier
  */
-public record BuildCommand(int x, int y, BuildingComponent.BuildingType type) implements ServerCommand {
+public record BuildCommand(int x, int y, String type) implements ServerCommand {
 }

--- a/server/src/main/java/net/lapidist/colony/server/commands/BuildCommandHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/BuildCommandHandler.java
@@ -6,7 +6,6 @@ import net.lapidist.colony.components.state.ResourceData;
 import net.lapidist.colony.components.state.ResourceUpdateData;
 import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.TilePos;
-import net.lapidist.colony.components.entities.BuildingComponent.BuildingType;
 import net.lapidist.colony.events.Events;
 import net.lapidist.colony.server.events.BuildingPlacedEvent;
 import net.lapidist.colony.server.services.NetworkService;
@@ -19,10 +18,10 @@ import java.util.function.Supplier;
  * Applies a {@link BuildCommand} to the game state and broadcasts the change.
  */
 public final class BuildCommandHandler implements CommandHandler<BuildCommand> {
-    private static final Map<BuildingType, ResourceData> COSTS = Map.of(
-            BuildingType.HOUSE, new ResourceData(1, 0, 0),
-            BuildingType.MARKET, new ResourceData(5, 2, 0),
-            BuildingType.FACTORY, new ResourceData(10, 5, 0)
+    private static final Map<String, ResourceData> COSTS = Map.of(
+            "HOUSE", new ResourceData(1, 0, 0),
+            "MARKET", new ResourceData(5, 2, 0),
+            "FACTORY", new ResourceData(10, 5, 0)
     );
 
     private final Supplier<MapState> stateSupplier;
@@ -58,7 +57,7 @@ public final class BuildCommandHandler implements CommandHandler<BuildCommand> {
                 || player.food() < cost.food()) {
             return;
         }
-        BuildingData building = new BuildingData(command.x(), command.y(), command.type().name());
+        BuildingData building = new BuildingData(command.x(), command.y(), command.type());
         state.buildings().add(building);
         ResourceData newResources = new ResourceData(
                 player.wood() - cost.wood(),
@@ -69,10 +68,9 @@ public final class BuildCommandHandler implements CommandHandler<BuildCommand> {
                 .playerResources(newResources)
                 .build();
         stateConsumer.accept(updated);
-        Events.dispatch(new BuildingPlacedEvent(command.x(), command.y(), command.type().name()));
+        Events.dispatch(new BuildingPlacedEvent(command.x(), command.y(), command.type()));
         networkService.broadcast(building);
         networkService.broadcast(new ResourceUpdateData(-1, -1,
                 newResources.wood(), newResources.stone(), newResources.food()));
     }
-
 }

--- a/server/src/main/java/net/lapidist/colony/server/commands/GatherCommand.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/GatherCommand.java
@@ -1,7 +1,5 @@
 package net.lapidist.colony.server.commands;
 
-import net.lapidist.colony.components.resources.ResourceType;
-
 /**
  * Command representing a resource gather request.
  *
@@ -9,5 +7,5 @@ import net.lapidist.colony.components.resources.ResourceType;
  * @param y            tile y coordinate
  * @param resourceType type of resource to gather
  */
-public record GatherCommand(int x, int y, ResourceType resourceType) implements ServerCommand {
+public record GatherCommand(int x, int y, String resourceType) implements ServerCommand {
 }

--- a/server/src/main/java/net/lapidist/colony/server/commands/GatherCommandHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/GatherCommandHandler.java
@@ -39,9 +39,9 @@ public final class GatherCommandHandler implements CommandHandler<GatherCommand>
         ResourceData res = tile.resources();
         ResourceData updated;
         switch (command.resourceType()) {
-            case WOOD -> updated = new ResourceData(Math.max(res.wood() - 1, 0), res.stone(), res.food());
-            case STONE -> updated = new ResourceData(res.wood(), Math.max(res.stone() - 1, 0), res.food());
-            case FOOD -> updated = new ResourceData(res.wood(), res.stone(), Math.max(res.food() - 1, 0));
+            case "WOOD" -> updated = new ResourceData(Math.max(res.wood() - 1, 0), res.stone(), res.food());
+            case "STONE" -> updated = new ResourceData(res.wood(), Math.max(res.stone() - 1, 0), res.food());
+            case "FOOD" -> updated = new ResourceData(res.wood(), res.stone(), Math.max(res.food() - 1, 0));
             default -> updated = res;
         }
         TileData newTile = tile.toBuilder().resources(updated).build();

--- a/server/src/main/java/net/lapidist/colony/server/handlers/BuildingPlacementRequestHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/handlers/BuildingPlacementRequestHandler.java
@@ -1,6 +1,5 @@
 package net.lapidist.colony.server.handlers;
 
-import net.lapidist.colony.components.entities.BuildingComponent;
 import net.lapidist.colony.components.state.BuildingPlacementData;
 import net.lapidist.colony.server.commands.BuildCommand;
 import net.lapidist.colony.server.commands.CommandBus;
@@ -22,7 +21,7 @@ public final class BuildingPlacementRequestHandler extends AbstractMessageHandle
         commandBus.dispatch(new BuildCommand(
                 data.x(),
                 data.y(),
-                BuildingComponent.BuildingType.valueOf(data.buildingType())
+                data.buildingType()
         ));
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/entities/factories/BuildingFactoryTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/entities/factories/BuildingFactoryTest.java
@@ -3,7 +3,9 @@ package net.lapidist.colony.tests.client.entities.factories;
 import com.artemis.World;
 import com.artemis.WorldConfigurationBuilder;
 import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.Gdx;
 import net.lapidist.colony.client.entities.factories.BuildingFactory;
+import net.lapidist.colony.mod.PrototypeManager;
 import net.lapidist.colony.components.entities.BuildingComponent;
 import org.junit.Test;
 
@@ -16,10 +18,11 @@ public class BuildingFactoryTest {
     @Test
     public void createSetsBuildingType() {
         World world = new World(new WorldConfigurationBuilder().build());
-        var entity = BuildingFactory.create(world, BuildingComponent.BuildingType.HOUSE, new Vector2(X, Y));
+        PrototypeManager.load(Gdx.files.internal("sample-mod.json"));
+        var entity = BuildingFactory.create(world, "HOUSE", new Vector2(X, Y));
         BuildingComponent comp = entity.getComponent(BuildingComponent.class);
 
-        assertEquals(BuildingComponent.BuildingType.HOUSE, comp.getBuildingType());
+        assertEquals("HOUSE", comp.getBuildingType());
         assertEquals(X, comp.getX());
         assertEquals(Y, comp.getY());
         world.dispose();

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/BuildingRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/BuildingRendererTest.java
@@ -5,8 +5,10 @@ import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.utils.viewport.ExtendViewport;
+import com.badlogic.gdx.Gdx;
 import net.lapidist.colony.client.renderers.BuildingRenderer;
 import net.lapidist.colony.client.renderers.DefaultAssetResolver;
+import net.lapidist.colony.mod.PrototypeManager;
 import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.client.systems.CameraProvider;
 import net.lapidist.colony.client.render.data.RenderBuilding;
@@ -26,6 +28,7 @@ public class BuildingRendererTest {
 
     @Test
     public void rendersBuildingTexture() {
+        PrototypeManager.load(Gdx.files.internal("sample-mod.json"));
         SpriteBatch batch = mock(SpriteBatch.class);
         ResourceLoader loader = mock(ResourceLoader.class);
         TextureRegion region = mock(TextureRegion.class);
@@ -56,6 +59,7 @@ public class BuildingRendererTest {
 
     @Test
     public void cachesTextureRegions() {
+        PrototypeManager.load(Gdx.files.internal("sample-mod.json"));
         SpriteBatch batch = mock(SpriteBatch.class);
         ResourceLoader loader = mock(ResourceLoader.class);
         TextureRegion region = mock(TextureRegion.class);

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/RendererEnumMapTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/RendererEnumMapTest.java
@@ -7,7 +7,8 @@ import net.lapidist.colony.client.renderers.DefaultAssetResolver;
 import net.lapidist.colony.client.renderers.TileRenderer;
 import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.client.systems.CameraProvider;
-import net.lapidist.colony.components.entities.BuildingComponent;
+import com.badlogic.gdx.Gdx;
+import net.lapidist.colony.mod.PrototypeManager;
 import net.lapidist.colony.components.maps.TileComponent;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
@@ -43,6 +44,7 @@ public class RendererEnumMapTest {
         SpriteBatch batch = mock(SpriteBatch.class);
         ResourceLoader loader = mock(ResourceLoader.class);
         when(loader.findRegion(anyString())).thenReturn(new TextureRegion());
+        PrototypeManager.load(Gdx.files.internal("sample-mod.json"));
         BuildingRenderer renderer = new BuildingRenderer(
                 batch,
                 loader,
@@ -54,9 +56,9 @@ public class RendererEnumMapTest {
         f.setAccessible(true);
         java.util.Map<?, ?> map = (java.util.Map<?, ?>) f.get(renderer);
 
-        assertEquals(BuildingComponent.BuildingType.values().length, map.size());
-        for (BuildingComponent.BuildingType type : BuildingComponent.BuildingType.values()) {
-            assertNotNull(map.get(type));
+        assertEquals(PrototypeManager.buildings().size(), map.size());
+        for (var type : PrototypeManager.buildings()) {
+            assertNotNull(map.get(type.id()));
         }
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/components/BuildingTypeTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/components/BuildingTypeTest.java
@@ -1,6 +1,7 @@
 package net.lapidist.colony.tests.components;
 
-import net.lapidist.colony.components.entities.BuildingComponent;
+import com.badlogic.gdx.Gdx;
+import net.lapidist.colony.mod.PrototypeManager;
 import net.lapidist.colony.i18n.I18n;
 import org.junit.Test;
 
@@ -11,9 +12,10 @@ import static org.junit.Assert.assertEquals;
 public class BuildingTypeTest {
     @Test
     public void returnsLocalizedString() {
+        PrototypeManager.load(Gdx.files.internal("sample-mod.json"));
         I18n.setLocale(Locale.ENGLISH);
-        assertEquals("House", BuildingComponent.BuildingType.HOUSE.toString());
+        assertEquals("House", PrototypeManager.building("HOUSE").toString());
         I18n.setLocale(Locale.FRENCH);
-        assertEquals("Maison", BuildingComponent.BuildingType.HOUSE.toString());
+        assertEquals("Maison", PrototypeManager.building("HOUSE").toString());
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/network/GameServerGatherBroadcastTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/network/GameServerGatherBroadcastTest.java
@@ -3,7 +3,6 @@ package net.lapidist.colony.tests.network;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.components.state.ResourceGatherRequestData;
 import net.lapidist.colony.components.state.ResourceUpdateData;
-import net.lapidist.colony.components.resources.ResourceType;
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.server.GameServerConfig;
 import org.junit.Test;
@@ -36,7 +35,7 @@ public class GameServerGatherBroadcastTest {
         latchA.await(1, TimeUnit.SECONDS);
         latchB.await(1, TimeUnit.SECONDS);
 
-        ResourceGatherRequestData data = new ResourceGatherRequestData(0, 0, ResourceType.WOOD);
+        ResourceGatherRequestData data = new ResourceGatherRequestData(0, 0, "WOOD");
         clientA.sendGatherRequest(data);
 
         Thread.sleep(WAIT_MS);

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationPlayerResourcesTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationPlayerResourcesTest.java
@@ -4,7 +4,6 @@ import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.ResourceGatherRequestData;
 import net.lapidist.colony.components.resources.PlayerResourceComponent;
-import net.lapidist.colony.components.resources.ResourceType;
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.server.GameServerConfig;
 import net.lapidist.colony.tests.GdxTestRunner;
@@ -42,7 +41,7 @@ public class GameSimulationPlayerResourcesTest {
         MapState state = receiver.getMapState();
         GameSimulation sim = new GameSimulation(state, receiver);
 
-        ResourceGatherRequestData data = new ResourceGatherRequestData(0, 0, ResourceType.WOOD);
+        ResourceGatherRequestData data = new ResourceGatherRequestData(0, 0, "WOOD");
         sender.sendGatherRequest(data);
 
         Thread.sleep(WAIT_MS);

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationResourceUpdateTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationResourceUpdateTest.java
@@ -4,7 +4,6 @@ import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.ResourceGatherRequestData;
 import net.lapidist.colony.components.resources.ResourceComponent;
-import net.lapidist.colony.components.resources.ResourceType;
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.server.GameServerConfig;
 import net.lapidist.colony.tests.GdxTestRunner;
@@ -43,7 +42,7 @@ public class GameSimulationResourceUpdateTest {
         MapState state = receiver.getMapState();
         GameSimulation sim = new GameSimulation(state, receiver);
 
-        ResourceGatherRequestData data = new ResourceGatherRequestData(0, 0, ResourceType.WOOD);
+        ResourceGatherRequestData data = new ResourceGatherRequestData(0, 0, "WOOD");
         sender.sendGatherRequest(data);
 
         Thread.sleep(WAIT_MS);

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerPlayerResourceSaveTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerPlayerResourceSaveTest.java
@@ -2,7 +2,6 @@ package net.lapidist.colony.tests.server;
 
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.components.state.ResourceGatherRequestData;
-import net.lapidist.colony.components.resources.ResourceType;
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.server.GameServerConfig;
 import net.lapidist.colony.io.Paths;
@@ -32,7 +31,7 @@ public class GameServerPlayerResourceSaveTest {
         client.start(state -> latch.countDown());
         latch.await(1, TimeUnit.SECONDS);
 
-        client.sendGatherRequest(new ResourceGatherRequestData(0, 0, ResourceType.WOOD));
+        client.sendGatherRequest(new ResourceGatherRequestData(0, 0, "WOOD"));
         Thread.sleep(WAIT_MS);
 
         client.stop();

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/InputSystemResourceTypeTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/InputSystemResourceTypeTest.java
@@ -16,7 +16,6 @@ import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.ResourceData;
 import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.TilePos;
-import net.lapidist.colony.components.resources.ResourceType;
 import net.lapidist.colony.components.state.ResourceGatherRequestData;
 import net.lapidist.colony.settings.KeyAction;
 import net.lapidist.colony.settings.KeyBindings;
@@ -61,7 +60,7 @@ public class InputSystemResourceTypeTest {
         ArgumentCaptor<ResourceGatherRequestData> captor =
                 ArgumentCaptor.forClass(ResourceGatherRequestData.class);
         verify(client).sendGatherRequest(captor.capture());
-        assertEquals(ResourceType.STONE, captor.getValue().resourceType());
+        assertEquals("STONE", captor.getValue().resourceType());
     }
 
     @Test
@@ -100,6 +99,6 @@ public class InputSystemResourceTypeTest {
         ArgumentCaptor<ResourceGatherRequestData> captor =
                 ArgumentCaptor.forClass(ResourceGatherRequestData.class);
         verify(client).sendGatherRequest(captor.capture());
-        assertEquals(ResourceType.WOOD, captor.getValue().resourceType());
+        assertEquals("WOOD", captor.getValue().resourceType());
     }
 }

--- a/tests/src/test/resources/sample-mod.json
+++ b/tests/src/test/resources/sample-mod.json
@@ -1,0 +1,12 @@
+{
+  "buildings": [
+    {"id": "HOUSE", "key": "building.house"},
+    {"id": "MARKET", "key": "building.market"},
+    {"id": "FACTORY", "key": "building.factory"}
+  ],
+  "resources": [
+    {"id": "WOOD"},
+    {"id": "STONE"},
+    {"id": "FOOD"}
+  ]
+}


### PR DESCRIPTION
## Summary
- introduce `PrototypeManager` to load building/resource types from JSON mods
- replace hardcoded enums with runtime strings
- handle dynamic types in serialization
- update client/server systems and tests
- add sample mod descriptor used by tests

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_684c06ee00208328abd8f39be0f1f639