### PR TITLE
feat(server): add chunk request support

### DIFF
--- a/core/src/main/java/net/lapidist/colony/components/state/MapChunkRequest.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/MapChunkRequest.java
@@ -1,0 +1,12 @@
+package net.lapidist.colony.components.state;
+
+import net.lapidist.colony.serialization.KryoType;
+
+/**
+ * Request message sent by clients to retrieve a map chunk.
+ *
+ * @param chunkX chunk x coordinate
+ * @param chunkY chunk y coordinate
+ */
+@KryoType
+public record MapChunkRequest(int chunkX, int chunkY) { }

--- a/core/src/main/java/net/lapidist/colony/serialization/SerializationRegistrar.java
+++ b/core/src/main/java/net/lapidist/colony/serialization/SerializationRegistrar.java
@@ -14,6 +14,7 @@ import net.lapidist.colony.components.state.ResourceGatherRequestData;
 import net.lapidist.colony.components.state.ResourceUpdateData;
 import net.lapidist.colony.components.state.MapMetadata;
 import net.lapidist.colony.components.state.MapChunk;
+import net.lapidist.colony.components.state.MapChunkRequest;
 import net.lapidist.colony.save.SaveData;
 
 /**
@@ -54,7 +55,7 @@ public final class SerializationRegistrar {
     }
 
     /** Precomputed registration hash for quick access. */
-    public static final int REGISTRATION_HASH = 1025588104;
+    public static final int REGISTRATION_HASH = -522251697;
 
     private static final Class<?>[] REGISTERED_TYPES = {
             TileData.class,
@@ -69,6 +70,7 @@ public final class SerializationRegistrar {
             ResourceUpdateData.class,
             MapMetadata.class,
             MapChunk.class,
+            MapChunkRequest.class,
             net.lapidist.colony.components.state.ChunkPos.class,
             net.lapidist.colony.map.MapChunkData.class,
             TilePos.class,

--- a/server/src/main/java/net/lapidist/colony/server/GameServer.java
+++ b/server/src/main/java/net/lapidist/colony/server/GameServer.java
@@ -16,6 +16,7 @@ import net.lapidist.colony.server.handlers.BuildingPlacementRequestHandler;
 import net.lapidist.colony.server.handlers.BuildingRemovalRequestHandler;
 import net.lapidist.colony.server.handlers.ChatMessageHandler;
 import net.lapidist.colony.server.handlers.ResourceGatherRequestHandler;
+import net.lapidist.colony.server.handlers.MapChunkRequestHandler;
 import net.lapidist.colony.server.commands.CommandBus;
 import net.lapidist.colony.server.commands.CommandHandler;
 import net.lapidist.colony.server.commands.TileSelectionCommandHandler;
@@ -132,7 +133,8 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
                     new BuildingPlacementRequestHandler(commandBus),
                     new BuildingRemovalRequestHandler(commandBus),
                     new ChatMessageHandler(networkService, commandBus),
-                    new ResourceGatherRequestHandler(commandBus)
+                    new ResourceGatherRequestHandler(commandBus),
+                    new MapChunkRequestHandler(() -> mapState, networkService)
             );
         }
         registerHandlers(handlers);

--- a/server/src/main/java/net/lapidist/colony/server/handlers/MapChunkRequestHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/handlers/MapChunkRequestHandler.java
@@ -1,0 +1,29 @@
+package net.lapidist.colony.server.handlers;
+
+import net.lapidist.colony.components.state.MapChunkRequest;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.network.AbstractMessageHandler;
+import net.lapidist.colony.server.services.NetworkService;
+
+import java.util.function.Supplier;
+
+/** Handles incoming {@link MapChunkRequest} messages by sending the requested chunk. */
+public final class MapChunkRequestHandler extends AbstractMessageHandler<MapChunkRequest> {
+    private final Supplier<MapState> stateSupplier;
+    private final NetworkService networkService;
+
+    public MapChunkRequestHandler(final Supplier<MapState> stateSupplierToUse,
+                                  final NetworkService networkServiceToUse) {
+        super(MapChunkRequest.class);
+        this.stateSupplier = stateSupplierToUse;
+        this.networkService = networkServiceToUse;
+    }
+
+    @Override
+    public void handle(final MapChunkRequest message) {
+        MapState state = stateSupplier.get();
+        if (state != null) {
+            networkService.broadcastChunk(state, message.chunkX(), message.chunkY());
+        }
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/server/services/MapService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/MapService.java
@@ -4,6 +4,7 @@ import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.io.Paths;
 import net.lapidist.colony.map.MapGenerator;
+import net.lapidist.colony.map.MapChunkData;
 import net.lapidist.colony.server.io.GameStateIO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,9 +48,10 @@ public final class MapService {
     }
 
     private MapState generateMap() {
-        return mapGenerator.generate(
-                GameConstants.MAP_WIDTH,
-                GameConstants.MAP_HEIGHT
-        );
+        int width = (int) Math.ceil(GameConstants.MAP_WIDTH / (double) MapChunkData.CHUNK_SIZE)
+                * MapChunkData.CHUNK_SIZE;
+        int height = (int) Math.ceil(GameConstants.MAP_HEIGHT / (double) MapChunkData.CHUNK_SIZE)
+                * MapChunkData.CHUNK_SIZE;
+        return mapGenerator.generate(width, height);
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/server/NetworkServiceTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/NetworkServiceTest.java
@@ -48,6 +48,18 @@ public class NetworkServiceTest {
     }
 
     @Test
+    public void broadcastChunkSendsData() {
+        Server server = mock(Server.class);
+        NetworkService service = new NetworkService(server, 1, 2);
+        MapState state = new MapState();
+        state.putTile(new TileData());
+
+        service.broadcastChunk(state, 0, 0);
+
+        verify(server).sendToAllTCP(isA(MapChunk.class));
+    }
+
+    @Test
     public void stopStopsServer() {
         Server server = mock(Server.class);
         NetworkService service = new NetworkService(server, 1, 2);


### PR DESCRIPTION
## Summary
- support requesting chunks via `MapChunkRequest`
- send map data chunk-wise
- broadcast generated chunks
- handle chunk requests on the server
- verify chunk broadcast in tests

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684c85b5965c83289a45238a08f9f9c6