### PR TITLE
feat: make network buffer size configurable

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
+++ b/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
@@ -39,10 +39,9 @@ import java.util.function.Consumer;
 
 public final class GameClient extends AbstractMessageEndpoint {
     // Increase buffers to handle large serialized map data.
-    // Matches the server allocation of 4MB to allow receiving big map states.
-    private static final int BUFFER_SIZE = 4 * 1024 * 1024;
+    // Size is configured via game.networkBufferSize.
     private static final Logger LOGGER = LoggerFactory.getLogger(GameClient.class);
-    private final Client client = new Client(BUFFER_SIZE, BUFFER_SIZE);
+    private final Client client = new Client(GameConstants.NETWORK_BUFFER_SIZE, GameConstants.NETWORK_BUFFER_SIZE);
     private MapState mapState;
     private final Map<Class<?>, Queue<?>> messageQueues = new ConcurrentHashMap<>();
     private Iterable<MessageHandler<?>> handlers;

--- a/core/src/main/java/net/lapidist/colony/components/GameConstants.java
+++ b/core/src/main/java/net/lapidist/colony/components/GameConstants.java
@@ -9,4 +9,5 @@ public final class GameConstants {
     public static final int MAP_HEIGHT = ColonyConfig.get().getInt("game.mapHeight");
     public static final int TILE_SIZE = ColonyConfig.get().getInt("game.tileSize");
     public static final int CHUNK_LOAD_RADIUS = ColonyConfig.get().getInt("game.chunkLoadRadius");
+    public static final int NETWORK_BUFFER_SIZE = ColonyConfig.get().getInt("game.networkBufferSize");
 }

--- a/core/src/main/resources/game.conf
+++ b/core/src/main/resources/game.conf
@@ -5,6 +5,7 @@ game {
   chunkLoadRadius = 1
   autosaveInterval = 600000
   defaultSaveName = "autosave"
+  networkBufferSize = 4194304
   server {
     tcpPort = 54555
     udpPort = 54777

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,7 @@
 # Configuration
 
 Default settings are read from `core/src/main/resources/game.conf`. The file
-controls the initial map size, autosave interval and server ports:
+controls the initial map size, network buffer size, autosave interval and server ports:
 
 ```hocon
 game {
@@ -10,6 +10,7 @@ game {
   tileSize = 32
   autosaveInterval = 600000
   defaultSaveName = "autosave"
+  networkBufferSize = 4194304
   server {
     tcpPort = 54555
     udpPort = 54777

--- a/server/src/main/java/net/lapidist/colony/server/GameServer.java
+++ b/server/src/main/java/net/lapidist/colony/server/GameServer.java
@@ -3,6 +3,7 @@ package net.lapidist.colony.server;
 import com.esotericsoftware.kryonet.Server;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.config.ColonyConfig;
+import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.events.Events;
 import net.lapidist.colony.serialization.KryoRegistry;
 import net.lapidist.colony.mod.GameMod;
@@ -39,13 +40,10 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
     public static final int TCP_PORT = ColonyConfig.get().getInt("game.server.tcpPort");
     public static final int UDP_PORT = ColonyConfig.get().getInt("game.server.udpPort");
 
-    // Increase buffers so the entire map can be serialized in one object.
-    // Larger maps (e.g. 320x320) require several megabytes when encoded by Kryo,
-    // so allocate 4MB to avoid overflow.
-    private static final int BUFFER_SIZE = 4 * 1024 * 1024;
+    // Buffer size for Kryo serialization configured via game.networkBufferSize.
     private static final Logger LOGGER = LoggerFactory.getLogger(GameServer.class);
 
-    private final Server server = new Server(BUFFER_SIZE, BUFFER_SIZE);
+    private final Server server = new Server(GameConstants.NETWORK_BUFFER_SIZE, GameConstants.NETWORK_BUFFER_SIZE);
     private final long autosaveInterval;
     private final String saveName;
     private final MapGenerator mapGenerator;

--- a/tests/src/test/java/net/lapidist/colony/tests/network/NetworkBufferSizeConfigTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/network/NetworkBufferSizeConfigTest.java
@@ -1,0 +1,16 @@
+package net.lapidist.colony.tests.network;
+
+import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.config.ColonyConfig;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class NetworkBufferSizeConfigTest {
+
+    @Test
+    public void readsBufferSizeFromConfig() {
+        int expected = ColonyConfig.get().getInt("game.networkBufferSize");
+        assertEquals(expected, GameConstants.NETWORK_BUFFER_SIZE);
+    }
+}


### PR DESCRIPTION
## Summary
- add `networkBufferSize` option in `game.conf`
- expose `NETWORK_BUFFER_SIZE` via `GameConstants`
- use the configurable buffer size in `GameServer` and `GameClient`
- document the new setting
- test that the buffer size is loaded from config

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684cbe30a89c83289f2b3334c77ebcb6