### PR TITLE
feat: add scrollable chat log

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/ui/ChatBox.java
+++ b/client/src/main/java/net/lapidist/colony/client/ui/ChatBox.java
@@ -3,6 +3,7 @@ package net.lapidist.colony.client.ui;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextArea;
 import com.badlogic.gdx.scenes.scene2d.ui.TextField;
@@ -16,9 +17,12 @@ import net.lapidist.colony.i18n.I18n;
 public final class ChatBox extends Table {
     private static final int PREF_ROWS = 6;
     private static final float LOG_HEIGHT = 100f;
+    private static final int MAX_MESSAGES = 100;
     private final TextArea log;
+    private final ScrollPane scroll;
     private final TextField input;
     private final GameClient client;
+    private final java.util.Deque<String> messages = new java.util.ArrayDeque<>();
 
     public ChatBox(final Skin skin, final GameClient clientToUse) {
         this.client = clientToUse;
@@ -31,6 +35,9 @@ public final class ChatBox extends Table {
         logStyle.disabledBackground = null;
         logStyle.focusedBackground = null;
         log.setStyle(logStyle);
+        scroll = new ScrollPane(log, skin);
+        scroll.setScrollingDisabled(true, false);
+        scroll.setFadeScrollBars(false);
         input = new TextField("", skin);
         input.setVisible(false);
         input.setMessageText(I18n.get("chat.placeholder"));
@@ -44,7 +51,7 @@ public final class ChatBox extends Table {
                 return false;
             }
         });
-        add(log).growX().height(LOG_HEIGHT).row();
+        add(scroll).growX().height(LOG_HEIGHT).row();
         add(input).growX();
     }
 
@@ -74,7 +81,13 @@ public final class ChatBox extends Table {
     public void addMessage(final ChatMessage msg) {
         String format = I18n.get("chat.format");
         String line = String.format(format, msg.playerId(), msg.text());
-        log.appendText(line + "\n");
+        messages.addLast(line);
+        while (messages.size() > MAX_MESSAGES) {
+            messages.removeFirst();
+        }
+        log.setText(String.join("\n", messages) + "\n");
+        scroll.layout();
+        scroll.setScrollPercentY(1f);
     }
 
     @Override

--- a/tests/src/test/java/net/lapidist/colony/tests/ui/ChatBoxTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/ui/ChatBoxTest.java
@@ -1,7 +1,10 @@
 package net.lapidist.colony.tests.ui;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.utils.viewport.ScreenViewport;
 import net.lapidist.colony.chat.ChatMessage;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.client.ui.ChatBox;
@@ -33,5 +36,40 @@ public class ChatBoxTest {
         com.badlogic.gdx.scenes.scene2d.ui.TextArea log =
                 (com.badlogic.gdx.scenes.scene2d.ui.TextArea) logField.get(box);
         assertTrue(log.getText().contains("1: hi"));
+    }
+
+    @Test
+    public void keepsMaxMessagesAndScrollsToBottom() throws Exception {
+        Skin skin = new Skin(Gdx.files.internal("skin/default.json"));
+        ChatBox box = new ChatBox(skin, mock(GameClient.class));
+        Stage stage = new Stage(new ScreenViewport(), mock(Batch.class));
+        stage.addActor(box);
+        final int size = 200;
+        stage.getViewport().update(size, size, true);
+
+        Field maxField = ChatBox.class.getDeclaredField("MAX_MESSAGES");
+        maxField.setAccessible(true);
+        int max = maxField.getInt(null);
+
+        final int extra = 5;
+        for (int i = 0; i < max + extra; i++) {
+            box.addMessage(new ChatMessage(i, "msg" + i));
+        }
+
+        Field logField = ChatBox.class.getDeclaredField("log");
+        logField.setAccessible(true);
+        com.badlogic.gdx.scenes.scene2d.ui.TextArea log =
+                (com.badlogic.gdx.scenes.scene2d.ui.TextArea) logField.get(box);
+        String[] lines = log.getText().split("\\n");
+        assertEquals(max, lines.length);
+        assertFalse(lines[0].startsWith("0:"));
+
+        stage.act(0f);
+
+        Field scrollField = ChatBox.class.getDeclaredField("scroll");
+        scrollField.setAccessible(true);
+        com.badlogic.gdx.scenes.scene2d.ui.ScrollPane scroll =
+                (com.badlogic.gdx.scenes.scene2d.ui.ScrollPane) scrollField.get(box);
+        assertEquals(scroll.getMaxY(), scroll.getScrollY(), 0f);
     }
 }


### PR DESCRIPTION
## Summary
- make chat messages scrollable and limit history size
- ensure newest chat lines are visible
- test scrolling and history trimming

## Testing
- `./scripts/check.sh`


------
https://chatgpt.com/codex/tasks/task_e_684d2b92370c8328869774708dbb75cd