### PR TITLE
feat(client): scrollable load screen

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/LoadGameScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/LoadGameScreen.java
@@ -2,6 +2,8 @@ package net.lapidist.colony.client.screens;
 
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
@@ -20,6 +22,8 @@ public final class LoadGameScreen extends BaseScreen {
     public LoadGameScreen(final Colony game) {
         this.colony = game;
 
+        Table list = new Table();
+
         List<String> saves = listSaves();
         for (String save : saves) {
             TextButton loadButton = new TextButton(save, getSkin());
@@ -27,7 +31,7 @@ public final class LoadGameScreen extends BaseScreen {
             Table row = new Table();
             row.add(loadButton).padRight(PADDING);
             row.add(deleteButton);
-            getRoot().add(row).row();
+            list.add(row).row();
 
             loadButton.addListener(new ChangeListener() {
                 @Override
@@ -59,6 +63,14 @@ public final class LoadGameScreen extends BaseScreen {
                 }
             });
         }
+
+        if (saves.isEmpty()) {
+            list.add(new Label(I18n.get("loadGame.none"), getSkin())).row();
+        }
+
+        ScrollPane scroll = new ScrollPane(list, getSkin());
+        scroll.setScrollingDisabled(true, false);
+        getRoot().add(scroll).expand().fill().row();
 
         TextButton backButton = new TextButton(I18n.get("common.back"), getSkin());
         getRoot().add(backButton).row();

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -10,6 +10,7 @@ common.back=Back
 loadGame.delete=Delete
 loadGame.dialogTitle=Delete Save
 loadGame.confirm=Are you sure?
+loadGame.none=No saves found
 common.yes=Yes
 common.no=No
 map.menu=Menu

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -9,6 +9,7 @@ common.back=Zurück
 loadGame.delete=Löschen
 loadGame.dialogTitle=Speicher löschen
 loadGame.confirm=Bist du sicher?
+loadGame.none=Keine Spielstände gefunden
 common.yes=Ja
 common.no=Nein
 map.menu=Menü

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -9,6 +9,7 @@ common.back=Atrás
 loadGame.delete=Eliminar
 loadGame.dialogTitle=Eliminar guardado
 loadGame.confirm=¿Estás seguro?
+loadGame.none=No hay partidas guardadas
 common.yes=Sí
 common.no=No
 map.menu=Menú

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -9,6 +9,7 @@ common.back=Retour
 loadGame.delete=Supprimer
 loadGame.dialogTitle=Supprimer la sauvegarde
 loadGame.confirm=Êtes-vous sûr ?
+loadGame.none=Aucune sauvegarde trouvée
 common.yes=Oui
 common.no=Non
 map.menu=Menu

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/LoadGameScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/LoadGameScreenTest.java
@@ -1,6 +1,7 @@
 package net.lapidist.colony.tests.screens;
 
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
@@ -30,6 +31,12 @@ public class LoadGameScreenTest {
         return (Table) f.get(screen);
     }
 
+    private static Table getList(final LoadGameScreen screen) throws Exception {
+        Table root = getRoot(screen);
+        ScrollPane scroll = (ScrollPane) root.getChildren().first();
+        return (Table) scroll.getActor();
+    }
+
     @Test
     public void backButtonReturnsToMainMenu() throws Exception {
         Colony colony = mock(Colony.class);
@@ -53,9 +60,9 @@ public class LoadGameScreenTest {
         Colony colony = mock(Colony.class);
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
             LoadGameScreen screen = new LoadGameScreen(colony);
-            Table root = getRoot(screen);
+            Table list = getList(screen);
             Table row = null;
-            for (com.badlogic.gdx.scenes.scene2d.Actor child : root.getChildren()) {
+            for (com.badlogic.gdx.scenes.scene2d.Actor child : list.getChildren()) {
                 if (child instanceof Table t) {
                     TextButton btn = (TextButton) t.getChildren().first();
                     if (save.equals(btn.getText().toString())) {


### PR DESCRIPTION
## Summary
- make load game screen scrollable with fallback text when no saves
- keep back button accessible below the scroll pane
- add i18n keys for load screen message
- adjust tests for scrollable layout

## Testing
- `./scripts/check.sh`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684d2b824c2483288376bf89596a6840