### PR TITLE
feat: send initial chunks on connect

### DIFF
--- a/server/src/main/java/net/lapidist/colony/server/services/NetworkService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/NetworkService.java
@@ -7,6 +7,7 @@ import net.lapidist.colony.components.state.MapChunk;
 import net.lapidist.colony.components.state.MapMetadata;
 import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.components.state.TileData;
+import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.map.MapChunkData;
 import net.lapidist.colony.network.DispatchListener;
 import org.slf4j.Logger;
@@ -49,6 +50,7 @@ public final class NetworkService {
             public void connected(final Connection connection) {
                 LOGGER.info("Connection established: {}", connection.getID());
                 sendMapMetadata(connection, mapState);
+                sendInitialChunks(connection, mapState);
             }
         });
     }
@@ -81,6 +83,26 @@ public final class NetworkService {
         );
         connection.sendTCP(meta);
         LOGGER.info("Sent map metadata with {} chunks to connection {}", chunkCount, connection.getID());
+    }
+
+    private void sendInitialChunks(final Connection connection, final MapState state) {
+        if (state.playerPos() == null) {
+            return;
+        }
+        int chunkX = Math.floorDiv(state.playerPos().x(), MapChunkData.CHUNK_SIZE);
+        int chunkY = Math.floorDiv(state.playerPos().y(), MapChunkData.CHUNK_SIZE);
+        int radius = GameConstants.CHUNK_LOAD_RADIUS;
+        int sent = 0;
+        for (int x = chunkX - radius; x <= chunkX + radius; x++) {
+            for (int y = chunkY - radius; y <= chunkY + radius; y++) {
+                MapChunkData chunk = state.chunks().get(new net.lapidist.colony.components.state.ChunkPos(x, y));
+                if (chunk != null) {
+                    connection.sendTCP(toChunkMessage(0, x, y, chunk));
+                    sent++;
+                }
+            }
+        }
+        LOGGER.info("Sent {} initial chunks around spawn to connection {}", sent, connection.getID());
     }
 
     public void sendChunk(final Connection connection, final MapState state, final int chunkX, final int chunkY) {

--- a/tests/src/test/java/net/lapidist/colony/tests/server/NetworkServiceTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/NetworkServiceTest.java
@@ -33,6 +33,7 @@ public class NetworkServiceTest {
         Connection connection = mock(Connection.class);
         listener.connected(connection);
         verify(connection).sendTCP(isA(MapMetadata.class));
+        verify(connection, atLeastOnce()).sendTCP(isA(MapChunk.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- deliver map chunks near spawn when a client connects
- ensure network service test expects initial chunks

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684cbbada9d48328b5126d79e562705c