### PR TITLE
feat: compress map chunks

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
+++ b/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
@@ -25,7 +25,6 @@ import net.lapidist.colony.client.network.handlers.MapMetadataHandler;
 import net.lapidist.colony.client.network.handlers.MapChunkHandler;
 import net.lapidist.colony.client.network.handlers.QueueingMessageHandler;
 import net.lapidist.colony.client.network.handlers.ResourceUpdateHandler;
-import net.lapidist.colony.components.state.MapChunk;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -113,7 +112,7 @@ public final class GameClient extends AbstractMessageEndpoint {
                         loadMessageListener.accept(net.lapidist.colony.i18n.I18n.get("loading.chunks"));
                     }
                 }),
-                new MapChunkHandler(this::handleChunk),
+                new MapChunkHandler(this::handleChunk, client.getKryo()),
                 new QueueingMessageHandler<>(TileSelectionData.class, messageQueues),
                 new QueueingMessageHandler<>(BuildingData.class, messageQueues),
                 new QueueingMessageHandler<>(BuildingRemovalData.class, messageQueues),
@@ -181,9 +180,12 @@ public final class GameClient extends AbstractMessageEndpoint {
         return chunks;
     }
 
-    private void handleChunk(final MapChunk chunk) {
+    private void handleChunk(final MapChunkData chunk) {
         if (tileBuffer != null) {
-            tileBuffer.putAll(chunk.tiles());
+            for (var entry : chunk.getTiles().entrySet()) {
+                TileData td = entry.getValue();
+                tileBuffer.put(new TilePos(td.x(), td.y()), td);
+            }
             receivedChunks++;
             if (loadProgressListener != null && expectedChunks > 0) {
                 loadProgressListener.accept(receivedChunks / (float) expectedChunks);
@@ -212,7 +214,7 @@ public final class GameClient extends AbstractMessageEndpoint {
             data = new MapChunkData(chunk.chunkX(), chunk.chunkY());
             mapState.chunks().put(posKey, data);
         }
-        for (var entry : chunk.tiles().entrySet()) {
+        for (var entry : chunk.getTiles().entrySet()) {
             TileData td = entry.getValue();
             int localX = Math.floorMod(td.x(), MapChunkData.CHUNK_SIZE);
             int localY = Math.floorMod(td.y(), MapChunkData.CHUNK_SIZE);

--- a/client/src/main/java/net/lapidist/colony/client/network/handlers/MapChunkHandler.java
+++ b/client/src/main/java/net/lapidist/colony/client/network/handlers/MapChunkHandler.java
@@ -1,23 +1,39 @@
 package net.lapidist.colony.client.network.handlers;
 
-import net.lapidist.colony.components.state.MapChunk;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import net.lapidist.colony.components.state.MapChunkBytes;
+import net.lapidist.colony.map.MapChunkData;
 import net.lapidist.colony.network.AbstractMessageHandler;
 
+import java.io.ByteArrayInputStream;
 import java.util.function.Consumer;
+import java.util.zip.GZIPInputStream;
 
 /**
- * Receives map chunk data and triggers a callback.
+ * Receives compressed map chunk data and triggers a callback with the
+ * deserialized {@link MapChunkData}.
  */
-public final class MapChunkHandler extends AbstractMessageHandler<MapChunk> {
-    private final Consumer<MapChunk> consumer;
+public final class MapChunkHandler extends AbstractMessageHandler<MapChunkBytes> {
+    private final Consumer<MapChunkData> consumer;
+    private final Kryo kryo;
 
-    public MapChunkHandler(final Consumer<MapChunk> consumerToUse) {
-        super(MapChunk.class);
+    public MapChunkHandler(final Consumer<MapChunkData> consumerToUse, final Kryo kryoInstance) {
+        super(MapChunkBytes.class);
         this.consumer = consumerToUse;
+        this.kryo = kryoInstance;
     }
 
     @Override
-    public void handle(final MapChunk message) {
-        consumer.accept(message);
+    public void handle(final MapChunkBytes message) {
+        try {
+            ByteArrayInputStream bais = new ByteArrayInputStream(message.data());
+            try (GZIPInputStream gzip = new GZIPInputStream(bais); Input input = new Input(gzip)) {
+                MapChunkData chunk = kryo.readObject(input, MapChunkData.class);
+                consumer.accept(chunk);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to decode chunk", e);
+        }
     }
 }

--- a/core/src/main/java/net/lapidist/colony/components/state/MapChunkBytes.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/MapChunkBytes.java
@@ -1,0 +1,9 @@
+package net.lapidist.colony.components.state;
+
+import net.lapidist.colony.serialization.KryoType;
+
+/**
+ * Compressed map chunk payload sent from the server to clients.
+ */
+@KryoType
+public record MapChunkBytes(int chunkX, int chunkY, byte[] data) { }

--- a/core/src/main/java/net/lapidist/colony/map/MapChunkData.java
+++ b/core/src/main/java/net/lapidist/colony/map/MapChunkData.java
@@ -84,4 +84,12 @@ public final class MapChunkData {
     public Map<TilePos, TileData> getTiles() {
         return tiles;
     }
+
+    public int chunkX() {
+        return baseX / CHUNK_SIZE;
+    }
+
+    public int chunkY() {
+        return baseY / CHUNK_SIZE;
+    }
 }

--- a/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
@@ -23,6 +23,7 @@ public final class SaveMigrator {
         register(new V8ToV9Migration());
         register(new V9ToV10Migration());
         register(new V10ToV11Migration());
+        register(new V11ToV12Migration());
     }
 
     private SaveMigrator() {

--- a/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
@@ -14,9 +14,10 @@ public enum SaveVersion {
     V8(8),
     V9(9),
     V10(10),
-    V11(11);
+    V11(11),
+    V12(12);
 
-    public static final SaveVersion CURRENT = V11;
+    public static final SaveVersion CURRENT = V12;
 
     private final int number;
 

--- a/core/src/main/java/net/lapidist/colony/save/V11ToV12Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V11ToV12Migration.java
@@ -1,0 +1,23 @@
+package net.lapidist.colony.save;
+
+import net.lapidist.colony.components.state.MapState;
+
+/** Migration from save version 11 to 12 with no data changes. */
+public final class V11ToV12Migration implements MapStateMigration {
+    @Override
+    public int fromVersion() {
+        return SaveVersion.V11.number();
+    }
+
+    @Override
+    public int toVersion() {
+        return SaveVersion.V12.number();
+    }
+
+    @Override
+    public MapState apply(final MapState state) {
+        return state.toBuilder()
+                .version(toVersion())
+                .build();
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/serialization/SerializationRegistrar.java
+++ b/core/src/main/java/net/lapidist/colony/serialization/SerializationRegistrar.java
@@ -14,6 +14,7 @@ import net.lapidist.colony.components.state.ResourceGatherRequestData;
 import net.lapidist.colony.components.state.ResourceUpdateData;
 import net.lapidist.colony.components.state.MapMetadata;
 import net.lapidist.colony.components.state.MapChunk;
+import net.lapidist.colony.components.state.MapChunkBytes;
 import net.lapidist.colony.components.state.MapChunkRequest;
 import net.lapidist.colony.save.SaveData;
 import net.lapidist.colony.components.state.PlayerPosition;
@@ -42,6 +43,7 @@ public final class SerializationRegistrar {
         kryo.register(java.util.List.class);
         kryo.register(java.util.HashMap.class);
         kryo.register(java.util.Map.class);
+        kryo.register(byte[].class);
     }
 
     /**
@@ -57,7 +59,7 @@ public final class SerializationRegistrar {
     }
 
     /** Precomputed registration hash for quick access. */
-    public static final int REGISTRATION_HASH = 403491417;
+    public static final int REGISTRATION_HASH = 1490495894;
 
     private static final Class<?>[] REGISTERED_TYPES = {
             TileData.class,
@@ -72,6 +74,7 @@ public final class SerializationRegistrar {
             ResourceUpdateData.class,
             MapMetadata.class,
             MapChunk.class,
+            MapChunkBytes.class,
             MapChunkRequest.class,
             net.lapidist.colony.components.state.ChunkPos.class,
             net.lapidist.colony.map.MapChunkData.class,

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -46,4 +46,8 @@ The client submits requests using methods such as `sendTileSelectionRequest`. Ea
 TileSelectionData update = client.poll(TileSelectionData.class);
 ```
 
+Map chunks are transmitted as GZIP-compressed Kryo streams to keep transfer
+sizes small. The client decompresses each chunk before applying it to the map
+state.
+
 For additional details see [architecture.md](architecture.md).

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -81,7 +81,8 @@ reason.
 
 `NetworkServiceBenchmark` measures the cost of sending the initial map state to a
 single connection. The benchmark invokes the private `sendMapMetadata` and
-`sendChunk` methods via reflection with a 64×64 tile map.
+`sendChunk` methods via reflection with a 64×64 tile map. Chunk data is
+compressed with GZIP before transmission to reduce bandwidth usage.
 
 ### Benchmark results (JDK 21)
 

--- a/server/src/main/java/net/lapidist/colony/server/services/NetworkService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/NetworkService.java
@@ -7,8 +7,6 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Output;
 import net.lapidist.colony.components.state.MapChunkBytes;
 import net.lapidist.colony.components.state.MapMetadata;
-import net.lapidist.colony.components.state.TilePos;
-import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.map.MapChunkData;
 import net.lapidist.colony.network.DispatchListener;
@@ -106,7 +104,7 @@ public final class NetworkService {
             for (int y = chunkY - radius; y <= chunkY + radius; y++) {
                 MapChunkData chunk = state.chunks().get(new net.lapidist.colony.components.state.ChunkPos(x, y));
                 if (chunk != null) {
-                    connection.sendTCP(toChunkMessage(0, x, y, chunk));
+                    connection.sendTCP(toChunkBytes(x, y, chunk));
                     sent++;
                 }
             }

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV11Test.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV11Test.java
@@ -1,0 +1,41 @@
+package net.lapidist.colony.tests.server;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Output;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.serialization.KryoRegistry;
+import net.lapidist.colony.save.SaveData;
+import net.lapidist.colony.save.SaveVersion;
+import net.lapidist.colony.serialization.SerializationRegistrar;
+import net.lapidist.colony.server.io.GameStateIO;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+
+public class GameStateIOMigrationV11Test {
+
+    @Test
+    public void migratesV11ToCurrent() throws Exception {
+        Path file = Files.createTempFile("state", ".dat");
+        MapState state = MapState.builder()
+                .version(SaveVersion.V11.number())
+                .build();
+        Kryo kryo = new Kryo();
+        KryoRegistry.register(kryo);
+        try (Output output = new Output(Files.newOutputStream(file))) {
+            SaveData data = new SaveData(
+                    SaveVersion.V11.number(),
+                    SerializationRegistrar.registrationHash(),
+                    state
+            );
+            kryo.writeObject(output, data);
+        }
+
+        MapState loaded = GameStateIO.load(file);
+        Files.deleteIfExists(file);
+        assertEquals(SaveVersion.CURRENT.number(), loaded.version());
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/server/NetworkServiceTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/NetworkServiceTest.java
@@ -5,7 +5,7 @@ import com.esotericsoftware.kryonet.Listener;
 import com.esotericsoftware.kryonet.Server;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.MapMetadata;
-import net.lapidist.colony.components.state.MapChunk;
+import net.lapidist.colony.components.state.MapChunkBytes;
 import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.server.services.NetworkService;
 import org.junit.Test;
@@ -49,13 +49,16 @@ public class NetworkServiceTest {
     @Test
     public void broadcastChunkSendsData() {
         Server server = mock(Server.class);
+        com.esotericsoftware.kryo.Kryo kryo = new com.esotericsoftware.kryo.Kryo();
+        net.lapidist.colony.serialization.KryoRegistry.register(kryo);
+        when(server.getKryo()).thenReturn(kryo);
         NetworkService service = new NetworkService(server, 1, 2);
         MapState state = new MapState();
         state.putTile(new TileData());
 
         service.broadcastChunk(state, 0, 0);
 
-        verify(server).sendToAllTCP(isA(MapChunk.class));
+        verify(server).sendToAllTCP(isA(MapChunkBytes.class));
     }
 
     @Test

--- a/tests/src/test/java/net/lapidist/colony/tests/server/NetworkServiceTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/NetworkServiceTest.java
@@ -18,6 +18,9 @@ public class NetworkServiceTest {
     @Test
     public void startBindsServerAndSendsStateOnConnect() throws Exception {
         Server server = mock(Server.class);
+        com.esotericsoftware.kryo.Kryo kryo = new com.esotericsoftware.kryo.Kryo();
+        net.lapidist.colony.serialization.KryoRegistry.register(kryo);
+        when(server.getKryo()).thenReturn(kryo);
         NetworkService service = new NetworkService(server, 1, 2);
         MapState state = new MapState();
         state.putTile(new TileData());
@@ -33,7 +36,7 @@ public class NetworkServiceTest {
         Connection connection = mock(Connection.class);
         listener.connected(connection);
         verify(connection).sendTCP(isA(MapMetadata.class));
-        verify(connection, atLeastOnce()).sendTCP(isA(MapChunk.class));
+        verify(connection, atLeastOnce()).sendTCP(isA(MapChunkBytes.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- stream `MapChunkData` directly without intermediate maps
- gzip-compress chunk data in `NetworkService`
- adapt `GameClient` chunk handler to decompress streams
- register new `MapChunkBytes` type and bump save version
- document chunk compression

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_684cbd24d4cc8328855ee77feb4dec1a