### PR TITLE
feat: add remove keybind label and scrolling list

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/KeybindsScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/KeybindsScreen.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.Input;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.InputListener;
+import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
@@ -35,6 +36,7 @@ public final class KeybindsScreen extends BaseScreen {
         this.colony = game;
         KeyBindings bindings = game.getSettings().getKeyBindings();
         Table root = getRoot();
+        Table list = new Table();
 
         for (KeyAction action : KeyAction.values()) {
             String label = I18n.get("keybind." + action.getI18nKey());
@@ -47,8 +49,12 @@ public final class KeybindsScreen extends BaseScreen {
                     btn.setText(label + ": ?");
                 }
             });
-            root.add(btn).row();
+            list.add(btn).row();
         }
+
+        ScrollPane scroll = new ScrollPane(list, getSkin());
+        scroll.setScrollingDisabled(true, false);
+        root.add(scroll).expand().fill().row();
 
         TextButton reset = new TextButton(I18n.get("common.reset"), getSkin());
         TextButton back = new TextButton(I18n.get("common.back"), getSkin());

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -29,6 +29,7 @@ keybind.moveLeft=Move Left
 keybind.moveRight=Move Right
 keybind.gather=Gather
 keybind.build=Build
+keybind.remove=Remove
 keybind.chat=Chat
 keybind.minimap=Minimap
 common.reset=Reset

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -28,6 +28,7 @@ keybind.moveLeft=Nach Links
 keybind.moveRight=Nach Rechts
 keybind.gather=Sammeln
 keybind.build=Bauen
+keybind.remove=Entfernen
 keybind.chat=Chat
 keybind.minimap=Minikarte
 common.reset=Zurücksetzen

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -28,6 +28,7 @@ keybind.moveLeft=Mover Izquierda
 keybind.moveRight=Mover Derecha
 keybind.gather=Recolectar
 keybind.build=Construir
+keybind.remove=Eliminar
 keybind.chat=Chat
 keybind.minimap=Minimapa
 common.reset=Restablecer

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -28,6 +28,7 @@ keybind.moveLeft=Gauche
 keybind.moveRight=Droite
 keybind.gather=Récolter
 keybind.build=Construire
+keybind.remove=Supprimer
 keybind.chat=Chat
 keybind.minimap=Mini-carte
 common.reset=Réinitialiser


### PR DESCRIPTION
## Summary
- localize the remove keybinding across all languages
- make keybinding list scrollable with reset/back fixed at the bottom

## Testing
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684c6119159483289279d75299a2eeb4