### PR TITLE
feat: add controllable player character

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -15,6 +15,7 @@ import net.lapidist.colony.client.systems.SelectionSystem;
 import net.lapidist.colony.client.systems.BuildPlacementSystem;
 import net.lapidist.colony.client.systems.MapRenderSystem;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
+import net.lapidist.colony.client.systems.PlayerMovementSystem;
 import net.lapidist.colony.client.systems.UISystem;
 import net.lapidist.colony.client.systems.network.TileUpdateSystem;
 import net.lapidist.colony.client.systems.network.BuildingUpdateSystem;
@@ -113,6 +114,7 @@ public final class MapWorldBuilder {
         cameraInputSystem.addProcessor(stage);
         SelectionSystem selectionSystem = new SelectionSystem(client, keyBindings);
         BuildPlacementSystem buildPlacementSystem = new BuildPlacementSystem(client, keyBindings);
+        PlayerMovementSystem movementSystem = new PlayerMovementSystem(keyBindings);
 
         WorldConfigurationBuilder builder = new WorldConfigurationBuilder()
                 .with(
@@ -122,6 +124,7 @@ public final class MapWorldBuilder {
                         selectionSystem,
                         buildPlacementSystem,
                         new PlayerInitSystem(playerResources),
+                        movementSystem,
                         new TileUpdateSystem(client),
                         new BuildingUpdateSystem(client),
                         new ResourceUpdateSystem(client),

--- a/client/src/main/java/net/lapidist/colony/client/systems/CameraInputSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/CameraInputSystem.java
@@ -9,6 +9,7 @@ import net.lapidist.colony.client.systems.input.GestureInputHandler;
 import net.lapidist.colony.client.systems.input.KeyboardInputHandler;
 import net.lapidist.colony.client.systems.input.ScrollInputProcessor;
 import net.lapidist.colony.settings.KeyBindings;
+import net.lapidist.colony.settings.KeyAction;
 
 /**
  * Handles camera input via gestures and keyboard.
@@ -47,6 +48,9 @@ public final class CameraInputSystem extends BaseSystem {
 
     @Override
     protected void processSystem() {
+        if (Gdx.input.isKeyJustPressed(keyBindings.getKey(KeyAction.TOGGLE_CAMERA))) {
+            cameraSystem.toggleMode();
+        }
         keyboardHandler.handleKeyboardInput(world.getDelta());
         keyboardHandler.clampCameraPosition();
         cameraSystem.getCamera().update();

--- a/client/src/main/java/net/lapidist/colony/client/systems/PlayerInitSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/PlayerInitSystem.java
@@ -4,6 +4,8 @@ import com.artemis.BaseSystem;
 import com.artemis.Entity;
 import net.lapidist.colony.components.resources.PlayerResourceComponent;
 import net.lapidist.colony.components.state.ResourceData;
+import net.lapidist.colony.components.entities.PlayerComponent;
+import net.lapidist.colony.client.util.CameraUtils;
 
 /** Creates a player entity with resource storage. */
 public final class PlayerInitSystem extends BaseSystem {
@@ -26,7 +28,11 @@ public final class PlayerInitSystem extends BaseSystem {
             pr.setWood(initialResources.wood());
             pr.setStone(initialResources.stone());
             pr.setFood(initialResources.food());
-            player.edit().add(pr);
+            PlayerComponent pc = new PlayerComponent();
+            var pos = CameraUtils.getWorldCenter();
+            pc.setX(pos.x);
+            pc.setY(pos.y);
+            player.edit().add(pr).add(pc);
             created = true;
         }
     }

--- a/client/src/main/java/net/lapidist/colony/client/systems/PlayerMovementSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/PlayerMovementSystem.java
@@ -1,0 +1,66 @@
+package net.lapidist.colony.client.systems;
+
+import com.artemis.BaseSystem;
+import com.artemis.ComponentMapper;
+import com.artemis.Entity;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.math.MathUtils;
+import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.components.entities.PlayerComponent;
+import net.lapidist.colony.settings.KeyAction;
+import net.lapidist.colony.settings.KeyBindings;
+
+/** Handles player movement when player camera mode is active. */
+public final class PlayerMovementSystem extends BaseSystem {
+    private static final float SPEED = 400f; // units per second
+
+    private final KeyBindings keyBindings;
+    private PlayerCameraSystem cameraSystem;
+    private ComponentMapper<PlayerComponent> playerMapper;
+    private Entity player;
+
+    public PlayerMovementSystem(final KeyBindings bindings) {
+        this.keyBindings = bindings;
+    }
+
+    @Override
+    public void initialize() {
+        cameraSystem = world.getSystem(PlayerCameraSystem.class);
+        playerMapper = world.getMapper(PlayerComponent.class);
+        var players = world.getAspectSubscriptionManager()
+                .get(com.artemis.Aspect.all(PlayerComponent.class))
+                .getEntities();
+        if (players.size() > 0) {
+            player = world.getEntity(players.get(0));
+        }
+    }
+
+    @Override
+    protected void processSystem() {
+        if (!cameraSystem.isPlayerMode() || player == null) {
+            return;
+        }
+        PlayerComponent pc = playerMapper.get(player);
+        float move = SPEED * world.getDelta();
+        if (Gdx.input.isKeyPressed(keyBindings.getKey(KeyAction.MOVE_UP))) {
+            pc.setY(pc.getY() + move);
+        }
+        if (Gdx.input.isKeyPressed(keyBindings.getKey(KeyAction.MOVE_DOWN))) {
+            pc.setY(pc.getY() - move);
+        }
+        if (Gdx.input.isKeyPressed(keyBindings.getKey(KeyAction.MOVE_LEFT))) {
+            pc.setX(pc.getX() - move);
+        }
+        if (Gdx.input.isKeyPressed(keyBindings.getKey(KeyAction.MOVE_RIGHT))) {
+            pc.setX(pc.getX() + move);
+        }
+        clampPosition(pc);
+    }
+
+    private void clampPosition(final PlayerComponent pc) {
+        float maxX = GameConstants.MAP_WIDTH * GameConstants.TILE_SIZE;
+        float maxY = GameConstants.MAP_HEIGHT * GameConstants.TILE_SIZE;
+        pc.setX(MathUtils.clamp(pc.getX(), 0, maxX));
+        pc.setY(MathUtils.clamp(pc.getY(), 0, maxY));
+    }
+}

--- a/client/src/main/java/net/lapidist/colony/client/systems/input/GestureInputHandler.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/input/GestureInputHandler.java
@@ -10,7 +10,6 @@ public final class GestureInputHandler {
 
     private static final float ZOOM_SPEED = 0.02f;
     private static final float MIN_ZOOM = 0.5f;
-    private static final float MAX_ZOOM = 2f;
 
     private final PlayerCameraSystem cameraSystem;
 
@@ -21,7 +20,7 @@ public final class GestureInputHandler {
     public boolean scrolled(final float amountX, final float amountY) {
         var cam = (com.badlogic.gdx.graphics.OrthographicCamera) cameraSystem.getCamera();
         final float zoom = cam.zoom + amountY * ZOOM_SPEED;
-        cam.zoom = MathUtils.clamp(zoom, MIN_ZOOM, MAX_ZOOM);
+        cam.zoom = MathUtils.clamp(zoom, MIN_ZOOM, cameraSystem.getMaxZoom());
         cam.update();
         return true;
     }
@@ -41,7 +40,7 @@ public final class GestureInputHandler {
         var cam = (com.badlogic.gdx.graphics.OrthographicCamera) cameraSystem.getCamera();
         final float ratio = initialDistance / distance;
         final float zoom = cam.zoom * ratio;
-        cam.zoom = MathUtils.clamp(zoom, MIN_ZOOM, MAX_ZOOM);
+        cam.zoom = MathUtils.clamp(zoom, MIN_ZOOM, cameraSystem.getMaxZoom());
         cam.update();
         return true;
     }

--- a/client/src/main/java/net/lapidist/colony/client/systems/input/KeyboardInputHandler.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/input/KeyboardInputHandler.java
@@ -29,6 +29,9 @@ public final class KeyboardInputHandler {
     }
 
     public void handleKeyboardInput(final float deltaTime) {
+        if (cameraSystem.isPlayerMode()) {
+            return;
+        }
         final float moveAmount = CAMERA_SPEED * deltaTime;
         final Vector3 position = cameraSystem.getCamera().position;
 
@@ -47,6 +50,9 @@ public final class KeyboardInputHandler {
     }
 
     public void clampCameraPosition() {
+        if (cameraSystem.isPlayerMode()) {
+            return;
+        }
         final Vector3 position = cameraSystem.getCamera().position;
         final float mapWidth = GameConstants.MAP_WIDTH * GameConstants.TILE_SIZE;
         final float mapHeight = GameConstants.MAP_HEIGHT * GameConstants.TILE_SIZE;

--- a/core/src/main/java/net/lapidist/colony/components/entities/PlayerComponent.java
+++ b/core/src/main/java/net/lapidist/colony/components/entities/PlayerComponent.java
@@ -1,0 +1,25 @@
+package net.lapidist.colony.components.entities;
+
+import com.artemis.Component;
+
+/** Component holding the player's world position. */
+public final class PlayerComponent extends Component {
+    private float x;
+    private float y;
+
+    public float getX() {
+        return x;
+    }
+
+    public void setX(final float xToSet) {
+        this.x = xToSet;
+    }
+
+    public float getY() {
+        return y;
+    }
+
+    public void setY(final float yToSet) {
+        this.y = yToSet;
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/settings/KeyAction.java
+++ b/core/src/main/java/net/lapidist/colony/settings/KeyAction.java
@@ -12,7 +12,8 @@ public enum KeyAction {
     BUILD("build"),
     REMOVE("remove"),
     CHAT("chat"),
-    MINIMAP("minimap");
+    MINIMAP("minimap"),
+    TOGGLE_CAMERA("toggleCamera");
 
     private final String i18nKey;
 

--- a/core/src/main/java/net/lapidist/colony/settings/KeyBindings.java
+++ b/core/src/main/java/net/lapidist/colony/settings/KeyBindings.java
@@ -21,7 +21,8 @@ public final class KeyBindings {
             KeyAction.BUILD, Input.Keys.B,
             KeyAction.REMOVE, Input.Keys.R,
             KeyAction.CHAT, Input.Keys.T,
-            KeyAction.MINIMAP, Input.Keys.M
+            KeyAction.MINIMAP, Input.Keys.M,
+            KeyAction.TOGGLE_CAMERA, Input.Keys.F
     );
 
     private final EnumMap<KeyAction, Integer> bindings = new EnumMap<>(KeyAction.class);

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -32,6 +32,7 @@ keybind.build=Build
 keybind.remove=Remove
 keybind.chat=Chat
 keybind.minimap=Minimap
+keybind.toggleCamera=Toggle Camera
 common.reset=Reset
 ui.resources=Resources
 building.house=House

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -31,6 +31,7 @@ keybind.build=Bauen
 keybind.remove=Entfernen
 keybind.chat=Chat
 keybind.minimap=Minikarte
+keybind.toggleCamera=Kamera Umschalten
 common.reset=Zurücksetzen
 ui.resources=Rohstoffe
 building.house=Haus

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -31,6 +31,7 @@ keybind.build=Construir
 keybind.remove=Eliminar
 keybind.chat=Chat
 keybind.minimap=Minimapa
+keybind.toggleCamera=Cambiar Cámara
 common.reset=Restablecer
 ui.resources=Recursos
 building.house=Casa

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -31,6 +31,7 @@ keybind.build=Construire
 keybind.remove=Supprimer
 keybind.chat=Chat
 keybind.minimap=Mini-carte
+keybind.toggleCamera=Basculer Caméra
 common.reset=Réinitialiser
 ui.resources=Ressources
 building.house=Maison

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -14,6 +14,7 @@ This page lists the default keyboard bindings and how to customize them in-game.
 | Build | **B** | Toggle building placement mode |
 | Chat | **T** | Open the chat input box |
 | Toggle Minimap | **M** | Show or hide the minimap |
+| Toggle Camera | **F** | Switch between map overview and player camera |
 
 The defaults are defined in [`KeyBindings.java`](../core/src/main/java/net/lapidist/colony/settings/KeyBindings.java).
 

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulation.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulation.java
@@ -51,6 +51,7 @@ public final class GameSimulation {
                         new SelectionSystem(client, keys),
                         new BuildPlacementSystem(client, keys),
                         new net.lapidist.colony.client.systems.PlayerInitSystem(),
+                        new net.lapidist.colony.client.systems.PlayerMovementSystem(keys),
                         new TileUpdateSystem(client),
                         new BuildingUpdateSystem(client),
                         new ResourceUpdateSystem(client)

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MapWorldBuilderConfigurationTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MapWorldBuilderConfigurationTest.java
@@ -12,6 +12,7 @@ import net.lapidist.colony.client.systems.BuildPlacementSystem;
 import net.lapidist.colony.client.systems.CameraInputSystem;
 import net.lapidist.colony.client.systems.MapInitSystem;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
+import net.lapidist.colony.client.systems.PlayerMovementSystem;
 import net.lapidist.colony.client.systems.SelectionSystem;
 import net.lapidist.colony.client.systems.PlayerInitSystem;
 import net.lapidist.colony.client.systems.MapRenderSystem;
@@ -56,6 +57,7 @@ public class MapWorldBuilderConfigurationTest {
             assertNotNull(world.getSystem(CameraInputSystem.class));
             assertNotNull(world.getSystem(SelectionSystem.class));
             assertNotNull(world.getSystem(BuildPlacementSystem.class));
+            assertNotNull(world.getSystem(PlayerMovementSystem.class));
             assertNotNull(world.getSystem(PlayerInitSystem.class));
             assertNotNull(world.getSystem(MapRenderSystem.class));
             assertNull(world.getSystem(MapInitSystem.class));
@@ -87,6 +89,7 @@ public class MapWorldBuilderConfigurationTest {
 
             assertNotNull(world.getSystem(MapInitSystem.class));
             assertNotNull(world.getSystem(PlayerCameraSystem.class));
+            assertNotNull(world.getSystem(PlayerMovementSystem.class));
             assertNotNull(world.getSystem(MapRenderDataSystem.class));
             assertEquals(1, world.getAspectSubscriptionManager()
                     .get(Aspect.all(PlayerResourceComponent.class))

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/PlayerCameraFollowTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/PlayerCameraFollowTest.java
@@ -1,0 +1,49 @@
+package net.lapidist.colony.tests.systems;
+
+import com.artemis.Aspect;
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import net.lapidist.colony.client.systems.PlayerCameraSystem;
+import net.lapidist.colony.client.systems.PlayerInitSystem;
+import net.lapidist.colony.client.systems.PlayerMovementSystem;
+import net.lapidist.colony.components.entities.PlayerComponent;
+import net.lapidist.colony.settings.KeyBindings;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+@RunWith(GdxTestRunner.class)
+public class PlayerCameraFollowTest {
+    @Test
+    public void cameraFollowsPlayerInPlayerMode() {
+        KeyBindings keys = new KeyBindings();
+        World world = new World(new WorldConfigurationBuilder()
+                .with(new PlayerCameraSystem(), new PlayerInitSystem(), new PlayerMovementSystem(keys))
+                .build());
+        world.process();
+        world.setDelta(1f);
+        PlayerCameraSystem camera = world.getSystem(PlayerCameraSystem.class);
+        camera.toggleMode();
+
+        int id = world.getAspectSubscriptionManager()
+                .get(Aspect.all(PlayerComponent.class))
+                .getEntities().get(0);
+        PlayerComponent pc = world.getMapper(PlayerComponent.class).get(world.getEntity(id));
+        final float deltaX = 10f;
+        final float deltaY = 5f;
+        pc.setX(pc.getX() + deltaX);
+        pc.setY(pc.getY() + deltaY);
+
+        world.process();
+        world.setDelta(1f);
+        world.process();
+        world.setDelta(1f);
+        world.process();
+
+        final float epsilon = 0.001f;
+        assertEquals(pc.getX(), camera.getCamera().position.x, epsilon);
+        assertEquals(pc.getY(), camera.getCamera().position.y, epsilon);
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/PlayerMovementSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/PlayerMovementSystemTest.java
@@ -1,0 +1,32 @@
+package net.lapidist.colony.tests.systems;
+
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import net.lapidist.colony.client.systems.PlayerCameraSystem;
+import net.lapidist.colony.client.systems.PlayerInitSystem;
+import net.lapidist.colony.client.systems.PlayerMovementSystem;
+import net.lapidist.colony.settings.KeyBindings;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+@RunWith(GdxTestRunner.class)
+public class PlayerMovementSystemTest {
+    @Test
+    public void initializesWithPlayerEntity() throws Exception {
+        KeyBindings keys = new KeyBindings();
+        PlayerCameraSystem camera = new PlayerCameraSystem();
+        PlayerMovementSystem movement = new PlayerMovementSystem(keys);
+        World world = new World(new WorldConfigurationBuilder()
+                .with(camera, new PlayerInitSystem(), movement)
+                .build());
+        world.process();
+
+        int count = world.getAspectSubscriptionManager()
+                .get(com.artemis.Aspect.all(net.lapidist.colony.components.entities.PlayerComponent.class))
+                .getEntities().size();
+        assertEquals(1, count);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `PlayerComponent` to track player location
- add `PlayerMovementSystem` for WASD control
- follow player in `PlayerCameraSystem`
- toggle between map overview and player cameras
- restrict zoom in player mode
- document new controls and update translations
- extend tests for player systems

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684c852ad3d88328b9395827064c9713