### PR TITLE
feat: update map UI buttons

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/MapUiBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapUiBuilder.java
@@ -63,9 +63,9 @@ public final class MapUiBuilder {
 
         TextButton menuButton = new TextButton(I18n.get("map.menu"), skin);
         menuButton.setName("menuButton");
-        TextButton buildButton = new TextButton(I18n.get("map.build"), skin);
+        TextButton buildButton = new TextButton(I18n.get("map.build"), skin, "toggle");
         buildButton.setName("buildButton");
-        TextButton removeButton = new TextButton(I18n.get("map.remove"), skin);
+        TextButton removeButton = new TextButton(I18n.get("map.remove"), skin, "toggle");
         removeButton.setName("removeButton");
         TextButton mapButton = new TextButton(I18n.get("map.map"), skin);
         mapButton.setName("mapButton");
@@ -91,8 +91,12 @@ public final class MapUiBuilder {
             public void changed(final ChangeEvent event, final Actor actor) {
                 boolean enabled = !buildSystem.isBuildMode();
                 buildSystem.setBuildMode(enabled);
+                buildButton.setChecked(enabled);
                 if (enabled) {
                     buildSystem.setRemoveMode(false);
+                    removeButton.setProgrammaticChangeEvents(false);
+                    removeButton.setChecked(false);
+                    removeButton.setProgrammaticChangeEvents(true);
                 }
             }
         });
@@ -102,8 +106,12 @@ public final class MapUiBuilder {
             public void changed(final ChangeEvent event, final Actor actor) {
                 boolean enabled = !buildSystem.isRemoveMode();
                 buildSystem.setRemoveMode(enabled);
+                removeButton.setChecked(enabled);
                 if (enabled) {
                     buildSystem.setBuildMode(false);
+                    buildButton.setProgrammaticChangeEvents(false);
+                    buildButton.setChecked(false);
+                    buildButton.setProgrammaticChangeEvents(true);
                 }
             }
         });

--- a/tests/src/test/java/net/lapidist/colony/client/screens/MapUiButtonStateTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/screens/MapUiButtonStateTest.java
@@ -1,0 +1,69 @@
+package net.lapidist.colony.client.screens;
+
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
+import com.badlogic.gdx.utils.viewport.ScreenViewport;
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import net.lapidist.colony.client.Colony;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.client.systems.BuildPlacementSystem;
+import net.lapidist.colony.client.systems.CameraInputSystem;
+import net.lapidist.colony.client.systems.PlayerCameraSystem;
+import net.lapidist.colony.settings.Settings;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/** Tests for build and remove button state changes. */
+@RunWith(GdxTestRunner.class)
+public class MapUiButtonStateTest {
+
+    @Test
+    public void togglingButtonsUpdatesModesAndStates() {
+        Stage stage = new Stage(new ScreenViewport(), mock(Batch.class));
+        Settings settings = new Settings();
+        BuildPlacementSystem buildSystem = new BuildPlacementSystem(
+                mock(GameClient.class),
+                settings.getKeyBindings()
+        );
+        World world = new World(new WorldConfigurationBuilder()
+                .with(
+                        new PlayerCameraSystem(),
+                        new CameraInputSystem(settings.getKeyBindings()),
+                        buildSystem
+                )
+                .build());
+        GameClient client = mock(GameClient.class);
+        Colony colony = mock(Colony.class);
+        when(colony.getSettings()).thenReturn(settings);
+
+        MapUiBuilder.build(stage, world, client, colony);
+
+        TextButton buildButton = stage.getRoot().findActor("buildButton");
+        TextButton removeButton = stage.getRoot().findActor("removeButton");
+
+        // enable build mode
+        buildButton.toggle();
+        assertTrue(buildSystem.isBuildMode());
+        assertTrue(buildButton.isChecked());
+        assertFalse(buildSystem.isRemoveMode());
+        assertFalse(removeButton.isChecked());
+
+        // enable remove mode, should disable build
+        removeButton.toggle();
+        assertTrue(buildSystem.isRemoveMode());
+        assertTrue(removeButton.isChecked());
+        assertFalse(buildSystem.isBuildMode());
+        assertFalse(buildButton.isChecked());
+
+        // disable remove mode
+        removeButton.toggle();
+        assertFalse(buildSystem.isRemoveMode());
+        assertFalse(removeButton.isChecked());
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/client/screens/package-info.java
+++ b/tests/src/test/java/net/lapidist/colony/client/screens/package-info.java
@@ -1,0 +1,2 @@
+/** Tests for screen UI components. */
+package net.lapidist.colony.client.screens;


### PR DESCRIPTION
## Summary
- use toggle style for build and remove buttons in `MapUiBuilder`
- sync button checked state with build mode
- ensure build/remove are mutually exclusive
- test button behaviour in a new client test package

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684d2b813cf48328b40c3ad9585f4d6c