### PR TITLE
fix: remove unused param from findTile

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/systems/InputSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/InputSystem.java
@@ -136,7 +136,7 @@ public final class InputSystem extends BaseSystem {
             Vector2 worldCoords = CameraUtils.screenToWorldCoords(
                     cameraSystem.getViewport(), x, y);
             Vector2 tileCoords = CameraUtils.worldCoordsToTileCoords(worldCoords);
-            MapUtils.findTile(map, (int) tileCoords.x, (int) tileCoords.y, tileMapper)
+            MapUtils.findTile(map, (int) tileCoords.x, (int) tileCoords.y)
                     .ifPresent(tile -> {
                         TileComponent tc = tileMapper.get(tile);
                         var rc = resourceMapper.get(tile);

--- a/client/src/main/java/net/lapidist/colony/client/systems/SelectionSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/SelectionSystem.java
@@ -98,7 +98,7 @@ public final class SelectionSystem extends BaseSystem {
         boolean result = tileSelectionHandler.handleTap(x, y, map, tileMapper);
         var worldCoords = CameraUtils.screenToWorldCoords(cameraSystem.getViewport(), x, y);
         var tileCoords = CameraUtils.worldCoordsToTileCoords(worldCoords);
-        MapUtils.findTile(map, (int) tileCoords.x, (int) tileCoords.y, tileMapper)
+        MapUtils.findTile(map, (int) tileCoords.x, (int) tileCoords.y)
                 .ifPresent(tile -> {
                     TileComponent tc = tileMapper.get(tile);
                     ResourceComponent rc = resourceMapper.get(tile);

--- a/client/src/main/java/net/lapidist/colony/client/systems/input/BuildingPlacementHandler.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/input/BuildingPlacementHandler.java
@@ -37,7 +37,7 @@ public final class BuildingPlacementHandler {
         Vector2 worldCoords = CameraUtils.screenToWorldCoords(cameraSystem.getViewport(), x, y);
         Vector2 tileCoords = CameraUtils.worldCoordsToTileCoords(worldCoords);
 
-        return MapUtils.findTile(map, (int) tileCoords.x, (int) tileCoords.y, tileMapper)
+        return MapUtils.findTile(map, (int) tileCoords.x, (int) tileCoords.y)
                 .map(tile -> {
                     TileComponent tc = tileMapper.get(tile);
                     BuildingPlacementData msg = new BuildingPlacementData(

--- a/client/src/main/java/net/lapidist/colony/client/systems/input/TileSelectionHandler.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/input/TileSelectionHandler.java
@@ -46,7 +46,7 @@ public final class TileSelectionHandler {
         Vector2 worldCoords = CameraUtils.screenToWorldCoords(cameraSystem.getViewport(), x, y);
         Vector2 tileCoords = CameraUtils.worldCoordsToTileCoords(worldCoords);
 
-        return MapUtils.findTile(map, (int) tileCoords.x, (int) tileCoords.y, tileMapper)
+        return MapUtils.findTile(map, (int) tileCoords.x, (int) tileCoords.y)
                 .map(tile -> {
                     TileComponent tileComponent = tileMapper.get(tile);
                     boolean newState = !tileComponent.isSelected();

--- a/client/src/main/java/net/lapidist/colony/client/systems/network/ResourceUpdateSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/network/ResourceUpdateSystem.java
@@ -45,7 +45,7 @@ public final class ResourceUpdateSystem extends BaseSystem {
         ResourceUpdateData update;
         while ((update = client.poll(ResourceUpdateData.class)) != null) {
             final ResourceUpdateData data = update;
-            var found = MapUtils.findTile(mapComponent, data.x(), data.y(), tileMapper)
+            var found = MapUtils.findTile(mapComponent, data.x(), data.y())
                     .map(tile -> {
                         ResourceComponent rc = resourceMapper.get(tile);
                         int deltaWood = rc.getWood() - data.wood();

--- a/client/src/main/java/net/lapidist/colony/client/systems/network/TileUpdateSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/network/TileUpdateSystem.java
@@ -36,7 +36,7 @@ public final class TileUpdateSystem extends BaseSystem {
         TileSelectionData update;
         while ((update = client.poll(TileSelectionData.class)) != null) {
             final TileSelectionData data = update;
-                    MapUtils.findTile(mapComponent, data.x(), data.y(), tileMapper)
+                    MapUtils.findTile(mapComponent, data.x(), data.y())
                     .ifPresent(t -> {
                         var tc = tileMapper.get(t);
                         tc.setSelected(data.selected());

--- a/core/src/main/java/net/lapidist/colony/map/MapUtils.java
+++ b/core/src/main/java/net/lapidist/colony/map/MapUtils.java
@@ -5,8 +5,6 @@ import com.artemis.Entity;
 import com.artemis.World;
 import com.artemis.utils.IntBag;
 import net.lapidist.colony.components.maps.MapComponent;
-import net.lapidist.colony.components.maps.TileComponent;
-import com.artemis.ComponentMapper;
 import java.util.Optional;
 
 /**
@@ -56,14 +54,12 @@ public final class MapUtils {
      * @param map    the map component containing tiles
      * @param x      the tile x coordinate
      * @param y      the tile y coordinate
-     * @param mapper mapper for {@link TileComponent} instances
      * @return an {@link Optional} containing the tile entity if present
      */
     public static Optional<Entity> findTile(
             final MapComponent map,
             final int x,
-            final int y,
-            final ComponentMapper<TileComponent> mapper
+            final int y
     ) {
         if (map == null) {
             return Optional.empty();

--- a/tests/src/test/java/net/lapidist/colony/tests/map/MapUtilsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/map/MapUtilsTest.java
@@ -8,8 +8,6 @@ import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.map.MapUtils;
-import net.lapidist.colony.components.maps.TileComponent;
-import com.artemis.ComponentMapper;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -64,9 +62,7 @@ public class MapUtilsTest {
 
         MapComponent map = MapUtils.findMap(world).orElse(null);
         assertNotNull(map);
-        ComponentMapper<TileComponent> mapper = world.getMapper(TileComponent.class);
-
-        assertTrue(MapUtils.findTile(map, 1, 2, mapper).isPresent());
-        assertTrue(MapUtils.findTile(map, 0, 0, mapper).isEmpty());
+        assertTrue(MapUtils.findTile(map, 1, 2).isPresent());
+        assertTrue(MapUtils.findTile(map, 0, 0).isEmpty());
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationDelayedTileUpdateTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationDelayedTileUpdateTest.java
@@ -78,8 +78,7 @@ public class GameSimulationDelayedTileUpdateTest {
         return MapUtils.findTile(
                 mapComponent,
                 0,
-                0,
-                sim.getWorld().getMapper(TileComponent.class)
+                0
         ).map(t -> sim.getWorld().getMapper(TileComponent.class).get(t))
                 .orElse(null);
     }

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationInputSelectionTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationInputSelectionTest.java
@@ -66,8 +66,7 @@ public class GameSimulationInputSelectionTest {
             var tileOpt = MapUtils.findTile(
                     mapComponent,
                     0,
-                    0,
-                    sim.getWorld().getMapper(TileComponent.class)
+                    0
             );
             TileComponent tile = tileOpt.map(
                     t -> sim.getWorld().getMapper(TileComponent.class).get(t)


### PR DESCRIPTION
## Summary
- remove unnecessary ComponentMapper argument from `MapUtils.findTile`
- update game systems and scenario tests

## Testing
- `./gradlew clean test`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_684c2828f8148328b8f362f403464ece