### PR TITLE
feat: add map chunk data

### DIFF
--- a/core/src/main/java/net/lapidist/colony/components/state/ChunkPos.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/ChunkPos.java
@@ -1,0 +1,12 @@
+package net.lapidist.colony.components.state;
+
+import net.lapidist.colony.serialization.KryoType;
+
+/**
+ * Coordinate key used for chunk lookup.
+ *
+ * @param x chunk x coordinate
+ * @param y chunk y coordinate
+ */
+@KryoType
+public record ChunkPos(int x, int y) { }

--- a/core/src/main/java/net/lapidist/colony/map/MapChunkData.java
+++ b/core/src/main/java/net/lapidist/colony/map/MapChunkData.java
@@ -1,0 +1,64 @@
+package net.lapidist.colony.map;
+
+import net.lapidist.colony.components.state.TileData;
+import net.lapidist.colony.components.state.TilePos;
+import net.lapidist.colony.serialization.KryoType;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * Stores tile data for a 32x32 region of the map.
+ * Tiles are generated on demand using {@link PerlinNoise}.
+ */
+@KryoType
+public final class MapChunkData {
+    public static final int CHUNK_SIZE = 32;
+    private static final double NOISE_SCALE = 0.1;
+
+    private final Map<TilePos, TileData> tiles = new HashMap<>();
+    private final PerlinNoise noise;
+
+    public MapChunkData() {
+        this(new Random().nextLong());
+    }
+
+    public MapChunkData(final long seed) {
+        this.noise = new PerlinNoise(seed);
+    }
+
+    /**
+     * Returns the tile at the given local coordinates, generating it if needed.
+     *
+     * @param localX x coordinate within the chunk
+     * @param localY y coordinate within the chunk
+     * @return tile data instance
+     */
+    public TileData getTile(final int localX, final int localY) {
+        TilePos pos = new TilePos(localX, localY);
+        return tiles.computeIfAbsent(pos, p -> createTile(p.x(), p.y()));
+    }
+
+    private TileData createTile(final int x, final int y) {
+        double value = noise.noise(x * NOISE_SCALE, y * NOISE_SCALE);
+        String type = value > 0 ? "GRASS" : "DIRT";
+        return TileData.builder()
+                .x(x)
+                .y(y)
+                .tileType(type)
+                .passable(true)
+                .build();
+    }
+
+    /**
+     * @return true when all tiles in this chunk have been generated
+     */
+    public boolean isGenerated() {
+        return tiles.size() == CHUNK_SIZE * CHUNK_SIZE;
+    }
+
+    public Map<TilePos, TileData> getTiles() {
+        return tiles;
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/serialization/SerializationRegistrar.java
+++ b/core/src/main/java/net/lapidist/colony/serialization/SerializationRegistrar.java
@@ -66,6 +66,8 @@ public final class SerializationRegistrar {
             ResourceUpdateData.class,
             MapMetadata.class,
             MapChunk.class,
+            net.lapidist.colony.components.state.ChunkPos.class,
+            net.lapidist.colony.map.MapChunkData.class,
             TilePos.class,
             net.lapidist.colony.chat.ChatMessage.class,
             SaveData.class

--- a/tests/src/test/java/net/lapidist/colony/tests/map/MapChunkDataTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/map/MapChunkDataTest.java
@@ -1,0 +1,38 @@
+package net.lapidist.colony.tests.map;
+
+import net.lapidist.colony.map.MapChunkData;
+import net.lapidist.colony.components.state.TileData;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MapChunkDataTest {
+
+    private static final long SEED_ONE = 42L;
+    private static final long SEED_TWO = 123L;
+    private static final int SAMPLE_X = 5;
+    private static final int SAMPLE_Y = 5;
+
+    @Test
+    public void generatesTilesLazily() {
+        MapChunkData chunk = new MapChunkData(SEED_ONE);
+        assertFalse(chunk.isGenerated());
+        TileData first = chunk.getTile(0, 0);
+        assertNotNull(first);
+        assertSame(first, chunk.getTile(0, 0));
+        for (int x = 0; x < MapChunkData.CHUNK_SIZE; x++) {
+            for (int y = 0; y < MapChunkData.CHUNK_SIZE; y++) {
+                chunk.getTile(x, y);
+            }
+        }
+        assertTrue(chunk.isGenerated());
+        assertEquals(MapChunkData.CHUNK_SIZE * MapChunkData.CHUNK_SIZE, chunk.getTiles().size());
+    }
+
+    @Test
+    public void sameSeedProducesSameTiles() {
+        MapChunkData a = new MapChunkData(SEED_TWO);
+        MapChunkData b = new MapChunkData(SEED_TWO);
+        assertEquals(a.getTile(SAMPLE_X, SAMPLE_Y).tileType(), b.getTile(SAMPLE_X, SAMPLE_Y).tileType());
+    }
+}


### PR DESCRIPTION
## Summary
- create `ChunkPos` for chunk addressing
- implement `MapChunkData` for lazily generated chunk tiles
- register new types with `SerializationRegistrar`
- test lazy generation and deterministic seeding

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c6fb2c78c8328b55a4d9f3cecd39c