### PR TITLE
feat: transmit map size in metadata

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
+++ b/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
@@ -51,6 +51,8 @@ public final class GameClient extends AbstractMessageEndpoint {
     private java.util.Map<TilePos, TileData> tileBuffer;
     private int expectedChunks;
     private int receivedChunks;
+    private int mapWidth = GameConstants.MAP_WIDTH;
+    private int mapHeight = GameConstants.MAP_HEIGHT;
     private java.util.function.Consumer<Float> loadProgressListener;
     private java.util.function.Consumer<String> loadMessageListener;
 
@@ -96,12 +98,14 @@ public final class GameClient extends AbstractMessageEndpoint {
                             .playerResources(meta.playerResources());
                     tileBuffer = new java.util.HashMap<>();
                     expectedChunks = meta.chunkCount();
+                    mapWidth = meta.width();
+                    mapHeight = meta.height();
                     receivedChunks = 0;
                     if (loadProgressListener != null) {
                         loadProgressListener.accept(0f);
                     }
-                    int chunkWidth = (int) Math.ceil(GameConstants.MAP_WIDTH / (double) MapChunkData.CHUNK_SIZE);
-                    int chunkHeight = (int) Math.ceil(GameConstants.MAP_HEIGHT / (double) MapChunkData.CHUNK_SIZE);
+                    int chunkWidth = (int) Math.ceil(mapWidth / (double) MapChunkData.CHUNK_SIZE);
+                    int chunkHeight = (int) Math.ceil(mapHeight / (double) MapChunkData.CHUNK_SIZE);
                     for (int x = 0; x < chunkWidth; x++) {
                         for (int y = 0; y < chunkHeight; y++) {
                             send(new MapChunkRequest(x, y));
@@ -161,6 +165,14 @@ public final class GameClient extends AbstractMessageEndpoint {
 
     public int getPlayerId() {
         return playerId;
+    }
+
+    public int getMapWidth() {
+        return mapWidth;
+    }
+
+    public int getMapHeight() {
+        return mapHeight;
     }
 
     private static java.util.Map<ChunkPos, MapChunkData> buildChunks(final java.util.Map<TilePos, TileData> tiles) {

--- a/core/src/main/java/net/lapidist/colony/components/state/MapMetadata.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/MapMetadata.java
@@ -16,5 +16,7 @@ public record MapMetadata(
         String description,
         List<BuildingData> buildings,
         ResourceData playerResources,
+        int width,
+        int height,
         int chunkCount
 ) { }

--- a/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
@@ -24,6 +24,7 @@ public final class SaveMigrator {
         register(new V9ToV10Migration());
         register(new V10ToV11Migration());
         register(new V11ToV12Migration());
+        register(new V12ToV13Migration());
     }
 
     private SaveMigrator() {

--- a/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
@@ -15,9 +15,10 @@ public enum SaveVersion {
     V9(9),
     V10(10),
     V11(11),
-    V12(12);
+    V12(12),
+    V13(13);
 
-    public static final SaveVersion CURRENT = V12;
+    public static final SaveVersion CURRENT = V13;
 
     private final int number;
 

--- a/core/src/main/java/net/lapidist/colony/save/V12ToV13Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V12ToV13Migration.java
@@ -1,0 +1,23 @@
+package net.lapidist.colony.save;
+
+import net.lapidist.colony.components.state.MapState;
+
+/** Migration from save version 12 to 13 with no data changes. */
+public final class V12ToV13Migration implements MapStateMigration {
+    @Override
+    public int fromVersion() {
+        return SaveVersion.V12.number();
+    }
+
+    @Override
+    public int toVersion() {
+        return SaveVersion.V13.number();
+    }
+
+    @Override
+    public MapState apply(final MapState state) {
+        return state.toBuilder()
+                .version(toVersion())
+                .build();
+    }
+}

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -50,4 +50,8 @@ Map chunks are transmitted as GZIP-compressed Kryo streams to keep transfer
 sizes small. The client decompresses each chunk before applying it to the map
 state.
 
+`MapMetadata` provides initial game information including the map width and
+height. Clients use these dimensions to determine how many chunks to request
+when loading a new game.
+
 For additional details see [architecture.md](architecture.md).

--- a/server/src/main/java/net/lapidist/colony/server/services/NetworkService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/NetworkService.java
@@ -86,6 +86,8 @@ public final class NetworkService {
                 state.description(),
                 state.buildings(),
                 state.playerResources(),
+                GameConstants.MAP_WIDTH,
+                GameConstants.MAP_HEIGHT,
                 chunkCount
         );
         connection.sendTCP(meta);

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationMapLoadNetworkTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationMapLoadNetworkTest.java
@@ -38,6 +38,8 @@ public class GameSimulationMapLoadNetworkTest {
         MapState state = client.getMapState();
         assertNotNull(state);
         assertEquals(server.getMapState().name(), state.name());
+        assertEquals(net.lapidist.colony.components.GameConstants.MAP_WIDTH, client.getMapWidth());
+        assertEquals(net.lapidist.colony.components.GameConstants.MAP_HEIGHT, client.getMapHeight());
 
         GameSimulation sim = new GameSimulation(state, client);
         sim.step();

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV12Test.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV12Test.java
@@ -1,0 +1,41 @@
+package net.lapidist.colony.tests.server;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Output;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.serialization.KryoRegistry;
+import net.lapidist.colony.save.SaveData;
+import net.lapidist.colony.save.SaveVersion;
+import net.lapidist.colony.serialization.SerializationRegistrar;
+import net.lapidist.colony.server.io.GameStateIO;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+
+public class GameStateIOMigrationV12Test {
+
+    @Test
+    public void migratesV12ToCurrent() throws Exception {
+        Path file = Files.createTempFile("state", ".dat");
+        MapState state = MapState.builder()
+                .version(SaveVersion.V12.number())
+                .build();
+        Kryo kryo = new Kryo();
+        KryoRegistry.register(kryo);
+        try (Output output = new Output(Files.newOutputStream(file))) {
+            SaveData data = new SaveData(
+                    SaveVersion.V12.number(),
+                    SerializationRegistrar.registrationHash(),
+                    state
+            );
+            kryo.writeObject(output, data);
+        }
+
+        MapState loaded = GameStateIO.load(file);
+        Files.deleteIfExists(file);
+        assertEquals(SaveVersion.CURRENT.number(), loaded.version());
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/server/NetworkServiceTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/NetworkServiceTest.java
@@ -10,6 +10,7 @@ import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.server.services.NetworkService;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import static org.junit.Assert.*;
 
 import static org.mockito.Mockito.*;
 
@@ -35,7 +36,11 @@ public class NetworkServiceTest {
         Listener listener = captor.getValue();
         Connection connection = mock(Connection.class);
         listener.connected(connection);
-        verify(connection).sendTCP(isA(MapMetadata.class));
+        ArgumentCaptor<MapMetadata> metaCaptor = ArgumentCaptor.forClass(MapMetadata.class);
+        verify(connection).sendTCP(metaCaptor.capture());
+        MapMetadata meta = metaCaptor.getValue();
+        assertEquals(net.lapidist.colony.components.GameConstants.MAP_WIDTH, meta.width());
+        assertEquals(net.lapidist.colony.components.GameConstants.MAP_HEIGHT, meta.height());
         verify(connection, atLeastOnce()).sendTCP(isA(MapChunkBytes.class));
     }
 


### PR DESCRIPTION
## Summary
- extend `MapMetadata` with width/height
- include map size in `NetworkService.sendMapMetadata`
- use the received size in `GameClient` for chunk requests
- add getters for map dimensions on `GameClient`
- bump save version and add `V12ToV13Migration`
- test width/height handling in `NetworkServiceTest` and scenario
- document the new metadata fields

## Testing
- `./scripts/check.sh`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684cc6b83a308328b5d0cede3bbb3284