### PR TITLE
feat: implement chunk-based map state

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
+++ b/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
@@ -173,7 +173,8 @@ public final class GameClient extends AbstractMessageEndpoint {
             int chunkY = Math.floorDiv(pos.y(), MapChunkData.CHUNK_SIZE);
             int localX = Math.floorMod(pos.x(), MapChunkData.CHUNK_SIZE);
             int localY = Math.floorMod(pos.y(), MapChunkData.CHUNK_SIZE);
-            MapChunkData chunk = chunks.computeIfAbsent(new ChunkPos(chunkX, chunkY), p -> new MapChunkData(chunkX, chunkY));
+            ChunkPos posKey = new ChunkPos(chunkX, chunkY);
+            MapChunkData chunk = chunks.computeIfAbsent(posKey, p -> new MapChunkData(chunkX, chunkY));
             chunk.getTiles().put(new TilePos(localX, localY), data);
         }
         return chunks;

--- a/client/src/main/java/net/lapidist/colony/client/network/handlers/ResourceUpdateHandler.java
+++ b/client/src/main/java/net/lapidist/colony/client/network/handlers/ResourceUpdateHandler.java
@@ -5,6 +5,7 @@ import net.lapidist.colony.components.state.ResourceData;
 import net.lapidist.colony.components.state.ResourceUpdateData;
 import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.TilePos;
+import net.lapidist.colony.map.MapChunkData;
 import net.lapidist.colony.network.AbstractMessageHandler;
 
 import java.util.Map;
@@ -45,12 +46,16 @@ public final class ResourceUpdateHandler extends AbstractMessageHandler<Resource
             stateConsumer.accept(updated);
         } else {
             TilePos pos = new TilePos(message.x(), message.y());
-            TileData tile = state.tiles().get(pos);
+            TileData tile = state.getTile(pos.x(), pos.y());
             if (tile != null) {
                 TileData newTile = tile.toBuilder()
                         .resources(new ResourceData(message.wood(), message.stone(), message.food()))
                         .build();
-                state.tiles().put(pos, newTile);
+                int chunkX = Math.floorDiv(pos.x(), MapChunkData.CHUNK_SIZE);
+                int chunkY = Math.floorDiv(pos.y(), MapChunkData.CHUNK_SIZE);
+                int localX = Math.floorMod(pos.x(), MapChunkData.CHUNK_SIZE);
+                int localY = Math.floorMod(pos.y(), MapChunkData.CHUNK_SIZE);
+                state.getOrCreateChunk(chunkX, chunkY).getTiles().put(new TilePos(localX, localY), newTile);
             }
         }
     }

--- a/core/src/main/java/net/lapidist/colony/components/state/MapState.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/MapState.java
@@ -4,7 +4,6 @@ import net.lapidist.colony.serialization.KryoType;
 import net.lapidist.colony.save.SaveVersion;
 
 import net.lapidist.colony.map.MapChunkData;
-import net.lapidist.colony.components.state.ChunkPos;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -71,7 +70,7 @@ public record MapState(
         return new TileMapView();
     }
 
-    private class TileMapView extends java.util.AbstractMap<TilePos, TileData> {
+    private final class TileMapView extends java.util.AbstractMap<TilePos, TileData> {
         @Override
         public TileData get(final Object key) {
             if (key instanceof TilePos pos) {

--- a/core/src/main/java/net/lapidist/colony/map/DefaultMapGenerator.java
+++ b/core/src/main/java/net/lapidist/colony/map/DefaultMapGenerator.java
@@ -4,6 +4,7 @@ import net.lapidist.colony.components.state.BuildingData;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.TilePos;
+import net.lapidist.colony.map.MapChunkData;
 import net.lapidist.colony.components.state.ResourceData;
 import net.lapidist.colony.i18n.I18n;
 
@@ -33,7 +34,12 @@ public final class DefaultMapGenerator implements MapGenerator {
         for (int x = 0; x < width; x++) {
             for (int y = 0; y < height; y++) {
                 String type = noise.noise(x * NOISE_SCALE, y * NOISE_SCALE) > 0 ? "GRASS" : "DIRT";
-                state.tiles().put(new TilePos(x, y), createTile(x, y, type));
+                int chunkX = Math.floorDiv(x, MapChunkData.CHUNK_SIZE);
+                int chunkY = Math.floorDiv(y, MapChunkData.CHUNK_SIZE);
+                int localX = Math.floorMod(x, MapChunkData.CHUNK_SIZE);
+                int localY = Math.floorMod(y, MapChunkData.CHUNK_SIZE);
+                MapChunkData chunk = state.getOrCreateChunk(chunkX, chunkY);
+                chunk.getTiles().put(new TilePos(localX, localY), createTile(x, y, type));
             }
         }
 

--- a/core/src/main/java/net/lapidist/colony/map/DefaultMapGenerator.java
+++ b/core/src/main/java/net/lapidist/colony/map/DefaultMapGenerator.java
@@ -4,7 +4,6 @@ import net.lapidist.colony.components.state.BuildingData;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.TilePos;
-import net.lapidist.colony.map.MapChunkData;
 import net.lapidist.colony.components.state.ResourceData;
 import net.lapidist.colony.i18n.I18n;
 

--- a/core/src/main/java/net/lapidist/colony/map/MapChunkData.java
+++ b/core/src/main/java/net/lapidist/colony/map/MapChunkData.java
@@ -18,7 +18,8 @@ public final class MapChunkData {
     private static final double NOISE_SCALE = 0.1;
 
     private final Map<TilePos, TileData> tiles = new HashMap<>();
-    private final PerlinNoise noise;
+    private final long seed;
+    private transient PerlinNoise noise;
     private final int baseX;
     private final int baseY;
 
@@ -26,18 +27,26 @@ public final class MapChunkData {
         this(new Random().nextLong(), 0, 0);
     }
 
-    public MapChunkData(final long seed) {
-        this(seed, 0, 0);
+    public MapChunkData(final long seedValue) {
+        this(seedValue, 0, 0);
     }
 
     public MapChunkData(final int chunkX, final int chunkY) {
         this(new Random().nextLong(), chunkX, chunkY);
     }
 
-    public MapChunkData(final long seed, final int chunkX, final int chunkY) {
-        this.noise = new PerlinNoise(seed);
+    public MapChunkData(final long seedValue, final int chunkX, final int chunkY) {
+        this.seed = seedValue;
+        this.noise = new PerlinNoise(seedValue);
         this.baseX = chunkX * CHUNK_SIZE;
         this.baseY = chunkY * CHUNK_SIZE;
+    }
+
+    private PerlinNoise noise() {
+        if (noise == null) {
+            noise = new PerlinNoise(seed);
+        }
+        return noise;
     }
 
     /**
@@ -55,7 +64,7 @@ public final class MapChunkData {
     private TileData createTile(final int x, final int y) {
         int worldX = baseX + x;
         int worldY = baseY + y;
-        double value = noise.noise(worldX * NOISE_SCALE, worldY * NOISE_SCALE);
+        double value = noise().noise(worldX * NOISE_SCALE, worldY * NOISE_SCALE);
         String type = value > 0 ? "GRASS" : "DIRT";
         return TileData.builder()
                 .x(worldX)

--- a/core/src/main/java/net/lapidist/colony/map/MapChunkData.java
+++ b/core/src/main/java/net/lapidist/colony/map/MapChunkData.java
@@ -19,13 +19,25 @@ public final class MapChunkData {
 
     private final Map<TilePos, TileData> tiles = new HashMap<>();
     private final PerlinNoise noise;
+    private final int baseX;
+    private final int baseY;
 
     public MapChunkData() {
-        this(new Random().nextLong());
+        this(new Random().nextLong(), 0, 0);
     }
 
     public MapChunkData(final long seed) {
+        this(seed, 0, 0);
+    }
+
+    public MapChunkData(final int chunkX, final int chunkY) {
+        this(new Random().nextLong(), chunkX, chunkY);
+    }
+
+    public MapChunkData(final long seed, final int chunkX, final int chunkY) {
         this.noise = new PerlinNoise(seed);
+        this.baseX = chunkX * CHUNK_SIZE;
+        this.baseY = chunkY * CHUNK_SIZE;
     }
 
     /**
@@ -41,11 +53,13 @@ public final class MapChunkData {
     }
 
     private TileData createTile(final int x, final int y) {
-        double value = noise.noise(x * NOISE_SCALE, y * NOISE_SCALE);
+        int worldX = baseX + x;
+        int worldY = baseY + y;
+        double value = noise.noise(worldX * NOISE_SCALE, worldY * NOISE_SCALE);
         String type = value > 0 ? "GRASS" : "DIRT";
         return TileData.builder()
-                .x(x)
-                .y(y)
+                .x(worldX)
+                .y(worldY)
                 .tileType(type)
                 .passable(true)
                 .build();

--- a/core/src/main/java/net/lapidist/colony/map/MapFactory.java
+++ b/core/src/main/java/net/lapidist/colony/map/MapFactory.java
@@ -37,29 +37,32 @@ public final class MapFactory {
         Map<TilePos, Entity> tileMap = new HashMap<>();
         Array<Entity> entities = new Array<>();
 
-        for (Map.Entry<TilePos, TileData> entry : state.tiles().entrySet()) {
-            TileData td = entry.getValue();
-            Entity tile = world.createEntity();
-            TileComponent tileComponent = new TileComponent();
-            tileComponent.setTileType(TileComponent.TileType.valueOf(td.tileType()));
-            tileComponent.setPassable(td.passable());
-            tileComponent.setSelected(td.selected());
-            tileComponent.setHeight(GameConstants.TILE_SIZE);
-            tileComponent.setWidth(GameConstants.TILE_SIZE);
-            tileComponent.setX(td.x());
-            tileComponent.setY(td.y());
-            tile.edit().add(tileComponent);
+        for (var chunkEntry : state.chunks().entrySet()) {
+            for (Map.Entry<TilePos, TileData> entry : chunkEntry.getValue().getTiles().entrySet()) {
+                TileData td = entry.getValue();
+                Entity tile = world.createEntity();
+                TileComponent tileComponent = new TileComponent();
+                tileComponent.setTileType(TileComponent.TileType.valueOf(td.tileType()));
+                tileComponent.setPassable(td.passable());
+                tileComponent.setSelected(td.selected());
+                tileComponent.setHeight(GameConstants.TILE_SIZE);
+                tileComponent.setWidth(GameConstants.TILE_SIZE);
+                tileComponent.setX(td.x());
+                tileComponent.setY(td.y());
+                tile.edit().add(tileComponent);
 
-            ResourceComponent rc = new ResourceComponent();
-            if (td.resources() != null) {
-                rc.setWood(td.resources().wood());
-                rc.setStone(td.resources().stone());
-                rc.setFood(td.resources().food());
+
+                ResourceComponent rc = new ResourceComponent();
+                if (td.resources() != null) {
+                    rc.setWood(td.resources().wood());
+                    rc.setStone(td.resources().stone());
+                    rc.setFood(td.resources().food());
+                }
+                tile.edit().add(rc);
+
+                tiles.add(tile);
+                tileMap.put(new TilePos(td.x(), td.y()), tile);
             }
-            tile.edit().add(rc);
-
-            tiles.add(tile);
-            tileMap.put(entry.getKey(), tile);
         }
 
         for (BuildingData bd : state.buildings()) {

--- a/core/src/main/java/net/lapidist/colony/save/V3ToV4Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V3ToV4Migration.java
@@ -4,6 +4,7 @@ import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.ResourceData;
 import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.TilePos;
+import net.lapidist.colony.map.MapChunkData;
 
 /** Migration from save version 3 to version 4 adding resource data. */
 public final class V3ToV4Migration implements MapStateMigration {
@@ -22,13 +23,16 @@ public final class V3ToV4Migration implements MapStateMigration {
 
     @Override
     public MapState apply(final MapState state) {
-        for (TilePos pos : state.tiles().keySet()) {
-            TileData tile = state.tiles().get(pos);
-            if (tile.resources() == null) {
-                TileData updated = tile.toBuilder()
-                        .resources(new ResourceData(DEFAULT_WOOD, DEFAULT_STONE, DEFAULT_FOOD))
-                        .build();
-                state.tiles().put(pos, updated);
+        for (var chunkEntry : state.chunks().entrySet()) {
+            MapChunkData chunk = chunkEntry.getValue();
+            for (TilePos pos : chunk.getTiles().keySet()) {
+                TileData tile = chunk.getTiles().get(pos);
+                if (tile.resources() == null) {
+                    TileData updated = tile.toBuilder()
+                            .resources(new ResourceData(DEFAULT_WOOD, DEFAULT_STONE, DEFAULT_FOOD))
+                            .build();
+                    chunk.getTiles().put(pos, updated);
+                }
             }
         }
         return state.toBuilder().version(toVersion()).build();

--- a/server/src/main/java/net/lapidist/colony/server/commands/BuildCommandHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/BuildCommandHandler.java
@@ -46,7 +46,7 @@ public final class BuildCommandHandler implements CommandHandler<BuildCommand> {
     @Override
     public void handle(final BuildCommand command) {
         MapState state = stateSupplier.get();
-        TileData tile = state.tiles().get(new TilePos(command.x(), command.y()));
+        TileData tile = state.getTile(command.x(), command.y());
         boolean occupied = state.buildings().stream()
                 .anyMatch(b -> b.x() == command.x() && b.y() == command.y());
         if (tile == null || occupied) {

--- a/server/src/main/java/net/lapidist/colony/server/commands/BuildCommandHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/BuildCommandHandler.java
@@ -5,7 +5,6 @@ import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.ResourceData;
 import net.lapidist.colony.components.state.ResourceUpdateData;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.components.entities.BuildingComponent.BuildingType;
 import net.lapidist.colony.events.Events;
 import net.lapidist.colony.server.events.BuildingPlacedEvent;

--- a/server/src/main/java/net/lapidist/colony/server/commands/TileSelectionCommandHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/TileSelectionCommandHandler.java
@@ -3,6 +3,7 @@ package net.lapidist.colony.server.commands;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.TilePos;
+import net.lapidist.colony.map.MapChunkData;
 import net.lapidist.colony.components.state.TileSelectionData;
 import net.lapidist.colony.events.Events;
 import net.lapidist.colony.server.events.TileSelectionEvent;
@@ -31,11 +32,14 @@ public final class TileSelectionCommandHandler implements CommandHandler<TileSel
     @Override
     public void handle(final TileSelectionCommand command) {
         MapState state = stateSupplier.get();
-        TilePos pos = new TilePos(command.x(), command.y());
-        TileData tile = state.tiles().get(pos);
+        TileData tile = state.getTile(command.x(), command.y());
         if (tile != null) {
             TileData updated = tile.toBuilder().selected(command.selected()).build();
-            state.tiles().put(pos, updated);
+            int chunkX = Math.floorDiv(command.x(), MapChunkData.CHUNK_SIZE);
+            int chunkY = Math.floorDiv(command.y(), MapChunkData.CHUNK_SIZE);
+            int localX = Math.floorMod(command.x(), MapChunkData.CHUNK_SIZE);
+            int localY = Math.floorMod(command.y(), MapChunkData.CHUNK_SIZE);
+            state.getOrCreateChunk(chunkX, chunkY).getTiles().put(new TilePos(localX, localY), updated);
         }
         Events.dispatch(new TileSelectionEvent(command.x(), command.y(), command.selected()));
         networkService.broadcast(new TileSelectionData(command.x(), command.y(), command.selected()));

--- a/tests/src/test/java/net/lapidist/colony/tests/components/MapStateBuilderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/components/MapStateBuilderTest.java
@@ -18,7 +18,7 @@ public class MapStateBuilderTest {
                 .saveName("s")
                 .autosaveName("a")
                 .description("d")
-                .tiles(new HashMap<>())
+                .chunks(new HashMap<>())
                 .buildings(List.of())
                 .playerResources(new ResourceData());
         MapState state = builder.build();


### PR DESCRIPTION
## Summary
- store map tiles by chunk instead of flat tile map
- generate chunk coordinates in MapChunkData
- update map factory and generator to iterate chunks
- adjust network resource and server-side handlers
- expose helper builder method and tile view for compatibility

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test` *(fails: GameClientServerTest etc.)*
- `./gradlew check` *(fails due to test failures)*

------
https://chatgpt.com/codex/tasks/task_e_684c7212f4a08328b6084d6714c4a459