### PR TITLE
fix: prevent map screen resets during chunk loading

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
+++ b/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
@@ -179,6 +179,10 @@ public final class GameClient extends AbstractMessageEndpoint {
                 if (loadProgressListener != null) {
                     loadProgressListener.accept(1f);
                 }
+                // Switch to incremental chunk handling after the initial load
+                tileBuffer = null;
+                mapBuilder = null;
+                readyCallback = null;
             }
             return;
         }


### PR DESCRIPTION
## Summary
- stop repeated map screen resets caused by multiple chunk responses

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c9bcc12b08328a4202baa0fc6eeff