### PR TITLE
feat: persist camera position in saves

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/MapScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapScreen.java
@@ -27,7 +27,8 @@ public final class MapScreen implements Screen {
         world = MapWorldBuilder.build(
                 MapWorldBuilder.builder(state, client, stage, colony.getSettings().getKeyBindings()),
                 null,
-                colony.getSettings()
+                colony.getSettings(),
+                state.cameraPos()
         );
         MapUi ui = MapUiBuilder.build(stage, world, client, colony);
         minimapActor = ui.getMinimapActor();

--- a/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -66,7 +66,7 @@ public final class MapWorldBuilder {
             final KeyBindings keyBindings,
             final ResourceData playerResources
     ) {
-        return createBuilder(client, stage, keyBindings, null, playerResources, null);
+        return createBuilder(client, stage, keyBindings, null, playerResources, null, null);
     }
 
     /**
@@ -84,7 +84,7 @@ public final class MapWorldBuilder {
             final Stage stage,
             final KeyBindings keyBindings
     ) {
-        return createBuilder(client, stage, keyBindings, provider, new ResourceData(), null);
+        return createBuilder(client, stage, keyBindings, provider, new ResourceData(), null, null);
     }
 
     /**
@@ -102,7 +102,8 @@ public final class MapWorldBuilder {
                 keyBindings,
                 new ProvidedMapStateProvider(state),
                 state.playerResources(),
-                state.playerPos()
+                state.playerPos(),
+                state.cameraPos()
         );
     }
 
@@ -112,7 +113,8 @@ public final class MapWorldBuilder {
             final KeyBindings keyBindings,
             final MapStateProvider provider,
             final ResourceData playerResources,
-            final PlayerPosition playerPos
+            final PlayerPosition playerPos,
+            final net.lapidist.colony.components.state.CameraPosition cameraPos
     ) {
         CameraInputSystem cameraInputSystem = new CameraInputSystem(keyBindings);
         cameraInputSystem.addProcessor(stage);
@@ -157,7 +159,8 @@ public final class MapWorldBuilder {
     public static World build(
             final WorldConfigurationBuilder builder,
             final MapRendererFactory factory,
-            final Settings settings
+            final Settings settings,
+            final net.lapidist.colony.components.state.CameraPosition cameraPos
     ) {
         MapRendererFactory actualFactory = factory;
         if (actualFactory == null) {
@@ -171,6 +174,11 @@ public final class MapWorldBuilder {
             MapRenderer renderer = actualFactory.create(world);
             renderSystem.setMapRenderer(renderer);
             renderSystem.setCameraProvider(world.getSystem(PlayerCameraSystem.class));
+        }
+        PlayerCameraSystem cameraSystem = world.getSystem(PlayerCameraSystem.class);
+        if (cameraSystem != null && cameraPos != null) {
+            cameraSystem.getCamera().position.set(cameraPos.x(), cameraPos.y(), 0);
+            cameraSystem.getCamera().update();
         }
         Events.init(world.getSystem(EventSystem.class));
         return world;

--- a/core/src/main/java/net/lapidist/colony/components/state/CameraPosition.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/CameraPosition.java
@@ -1,0 +1,13 @@
+package net.lapidist.colony.components.state;
+
+import net.lapidist.colony.serialization.KryoType;
+
+/**
+ * Camera position in world coordinates.
+ *
+ * @param x camera X coordinate
+ * @param y camera Y coordinate
+ */
+@KryoType
+public record CameraPosition(float x, float y) {
+}

--- a/core/src/main/java/net/lapidist/colony/components/state/MapState.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/MapState.java
@@ -22,7 +22,8 @@ public record MapState(
         Map<ChunkPos, MapChunkData> chunks,
         List<BuildingData> buildings,
         ResourceData playerResources,
-        PlayerPosition playerPos
+        PlayerPosition playerPos,
+        CameraPosition cameraPos
 ) {
     public static final int CURRENT_VERSION = SaveVersion.CURRENT.number();
 
@@ -36,7 +37,8 @@ public record MapState(
                 new HashMap<>(),
                 new ArrayList<>(),
                 new ResourceData(),
-                new PlayerPosition(GameConstants.MAP_WIDTH / 2, GameConstants.MAP_HEIGHT / 2)
+                new PlayerPosition(GameConstants.MAP_WIDTH / 2, GameConstants.MAP_HEIGHT / 2),
+                new CameraPosition(GameConstants.MAP_WIDTH / 2f, GameConstants.MAP_HEIGHT / 2f)
         );
     }
 
@@ -121,6 +123,7 @@ public record MapState(
         private List<BuildingData> buildings;
         private ResourceData playerResources;
         private PlayerPosition playerPos;
+        private CameraPosition cameraPos;
 
         private Builder() {
             this(new MapState());
@@ -136,6 +139,7 @@ public record MapState(
             this.buildings = state.buildings;
             this.playerResources = state.playerResources;
             this.playerPos = state.playerPos;
+            this.cameraPos = state.cameraPos;
         }
 
         public Builder version(final int newVersion) {
@@ -183,6 +187,11 @@ public record MapState(
             return this;
         }
 
+        public Builder cameraPos(final CameraPosition newCameraPos) {
+            this.cameraPos = newCameraPos;
+            return this;
+        }
+
         public MapState build() {
             return new MapState(
                     version,
@@ -193,7 +202,8 @@ public record MapState(
                     chunks,
                     buildings,
                     playerResources,
-                    playerPos
+                    playerPos,
+                    cameraPos
             );
         }
     }

--- a/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
@@ -22,6 +22,7 @@ public final class SaveMigrator {
         register(new V7ToV8Migration());
         register(new V8ToV9Migration());
         register(new V9ToV10Migration());
+        register(new V10ToV11Migration());
     }
 
     private SaveMigrator() {

--- a/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
@@ -13,9 +13,10 @@ public enum SaveVersion {
     V7(7),
     V8(8),
     V9(9),
-    V10(10);
+    V10(10),
+    V11(11);
 
-    public static final SaveVersion CURRENT = V10;
+    public static final SaveVersion CURRENT = V11;
 
     private final int number;
 

--- a/core/src/main/java/net/lapidist/colony/save/V10ToV11Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V10ToV11Migration.java
@@ -1,0 +1,28 @@
+package net.lapidist.colony.save;
+
+import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.components.state.CameraPosition;
+import net.lapidist.colony.components.state.MapState;
+
+/** Migration from save version 10 to 11 adding camera position. */
+public final class V10ToV11Migration implements MapStateMigration {
+    @Override
+    public int fromVersion() {
+        return SaveVersion.V10.number();
+    }
+
+    @Override
+    public int toVersion() {
+        return SaveVersion.V11.number();
+    }
+
+    @Override
+    public MapState apply(final MapState state) {
+        return state.toBuilder()
+                .cameraPos(new CameraPosition(
+                        GameConstants.MAP_WIDTH / 2f,
+                        GameConstants.MAP_HEIGHT / 2f))
+                .version(toVersion())
+                .build();
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/serialization/SerializationRegistrar.java
+++ b/core/src/main/java/net/lapidist/colony/serialization/SerializationRegistrar.java
@@ -17,6 +17,7 @@ import net.lapidist.colony.components.state.MapChunk;
 import net.lapidist.colony.components.state.MapChunkRequest;
 import net.lapidist.colony.save.SaveData;
 import net.lapidist.colony.components.state.PlayerPosition;
+import net.lapidist.colony.components.state.CameraPosition;
 
 /**
  * Registers all serializable classes with a given Kryo instance.
@@ -56,7 +57,7 @@ public final class SerializationRegistrar {
     }
 
     /** Precomputed registration hash for quick access. */
-    public static final int REGISTRATION_HASH = -1119370346;
+    public static final int REGISTRATION_HASH = 403491417;
 
     private static final Class<?>[] REGISTERED_TYPES = {
             TileData.class,
@@ -77,6 +78,7 @@ public final class SerializationRegistrar {
             TilePos.class,
             net.lapidist.colony.chat.ChatMessage.class,
             PlayerPosition.class,
-            SaveData.class
+            SaveData.class,
+            CameraPosition.class
     };
 }

--- a/server/src/main/java/net/lapidist/colony/server/services/MapService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/MapService.java
@@ -56,6 +56,7 @@ public final class MapService {
         MapState state = mapGenerator.generate(width, height);
         return state.toBuilder()
                 .playerPos(new PlayerPosition(width / 2, height / 2))
+                .cameraPos(new net.lapidist.colony.components.state.CameraPosition(width / 2f, height / 2f))
                 .build();
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MapScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MapScreenTest.java
@@ -46,7 +46,7 @@ public class MapScreenTest {
             worldStatic.when(() -> MapWorldBuilder.builder(eq(state), eq(client),
                     any(Stage.class), eq(settings.getKeyBindings())))
                     .thenReturn(new WorldConfigurationBuilder());
-            worldStatic.when(() -> MapWorldBuilder.build(any(), isNull(), eq(settings)))
+            worldStatic.when(() -> MapWorldBuilder.build(any(), isNull(), eq(settings), any()))
                     .thenReturn(world);
             uiStatic.when(() -> MapUiBuilder.build(any(Stage.class), eq(world), eq(client), eq(colony)))
                     .thenAnswer(inv -> new MapUi(

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MapWorldBuilderConfigurationTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MapWorldBuilderConfigurationTest.java
@@ -54,7 +54,8 @@ public class MapWorldBuilderConfigurationTest {
             World world = MapWorldBuilder.build(
                     MapWorldBuilder.baseBuilder(client, stage, keys),
                     null,
-                    new net.lapidist.colony.settings.Settings()
+                    new net.lapidist.colony.settings.Settings(),
+                    null
             );
 
             assertNotNull(world.getSystem(CameraInputSystem.class));
@@ -86,7 +87,8 @@ public class MapWorldBuilderConfigurationTest {
             World world = MapWorldBuilder.build(
                     MapWorldBuilder.builder(new ProvidedMapStateProvider(state), client, stage, keys),
                     null,
-                    new net.lapidist.colony.settings.Settings()
+                    new net.lapidist.colony.settings.Settings(),
+                    null
             );
             world.process();
 
@@ -118,7 +120,8 @@ public class MapWorldBuilderConfigurationTest {
             World world = MapWorldBuilder.build(
                     MapWorldBuilder.builder(state, client, stage, keys),
                     null,
-                    new net.lapidist.colony.settings.Settings()
+                    new net.lapidist.colony.settings.Settings(),
+                    null
             );
             world.process();
 
@@ -153,7 +156,8 @@ public class MapWorldBuilderConfigurationTest {
             World world = MapWorldBuilder.build(
                     MapWorldBuilder.builder(state, client, stage, keys),
                     null,
-                    new net.lapidist.colony.settings.Settings()
+                    new net.lapidist.colony.settings.Settings(),
+                    null
             );
             world.process();
 
@@ -174,7 +178,7 @@ public class MapWorldBuilderConfigurationTest {
     public void selectsCameraSystemFromSettings() {
         net.lapidist.colony.settings.Settings settings = new net.lapidist.colony.settings.Settings();
         settings.getGraphicsSettings().setRenderer("sprite");
-        World world = MapWorldBuilder.build(new com.artemis.WorldConfigurationBuilder(), null, settings);
+        World world = MapWorldBuilder.build(new com.artemis.WorldConfigurationBuilder(), null, settings, null);
         assertNotNull(world.getSystem(PlayerCameraSystem.class));
         world.dispose();
     }

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MapWorldBuilderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MapWorldBuilderTest.java
@@ -32,7 +32,7 @@ public class MapWorldBuilderTest {
         WorldConfigurationBuilder builder = new WorldConfigurationBuilder()
                 .with(new EventSystem(), dummy);
 
-        World world = MapWorldBuilder.build(builder, null, new net.lapidist.colony.settings.Settings());
+        World world = MapWorldBuilder.build(builder, null, new net.lapidist.colony.settings.Settings(), null);
         world.setDelta(0f);
         world.process();
 

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerCameraPositionSaveTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerCameraPositionSaveTest.java
@@ -1,0 +1,41 @@
+package net.lapidist.colony.tests.server;
+
+import net.lapidist.colony.server.GameServer;
+import net.lapidist.colony.server.GameServerConfig;
+import net.lapidist.colony.server.io.GameStateIO;
+import net.lapidist.colony.io.Paths;
+import net.lapidist.colony.components.state.CameraPosition;
+import org.junit.Test;
+
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+
+public class GameServerCameraPositionSaveTest {
+
+    @Test
+    public void cameraPositionPersistsAcrossSaves() throws Exception {
+        GameServerConfig config = GameServerConfig.builder()
+                .saveName("camera-save")
+                .build();
+        Paths.get().deleteAutosave("camera-save");
+        GameServer server = new GameServer(config);
+        server.start();
+
+        Path saveFile = Paths.get().getAutosave("camera-save");
+        final float x = 5f;
+        final float y = 6f;
+        final float epsilon = 0.001f;
+        CameraPosition pos = new CameraPosition(x, y);
+        server.stop();
+        GameStateIO.save(server.getMapState().toBuilder().cameraPos(pos).build(), saveFile);
+
+        GameServer server2 = new GameServer(config);
+        server2.start();
+        CameraPosition loaded = server2.getMapState().cameraPos();
+        server2.stop();
+
+        assertEquals(x, loaded.x(), epsilon);
+        assertEquals(y, loaded.y(), epsilon);
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV10Test.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV10Test.java
@@ -1,0 +1,43 @@
+package net.lapidist.colony.tests.server;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Output;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.serialization.KryoRegistry;
+import net.lapidist.colony.save.SaveData;
+import net.lapidist.colony.save.SaveVersion;
+import net.lapidist.colony.serialization.SerializationRegistrar;
+import net.lapidist.colony.server.io.GameStateIO;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class GameStateIOMigrationV10Test {
+
+    @Test
+    public void migratesV10ToCurrent() throws Exception {
+        Path file = Files.createTempFile("state", ".dat");
+        MapState state = MapState.builder()
+                .version(SaveVersion.V10.number())
+                .build();
+        Kryo kryo = new Kryo();
+        KryoRegistry.register(kryo);
+        try (Output output = new Output(Files.newOutputStream(file))) {
+            SaveData data = new SaveData(
+                    SaveVersion.V10.number(),
+                    SerializationRegistrar.registrationHash(),
+                    state
+            );
+            kryo.writeObject(output, data);
+        }
+
+        MapState loaded = GameStateIO.load(file);
+        Files.deleteIfExists(file);
+        assertEquals(SaveVersion.CURRENT.number(), loaded.version());
+        assertNotNull(loaded.cameraPos());
+    }
+}


### PR DESCRIPTION
## Summary
- add `CameraPosition` record and include it in `MapState`
- bump save version to V11 and implement migration
- persist camera position when generating and loading worlds
- apply camera position when building the map world
- update serialization registry and tests

## Testing
- `./gradlew clean test --console=plain --no-daemon`
- `./gradlew check --console=plain --no-daemon`
- `./gradlew codeCoverageReport --console=plain --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_684cabca25d48328a66f822bd9c16a43