### PR TITLE
feat: throttle chunk requests

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -18,6 +18,7 @@ import net.lapidist.colony.client.systems.PlayerCameraSystem;
 import net.lapidist.colony.client.systems.PlayerMovementSystem;
 import net.lapidist.colony.client.systems.UISystem;
 import net.lapidist.colony.client.systems.ChunkLoadSystem;
+import net.lapidist.colony.client.systems.network.ChunkRequestQueueSystem;
 import net.lapidist.colony.client.systems.network.TileUpdateSystem;
 import net.lapidist.colony.client.systems.network.BuildingUpdateSystem;
 import net.lapidist.colony.client.systems.network.ResourceUpdateSystem;
@@ -135,6 +136,7 @@ public final class MapWorldBuilder {
                         new BuildingUpdateSystem(client),
                         new ResourceUpdateSystem(client),
                         new ChunkLoadSystem(client),
+                        new ChunkRequestQueueSystem(client),
                         new MapRenderSystem(),
                         new UISystem(stage)
                 );

--- a/client/src/main/java/net/lapidist/colony/client/systems/network/ChunkRequestQueueSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/network/ChunkRequestQueueSystem.java
@@ -1,0 +1,20 @@
+package net.lapidist.colony.client.systems.network;
+
+import com.artemis.BaseSystem;
+import net.lapidist.colony.client.network.GameClient;
+
+/**
+ * Sends queued chunk requests in batches each frame.
+ */
+public final class ChunkRequestQueueSystem extends BaseSystem {
+    private final GameClient client;
+
+    public ChunkRequestQueueSystem(final GameClient clientToUse) {
+        this.client = clientToUse;
+    }
+
+    @Override
+    protected void processSystem() {
+        client.processChunkRequestQueue();
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/network/GameClientChunkRequestQueueTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/network/GameClientChunkRequestQueueTest.java
@@ -1,0 +1,30 @@
+package net.lapidist.colony.tests.network;
+
+import net.lapidist.colony.client.network.GameClient;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/** Unit tests for {@link GameClient#processChunkRequestQueue(int)}. */
+public class GameClientChunkRequestQueueTest {
+
+    @Test
+    public void processesLimitedNumberOfChunkRequests() {
+        GameClient client = Mockito.spy(new GameClient(java.util.List.of()));
+        Mockito.doNothing().when(client).send(any());
+
+        int total = GameClient.CHUNK_REQUEST_BATCH_SIZE * 2;
+        for (int i = 0; i < total; i++) {
+            client.queueChunkRequest(i, 0);
+        }
+
+        client.processChunkRequestQueue(GameClient.CHUNK_REQUEST_BATCH_SIZE);
+        verify(client, times(GameClient.CHUNK_REQUEST_BATCH_SIZE)).send(any());
+
+        client.processChunkRequestQueue(GameClient.CHUNK_REQUEST_BATCH_SIZE);
+        verify(client, times(total)).send(any());
+    }
+}


### PR DESCRIPTION
## Summary
- queue chunk requests in `GameClient`
- add `ChunkRequestQueueSystem` to process chunk requests each frame
- include the system when building the world
- limit batch size in `processChunkRequestQueue`
- test chunk request throttling

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684cc654b6908328815a436bcfdc4989