### PR TITLE
feat(core): store map dimensions

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
+++ b/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
@@ -98,6 +98,8 @@ public final class GameClient extends AbstractMessageEndpoint {
                             .saveName(meta.saveName())
                             .autosaveName(meta.autosaveName())
                             .description(meta.description())
+                            .width(meta.width())
+                            .height(meta.height())
                             .buildings(new java.util.ArrayList<>(meta.buildings()))
                             .playerResources(meta.playerResources());
                     tileBuffer = new java.util.HashMap<>();

--- a/core/src/main/java/net/lapidist/colony/components/state/MapState.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/MapState.java
@@ -23,7 +23,9 @@ public record MapState(
         List<BuildingData> buildings,
         ResourceData playerResources,
         PlayerPosition playerPos,
-        CameraPosition cameraPos
+        CameraPosition cameraPos,
+        int width,
+        int height
 ) {
     public static final int CURRENT_VERSION = SaveVersion.CURRENT.number();
 
@@ -38,7 +40,9 @@ public record MapState(
                 new ArrayList<>(),
                 new ResourceData(),
                 new PlayerPosition(GameConstants.MAP_WIDTH / 2, GameConstants.MAP_HEIGHT / 2),
-                new CameraPosition(GameConstants.MAP_WIDTH / 2f, GameConstants.MAP_HEIGHT / 2f)
+                new CameraPosition(GameConstants.MAP_WIDTH / 2f, GameConstants.MAP_HEIGHT / 2f),
+                GameConstants.MAP_WIDTH,
+                GameConstants.MAP_HEIGHT
         );
     }
 
@@ -124,6 +128,8 @@ public record MapState(
         private ResourceData playerResources;
         private PlayerPosition playerPos;
         private CameraPosition cameraPos;
+        private int width;
+        private int height;
 
         private Builder() {
             this(new MapState());
@@ -140,6 +146,8 @@ public record MapState(
             this.playerResources = state.playerResources;
             this.playerPos = state.playerPos;
             this.cameraPos = state.cameraPos;
+            this.width = state.width();
+            this.height = state.height();
         }
 
         public Builder version(final int newVersion) {
@@ -192,6 +200,16 @@ public record MapState(
             return this;
         }
 
+        public Builder width(final int newWidth) {
+            this.width = newWidth;
+            return this;
+        }
+
+        public Builder height(final int newHeight) {
+            this.height = newHeight;
+            return this;
+        }
+
         public MapState build() {
             return new MapState(
                     version,
@@ -203,7 +221,9 @@ public record MapState(
                     buildings,
                     playerResources,
                     playerPos,
-                    cameraPos
+                    cameraPos,
+                    width,
+                    height
             );
         }
     }

--- a/core/src/main/java/net/lapidist/colony/map/ChunkedMapGenerator.java
+++ b/core/src/main/java/net/lapidist/colony/map/ChunkedMapGenerator.java
@@ -29,6 +29,8 @@ public final class ChunkedMapGenerator implements MapGenerator {
         state = state.toBuilder()
                 .name("map-" + random.nextInt(NAME_RANGE))
                 .description(I18n.get("generator.generatedMap"))
+                .width(width)
+                .height(height)
                 .build();
 
         int chunkWidth = (int) Math.ceil(width / (double) MapChunkData.CHUNK_SIZE);

--- a/core/src/main/java/net/lapidist/colony/map/MapFactory.java
+++ b/core/src/main/java/net/lapidist/colony/map/MapFactory.java
@@ -37,8 +37,8 @@ public final class MapFactory {
         Map<TilePos, Entity> tileMap = new HashMap<>();
         Array<Entity> entities = new Array<>();
 
-        for (int x = 0; x < GameConstants.MAP_WIDTH; x++) {
-            for (int y = 0; y < GameConstants.MAP_HEIGHT; y++) {
+        for (int x = 0; x < state.width(); x++) {
+            for (int y = 0; y < state.height(); y++) {
                 TileData td = state.getTile(x, y);
                 Entity tile = world.createEntity();
                 TileComponent tileComponent = new TileComponent();

--- a/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
@@ -25,6 +25,7 @@ public final class SaveMigrator {
         register(new V10ToV11Migration());
         register(new V11ToV12Migration());
         register(new V12ToV13Migration());
+        register(new V13ToV14Migration());
     }
 
     private SaveMigrator() {

--- a/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
@@ -16,9 +16,10 @@ public enum SaveVersion {
     V10(10),
     V11(11),
     V12(12),
-    V13(13);
+    V13(13),
+    V14(14);
 
-    public static final SaveVersion CURRENT = V13;
+    public static final SaveVersion CURRENT = V14;
 
     private final int number;
 

--- a/core/src/main/java/net/lapidist/colony/save/V13ToV14Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V13ToV14Migration.java
@@ -1,0 +1,26 @@
+package net.lapidist.colony.save;
+
+import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.components.state.MapState;
+
+/** Migration from save version 13 to 14 adding map dimensions. */
+public final class V13ToV14Migration implements MapStateMigration {
+    @Override
+    public int fromVersion() {
+        return SaveVersion.V13.number();
+    }
+
+    @Override
+    public int toVersion() {
+        return SaveVersion.V14.number();
+    }
+
+    @Override
+    public MapState apply(final MapState state) {
+        return state.toBuilder()
+                .width(GameConstants.MAP_WIDTH)
+                .height(GameConstants.MAP_HEIGHT)
+                .version(toVersion())
+                .build();
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/server/services/MapService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/MapService.java
@@ -55,6 +55,8 @@ public final class MapService {
                 * MapChunkData.CHUNK_SIZE;
         MapState state = mapGenerator.generate(width, height);
         return state.toBuilder()
+                .width(GameConstants.MAP_WIDTH)
+                .height(GameConstants.MAP_HEIGHT)
                 .playerPos(new PlayerPosition(width / 2, height / 2))
                 .cameraPos(new net.lapidist.colony.components.state.CameraPosition(width / 2f, height / 2f))
                 .build();

--- a/server/src/main/java/net/lapidist/colony/server/services/NetworkService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/NetworkService.java
@@ -86,8 +86,8 @@ public final class NetworkService {
                 state.description(),
                 state.buildings(),
                 state.playerResources(),
-                GameConstants.MAP_WIDTH,
-                GameConstants.MAP_HEIGHT,
+                state.width(),
+                state.height(),
                 chunkCount
         );
         connection.sendTCP(meta);

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV13Test.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV13Test.java
@@ -1,0 +1,41 @@
+package net.lapidist.colony.tests.server;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Output;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.serialization.KryoRegistry;
+import net.lapidist.colony.save.SaveData;
+import net.lapidist.colony.save.SaveVersion;
+import net.lapidist.colony.serialization.SerializationRegistrar;
+import net.lapidist.colony.server.io.GameStateIO;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+
+public class GameStateIOMigrationV13Test {
+
+    @Test
+    public void migratesV13ToCurrent() throws Exception {
+        Path file = Files.createTempFile("state", ".dat");
+        MapState state = MapState.builder()
+                .version(SaveVersion.V13.number())
+                .build();
+        Kryo kryo = new Kryo();
+        KryoRegistry.register(kryo);
+        try (Output output = new Output(Files.newOutputStream(file))) {
+            SaveData data = new SaveData(
+                    SaveVersion.V13.number(),
+                    SerializationRegistrar.registrationHash(),
+                    state
+            );
+            kryo.writeObject(output, data);
+        }
+
+        MapState loaded = GameStateIO.load(file);
+        Files.deleteIfExists(file);
+        assertEquals(SaveVersion.CURRENT.number(), loaded.version());
+    }
+}


### PR DESCRIPTION
## Summary
- extend MapState with width and height
- support new fields in builder and default constructor
- propagate dimensions through map generator, services and networking
- add save version V14 with migration
- test migrating saves from V13

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684d305d30688328b61fab0aec2e6d26