### PR TITLE
test: adapt tests for chunk-based map

### DIFF
--- a/tests/src/test/java/net/lapidist/colony/client/renderers/MapTileCacheTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/renderers/MapTileCacheTest.java
@@ -18,7 +18,6 @@ import com.badlogic.gdx.utils.viewport.ExtendViewport;
 import net.lapidist.colony.components.maps.MapComponent;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.map.MapFactory;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
@@ -39,7 +38,7 @@ public class MapTileCacheTest {
 
     private MapRenderData createData() {
         MapState state = new MapState();
-        state.tiles().put(new TilePos(0, 0), TileData.builder()
+        state.putTile(TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true)
                 .build());
         World world = new World(new WorldConfigurationBuilder().build());
@@ -53,7 +52,7 @@ public class MapTileCacheTest {
         MapState state = new MapState();
         int total = LARGE_TILE_COUNT;
         for (int i = 0; i < total; i++) {
-            state.tiles().put(new TilePos(i, 0), TileData.builder()
+            state.putTile(TileData.builder()
                     .x(i).y(0).tileType("GRASS").passable(true)
                     .build());
         }

--- a/tests/src/test/java/net/lapidist/colony/client/ui/MinimapActorTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/ui/MinimapActorTest.java
@@ -6,7 +6,6 @@ import net.lapidist.colony.client.systems.PlayerCameraSystem;
 import net.lapidist.colony.client.systems.network.MapLoadSystem;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.tests.GdxTestRunner;
 import net.lapidist.colony.client.core.io.TextureAtlasResourceLoader;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -39,7 +38,7 @@ public class MinimapActorTest {
                 .tileType("GRASS")
                 .passable(true)
                 .build();
-        state.tiles().put(new TilePos(0, 0), tile);
+        state.putTile(tile);
 
         World world = new World(new WorldConfigurationBuilder()
                 .with(new MapLoadSystem(state), new PlayerCameraSystem())
@@ -53,7 +52,7 @@ public class MinimapActorTest {
     @Test
     public void overlayRenderedAndCacheInvalidated() throws Exception {
         MapState state = new MapState();
-        state.tiles().put(new TilePos(0, 0), TileData.builder()
+        state.putTile(TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true)
                 .build());
 

--- a/tests/src/test/java/net/lapidist/colony/client/ui/MinimapCacheTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/ui/MinimapCacheTest.java
@@ -12,7 +12,6 @@ import net.lapidist.colony.components.maps.MapComponent;
 import net.lapidist.colony.components.maps.TileComponent;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.map.MapFactory;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
@@ -32,7 +31,7 @@ public class MinimapCacheTest {
 
     private World createWorld() {
         MapState state = new MapState();
-        state.tiles().put(new TilePos(0, 0), TileData.builder()
+        state.putTile(TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true)
                 .build());
         World world = new World(new WorldConfigurationBuilder().build());
@@ -90,9 +89,9 @@ public class MinimapCacheTest {
     @Test
     public void correctPixelColors() throws Exception {
         MapState state = new MapState();
-        state.tiles().put(new TilePos(0, 0), TileData.builder()
+        state.putTile(TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true).build());
-        state.tiles().put(new TilePos(1, 0), TileData.builder()
+        state.putTile(TileData.builder()
                 .x(1).y(0).tileType("DIRT").passable(true).build());
         World world = new World(new WorldConfigurationBuilder().build());
         MapFactory.create(world, state);

--- a/tests/src/test/java/net/lapidist/colony/tests/client/render/data/MapRenderDataBuilderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/render/data/MapRenderDataBuilderTest.java
@@ -10,7 +10,6 @@ import net.lapidist.colony.components.maps.MapComponent;
 import net.lapidist.colony.components.state.BuildingData;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -27,7 +26,7 @@ public class MapRenderDataBuilderTest {
     @Test
     public void convertsMapToRenderObjects() {
         MapState state = new MapState();
-        state.tiles().put(new TilePos(TILE_X, TILE_Y), TileData.builder()
+        state.putTile(TileData.builder()
                 .x(TILE_X).y(TILE_Y).tileType("GRASS").passable(true)
                 .resources(new net.lapidist.colony.components.state.ResourceData(WOOD, STONE, FOOD))
                 .build());
@@ -50,7 +49,7 @@ public class MapRenderDataBuilderTest {
     @Test
     public void updatesExistingRenderData() {
         MapState state = new MapState();
-        state.tiles().put(new TilePos(0, 0), TileData.builder()
+        state.putTile(TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true)
                 .build());
 

--- a/tests/src/test/java/net/lapidist/colony/tests/components/MapStateBuilderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/components/MapStateBuilderTest.java
@@ -4,6 +4,9 @@ import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.ResourceData;
 import org.junit.Test;
 
+import net.lapidist.colony.components.state.ChunkPos;
+import net.lapidist.colony.map.MapChunkData;
+
 import java.util.HashMap;
 import java.util.List;
 
@@ -27,5 +30,18 @@ public class MapStateBuilderTest {
         assertEquals("s", state.saveName());
         assertEquals("a", state.autosaveName());
         assertEquals("d", state.description());
+    }
+
+    @Test
+    public void builderRetainsChunks() {
+        MapChunkData chunk = new MapChunkData(0, 0);
+        HashMap<ChunkPos, MapChunkData> chunks = new HashMap<>();
+        chunks.put(new ChunkPos(0, 0), chunk);
+
+        MapState state = MapState.builder()
+                .chunks(chunks)
+                .build();
+
+        assertSame(chunk, state.chunks().get(new ChunkPos(0, 0)));
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/map/MapChunkDataTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/map/MapChunkDataTest.java
@@ -2,6 +2,7 @@ package net.lapidist.colony.tests.map;
 
 import net.lapidist.colony.map.MapChunkData;
 import net.lapidist.colony.components.state.TileData;
+import net.lapidist.colony.components.state.TilePos;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -34,5 +35,15 @@ public class MapChunkDataTest {
         MapChunkData a = new MapChunkData(SEED_TWO);
         MapChunkData b = new MapChunkData(SEED_TWO);
         assertEquals(a.getTile(SAMPLE_X, SAMPLE_Y).tileType(), b.getTile(SAMPLE_X, SAMPLE_Y).tileType());
+    }
+
+    @Test
+    public void retrievingTileAddsToMap() {
+        MapChunkData chunk = new MapChunkData(SEED_ONE);
+        assertFalse(chunk.isGenerated());
+        TileData tile = chunk.getTile(1, 2);
+        assertSame(tile, chunk.getTiles().get(new TilePos(1, 2)));
+        assertFalse(chunk.isGenerated());
+        assertEquals(1, chunk.getTiles().size());
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/map/MapUtilsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/map/MapUtilsTest.java
@@ -30,7 +30,7 @@ public class MapUtilsTest {
                 .tileType("GRASS")
                 .passable(true)
                 .build();
-        state.tiles().put(new TilePos(0, 0), tile);
+        state.putTile(tile);
 
         World world = new World(new WorldConfigurationBuilder()
                 .with(new MapLoadSystem(state))
@@ -53,7 +53,7 @@ public class MapUtilsTest {
                 .tileType("GRASS")
                 .passable(true)
                 .build();
-        state.tiles().put(new TilePos(1, 2), tile);
+        state.putTile(tile);
 
         World world = new World(new WorldConfigurationBuilder()
                 .with(new MapLoadSystem(state))

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationCameraTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationCameraTest.java
@@ -3,7 +3,6 @@ package net.lapidist.colony.tests.scenario;
 import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,7 +26,7 @@ public class GameSimulationCameraTest {
                 .tileType("GRASS")
                 .passable(true)
                 .build();
-        state.tiles().put(new TilePos(0, 0), tile);
+        state.putTile(tile);
 
         GameSimulation sim = new GameSimulation(state);
         float startX = sim.getCamera().getCamera().position.x;

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MapWorldBuilderConfigurationTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MapWorldBuilderConfigurationTest.java
@@ -20,7 +20,6 @@ import net.lapidist.colony.components.resources.PlayerResourceComponent;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.ResourceData;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.map.ProvidedMapStateProvider;
 import net.lapidist.colony.settings.KeyBindings;
 import net.lapidist.colony.tests.GdxTestRunner;
@@ -69,7 +68,7 @@ public class MapWorldBuilderConfigurationTest {
     @Test
     public void builderRegistersMapSystems() {
         MapState state = new MapState();
-        state.tiles().put(new TilePos(0, 0), TileData.builder()
+        state.putTile(TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true)
                 .build());
         Batch batch = mock(Batch.class);

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerChatCommandTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerChatCommandTest.java
@@ -2,7 +2,6 @@ package net.lapidist.colony.tests.server;
 
 import net.lapidist.colony.chat.ChatMessage;
 import net.lapidist.colony.client.network.GameClient;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.server.GameServerConfig;
 import net.lapidist.colony.server.events.TileSelectionEvent;
@@ -44,7 +43,7 @@ public class GameServerChatCommandTest {
         Thread.sleep(WAIT_MS);
         Events.update();
 
-        assertTrue(server.getMapState().tiles().get(new TilePos(0, 0)).selected());
+        assertTrue(server.getMapState().getTile(0, 0).selected());
         assertTrue(handled);
 
         client.stop();

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerHelperMethodsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerHelperMethodsTest.java
@@ -3,7 +3,6 @@ package net.lapidist.colony.tests.server;
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.server.GameServerConfig;
 import net.lapidist.colony.components.state.MapState;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.components.state.TileSelectionData;
 import net.lapidist.colony.io.Paths;
 import com.esotericsoftware.kryonet.Server;
@@ -62,6 +61,6 @@ public class GameServerHelperMethodsTest {
         Method dispatch = method(GameServer.class.getSuperclass(), "dispatch", Object.class);
         dispatch.invoke(server, new TileSelectionData(0, 0, true));
         MapState state = server.getMapState();
-        assertTrue(state.tiles().get(new TilePos(0, 0)).selected());
+        assertTrue(state.getTile(0, 0).selected());
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerSaveTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerSaveTest.java
@@ -94,17 +94,17 @@ public class GameServerSaveTest {
         GameServer first = new GameServer(cfg);
         first.start();
         TilePos pos = new TilePos(0, 0);
-        TileData modified = first.getMapState().tiles().get(pos)
+        TileData modified = first.getMapState().getTile(pos.x(), pos.y())
                 .toBuilder()
                 .selected(true)
                 .build();
-        first.getMapState().tiles().put(pos, modified);
+        first.getMapState().putTile(modified);
         GameStateIO.save(first.getMapState(), Paths.get().getAutosave("save-test"));
         first.stop();
 
         GameServer second = new GameServer(cfg);
         second.start();
-        boolean loaded = second.getMapState().tiles().get(new TilePos(0, 0)).selected();
+        boolean loaded = second.getMapState().getTile(0, 0).selected();
         second.stop();
 
         assertTrue(loaded);

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerSelectionTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerSelectionTest.java
@@ -2,7 +2,6 @@ package net.lapidist.colony.tests.server;
 
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.components.state.TileSelectionData;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.server.GameServerConfig;
 import net.lapidist.colony.events.Events;
@@ -45,7 +44,7 @@ public class GameServerSelectionTest {
         Thread.sleep(WAIT_MS);
         Events.update();
 
-        assertTrue(server.getMapState().tiles().get(new TilePos(0, 0)).selected());
+        assertTrue(server.getMapState().getTile(0, 0).selected());
         assertTrue(handled);
 
         client.stop();

--- a/tests/src/test/java/net/lapidist/colony/tests/server/NetworkServiceTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/NetworkServiceTest.java
@@ -7,7 +7,6 @@ import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.MapMetadata;
 import net.lapidist.colony.components.state.MapChunk;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.server.services.NetworkService;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -21,7 +20,7 @@ public class NetworkServiceTest {
         Server server = mock(Server.class);
         NetworkService service = new NetworkService(server, 1, 2);
         MapState state = new MapState();
-        state.tiles().put(new TilePos(0, 0), new TileData());
+        state.putTile(new TileData());
 
         service.start(state, o -> { });
 

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/BuildPlacementSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/BuildPlacementSystemTest.java
@@ -14,7 +14,6 @@ import net.lapidist.colony.client.systems.network.MapLoadSystem;
 import net.lapidist.colony.client.util.CameraUtils;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.settings.KeyAction;
 import net.lapidist.colony.settings.KeyBindings;
 import net.lapidist.colony.tests.GdxTestRunner;
@@ -69,7 +68,7 @@ public class BuildPlacementSystemTest {
         TileData tile = TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true)
                 .build();
-        state.tiles().put(new TilePos(0, 0), tile);
+        state.putTile(tile);
 
         GameClient client = mock(GameClient.class);
         KeyBindings keys = new KeyBindings();
@@ -99,7 +98,7 @@ public class BuildPlacementSystemTest {
     public void tapRemovesBuildingWhenEnabled() {
         MapState state = new MapState();
         state.buildings().add(new net.lapidist.colony.components.state.BuildingData(0, 0, "HOUSE"));
-        state.tiles().put(new TilePos(0, 0), TileData.builder()
+        state.putTile(TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true)
                 .build());
 

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/BuildPlacementWithSelectionSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/BuildPlacementWithSelectionSystemTest.java
@@ -13,7 +13,6 @@ import net.lapidist.colony.client.systems.network.MapLoadSystem;
 import net.lapidist.colony.client.util.CameraUtils;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.map.MapUtils;
 import net.lapidist.colony.settings.KeyBindings;
 import net.lapidist.colony.tests.GdxTestRunner;
@@ -32,7 +31,7 @@ public class BuildPlacementWithSelectionSystemTest {
         TileData tile = TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true)
                 .build();
-        state.tiles().put(new TilePos(0, 0), tile);
+        state.putTile(tile);
 
         GameClient client = mock(GameClient.class);
         KeyBindings keys = new KeyBindings();

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/BuildingUpdateSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/BuildingUpdateSystemTest.java
@@ -12,7 +12,6 @@ import net.lapidist.colony.components.maps.MapComponent;
 import net.lapidist.colony.components.entities.BuildingComponent;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.components.state.BuildingData;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
@@ -32,7 +31,7 @@ public class BuildingUpdateSystemTest {
                 .tileType("GRASS")
                 .passable(true)
                 .build();
-        state.tiles().put(new TilePos(0, 0), tile);
+        state.putTile(tile);
 
         GameClient client = new GameClient();
         World world = new World(new WorldConfigurationBuilder()

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/InputSystemGatherTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/InputSystemGatherTest.java
@@ -13,7 +13,6 @@ import net.lapidist.colony.client.util.CameraUtils;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.ResourceData;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,7 +35,7 @@ public class InputSystemGatherTest {
                 .passable(true)
                 .resources(res)
                 .build();
-        state.tiles().put(new TilePos(0, 0), tile);
+        state.putTile(tile);
 
         GameClient client = mock(GameClient.class);
         World world = new World(new WorldConfigurationBuilder()

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/InputSystemInitOrderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/InputSystemInitOrderTest.java
@@ -12,7 +12,6 @@ import net.lapidist.colony.client.systems.network.MapLoadSystem;
 import net.lapidist.colony.client.util.CameraUtils;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,7 +30,7 @@ public class InputSystemInitOrderTest {
                 .tileType("GRASS")
                 .passable(true)
                 .build();
-        state.tiles().put(new TilePos(0, 0), tile);
+        state.putTile(tile);
 
         GameClient client = mock(GameClient.class);
         World world = new World(new WorldConfigurationBuilder()

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/InputSystemResourceTypeTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/InputSystemResourceTypeTest.java
@@ -15,7 +15,6 @@ import net.lapidist.colony.client.util.CameraUtils;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.ResourceData;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.components.resources.ResourceType;
 import net.lapidist.colony.components.state.ResourceGatherRequestData;
 import net.lapidist.colony.settings.KeyAction;
@@ -35,7 +34,7 @@ public class InputSystemResourceTypeTest {
     public void gatherKeyUsesTileResourceType() {
         MapState state = new MapState();
         ResourceData res = new ResourceData(0, 2, 1);
-        state.tiles().put(new TilePos(0, 0), TileData.builder()
+        state.putTile(TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true)
                 .selected(true)
                 .resources(res)
@@ -75,7 +74,7 @@ public class InputSystemResourceTypeTest {
                 .passable(true)
                 .resources(res)
                 .build();
-        state.tiles().put(new TilePos(0, 0), tile);
+        state.putTile(tile);
 
         GameClient client = mock(GameClient.class);
         KeyBindings keys = new KeyBindings();

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/InputSystemSelectedTilesTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/InputSystemSelectedTilesTest.java
@@ -12,7 +12,6 @@ import net.lapidist.colony.client.systems.network.MapLoadSystem;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.ResourceData;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.settings.KeyAction;
 import net.lapidist.colony.settings.KeyBindings;
 import net.lapidist.colony.tests.GdxTestRunner;
@@ -31,12 +30,12 @@ public class InputSystemSelectedTilesTest {
     public void gatherKeyUsesSelectedTiles() {
         MapState state = new MapState();
         ResourceData res = new ResourceData(INITIAL_WOOD, 0, 0);
-        state.tiles().put(new TilePos(0, 0), TileData.builder()
+        state.putTile(TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true)
                 .selected(true)
                 .resources(res)
                 .build());
-        state.tiles().put(new TilePos(1, 0), TileData.builder()
+        state.putTile(TileData.builder()
                 .x(1).y(0).tileType("GRASS").passable(true)
                 .resources(res)
                 .build());

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/InputSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/InputSystemTest.java
@@ -17,7 +17,6 @@ import net.lapidist.colony.components.maps.MapComponent;
 import net.lapidist.colony.components.maps.TileComponent;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,7 +36,7 @@ public class InputSystemTest {
                 .tileType("GRASS")
                 .passable(true)
                 .build();
-        state.tiles().put(new TilePos(0, 0), tile);
+        state.putTile(tile);
 
         GameClient client = mock(GameClient.class);
         World world = new World(new WorldConfigurationBuilder()

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/MapInitSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/MapInitSystemTest.java
@@ -8,7 +8,6 @@ import net.lapidist.colony.client.systems.MapInitSystem;
 import net.lapidist.colony.components.maps.MapComponent;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.map.GeneratedMapStateProvider;
 import net.lapidist.colony.map.ProvidedMapStateProvider;
 import net.lapidist.colony.map.DefaultMapGenerator;
@@ -34,7 +33,7 @@ public class MapInitSystemTest {
                 .tileType("GRASS")
                 .passable(true)
                 .build();
-        state.tiles().put(new TilePos(0, 0), tile);
+        state.putTile(tile);
 
         World world = new World(new WorldConfigurationBuilder()
                 .with(new MapInitSystem(new ProvidedMapStateProvider(state)))
@@ -65,7 +64,7 @@ public class MapInitSystemTest {
     @Test
     public void mapFactoryCreatesLogicalComponents() {
         MapState state = new MapState();
-        state.tiles().put(new TilePos(0, 0), TileData.builder()
+        state.putTile(TileData.builder()
                 .x(0)
                 .y(0)
                 .tileType("GRASS")

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/MapLoadSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/MapLoadSystemTest.java
@@ -10,7 +10,6 @@ import net.lapidist.colony.components.maps.MapComponent;
 import net.lapidist.colony.components.state.BuildingData;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -27,7 +26,7 @@ public class MapLoadSystemTest {
                 .tileType("GRASS")
                 .passable(true)
                 .build();
-        state.tiles().put(new TilePos(0, 0), tile);
+        state.putTile(tile);
 
         BuildingData building = new BuildingData(1, 1, "HOUSE");
         state.buildings().add(building);

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/MapRenderDataSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/MapRenderDataSystemTest.java
@@ -6,7 +6,6 @@ import net.lapidist.colony.client.systems.MapInitSystem;
 import net.lapidist.colony.client.systems.MapRenderDataSystem;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.components.maps.TileComponent;
 import net.lapidist.colony.map.ProvidedMapStateProvider;
 import org.junit.Test;
@@ -29,7 +28,7 @@ public class MapRenderDataSystemTest {
     @Test
     public void populatesRenderDataFromMap() {
         MapState state = new MapState();
-        state.tiles().put(new TilePos(0, 0), TileData.builder()
+        state.putTile(TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true)
                 .build());
 
@@ -50,10 +49,10 @@ public class MapRenderDataSystemTest {
     @Test
     public void tracksSelectedTileIndices() {
         MapState state = new MapState();
-        state.tiles().put(new TilePos(0, 0), TileData.builder()
+        state.putTile(TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true).selected(true)
                 .build());
-        state.tiles().put(new TilePos(1, 0), TileData.builder()
+        state.putTile(TileData.builder()
                 .x(1).y(0).tileType("GRASS").passable(true)
                 .build());
 
@@ -73,7 +72,7 @@ public class MapRenderDataSystemTest {
     @Test
     public void updatesWhenMapChanges() {
         MapState state = new MapState();
-        state.tiles().put(new TilePos(0, 0), TileData.builder()
+        state.putTile(TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true)
                 .build());
         World world = new World(new WorldConfigurationBuilder()
@@ -105,10 +104,10 @@ public class MapRenderDataSystemTest {
     @Test
     public void onlyChangedTilesAreReplaced() {
         MapState state = new MapState();
-        state.tiles().put(new TilePos(0, 0), TileData.builder()
+        state.putTile(TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true)
                 .build());
-        state.tiles().put(new TilePos(1, 0), TileData.builder()
+        state.putTile(TileData.builder()
                 .x(1).y(0).tileType("GRASS").passable(true)
                 .build());
 
@@ -145,7 +144,7 @@ public class MapRenderDataSystemTest {
     @Test
     public void exposesUpdatedIndices() {
         MapState state = new MapState();
-        state.tiles().put(new TilePos(0, 0), TileData.builder()
+        state.putTile(TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true)
                 .build());
 

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/MapRenderSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/MapRenderSystemTest.java
@@ -10,7 +10,6 @@ import net.lapidist.colony.client.systems.MapRenderDataSystem;
 import net.lapidist.colony.client.render.MapRenderData;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.map.ProvidedMapStateProvider;
 import net.lapidist.colony.tests.GdxTestRunner;
 import net.lapidist.colony.client.renderers.SpriteBatchMapRenderer;
@@ -59,7 +58,7 @@ public class MapRenderSystemTest {
                 .tileType("GRASS")
                 .passable(true)
                 .build();
-        state.tiles().put(new TilePos(0, 0), tile);
+        state.putTile(tile);
 
         MapRenderSystem renderSystem = new MapRenderSystem();
 
@@ -118,7 +117,7 @@ public class MapRenderSystemTest {
                 .tileType("GRASS")
                 .passable(true)
                 .build();
-        state.tiles().put(new TilePos(0, 0), tile);
+        state.putTile(tile);
 
         MapRenderSystem renderSystem = new MapRenderSystem();
         MapRenderDataSystem dataSystem = new MapRenderDataSystem();
@@ -186,7 +185,7 @@ public class MapRenderSystemTest {
         Mockito.doNothing().when(gl).glDeleteProgram(Mockito.anyInt());
 
         MapState state = new MapState();
-        state.tiles().put(new TilePos(0, 0), TileData.builder()
+        state.putTile(TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true)
                 .build());
 

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/ResourceUpdateSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/ResourceUpdateSystemTest.java
@@ -16,7 +16,6 @@ import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.ResourceData;
 import net.lapidist.colony.components.state.ResourceUpdateData;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,7 +40,7 @@ public class ResourceUpdateSystemTest {
                 .passable(true)
                 .resources(res)
                 .build();
-        state.tiles().put(new TilePos(0, 0), tile);
+        state.putTile(tile);
 
         GameClient client = new GameClient();
         World world = new World(new WorldConfigurationBuilder()

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/SelectionSystemSelectedTilesTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/SelectionSystemSelectedTilesTest.java
@@ -12,7 +12,6 @@ import net.lapidist.colony.client.systems.network.MapLoadSystem;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.ResourceData;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.settings.KeyAction;
 import net.lapidist.colony.settings.KeyBindings;
 import net.lapidist.colony.tests.GdxTestRunner;
@@ -31,12 +30,12 @@ public class SelectionSystemSelectedTilesTest {
     public void gatherKeyUsesSelectedTiles() {
         MapState state = new MapState();
         ResourceData res = new ResourceData(INITIAL_WOOD, 0, 0);
-        state.tiles().put(new TilePos(0, 0), TileData.builder()
+        state.putTile(TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true)
                 .selected(true)
                 .resources(res)
                 .build());
-        state.tiles().put(new TilePos(1, 0), TileData.builder()
+        state.putTile(TileData.builder()
                 .x(1).y(0).tileType("GRASS").passable(true)
                 .resources(res)
                 .build());

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/TileSelectionHandlerSelectedTilesTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/TileSelectionHandlerSelectedTilesTest.java
@@ -15,7 +15,6 @@ import net.lapidist.colony.components.maps.MapComponent;
 import net.lapidist.colony.components.maps.TileComponent;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.map.MapUtils;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
@@ -30,7 +29,7 @@ public class TileSelectionHandlerSelectedTilesTest {
     @Test
     public void maintainsSelectedTileList() {
         MapState state = new MapState();
-        state.tiles().put(new TilePos(0, 0), TileData.builder()
+        state.putTile(TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true)
                 .build());
 

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/TileUpdateSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/TileUpdateSystemTest.java
@@ -13,7 +13,6 @@ import net.lapidist.colony.components.maps.MapComponent;
 import net.lapidist.colony.components.maps.TileComponent;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.components.state.TileSelectionData;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
@@ -33,7 +32,7 @@ public class TileUpdateSystemTest {
                 .tileType("GRASS")
                 .passable(true)
                 .build();
-        state.tiles().put(new TilePos(0, 0), tile);
+        state.putTile(tile);
 
         GameClient client = new GameClient();
         World world = new World(new WorldConfigurationBuilder()


### PR DESCRIPTION
## Summary
- update tests to use lazy chunk tiles
- verify chunk generation behavior in MapChunkData

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test check`

------
https://chatgpt.com/codex/tasks/task_e_684c7acccc5883288ccab5e10f535bf0