### PR TITLE
feat(server): allow custom map dimensions

### DIFF
--- a/server/src/main/java/net/lapidist/colony/server/GameServer.java
+++ b/server/src/main/java/net/lapidist/colony/server/GameServer.java
@@ -47,6 +47,8 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
     private final long autosaveInterval;
     private final String saveName;
     private final MapGenerator mapGenerator;
+    private final int mapWidth;
+    private final int mapHeight;
     private AutosaveService autosaveService;
     private ResourceProductionService resourceProductionService;
     private MapService mapService;
@@ -72,9 +74,11 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
         this.saveName = config.getSaveName();
         this.autosaveInterval = config.getAutosaveInterval();
         this.mapGenerator = config.getMapGenerator();
+        this.mapWidth = config.getWidth();
+        this.mapHeight = config.getHeight();
         this.handlers = handlersToUse;
         this.commandHandlers = commandHandlersToUse;
-        this.mapService = new MapService(mapGenerator, saveName);
+        this.mapService = new MapService(mapGenerator, saveName, mapWidth, mapHeight);
         this.networkService = new NetworkService(server, TCP_PORT, UDP_PORT);
         this.autosaveService = new AutosaveService(autosaveInterval, saveName, () -> mapState);
         this.resourceProductionService = new ResourceProductionService(

--- a/server/src/main/java/net/lapidist/colony/server/GameServerConfig.java
+++ b/server/src/main/java/net/lapidist/colony/server/GameServerConfig.java
@@ -1,6 +1,7 @@
 package net.lapidist.colony.server;
 
 import net.lapidist.colony.config.ColonyConfig;
+import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.map.ChunkedMapGenerator;
 import net.lapidist.colony.map.MapGenerator;
 
@@ -11,10 +12,14 @@ public final class GameServerConfig {
 
     static final String DEFAULT_SAVE_NAME = ColonyConfig.get().getString("game.defaultSaveName");
     static final long DEFAULT_INTERVAL = ColonyConfig.get().getLong("game.autosaveInterval");
+    static final int DEFAULT_WIDTH = GameConstants.MAP_WIDTH;
+    static final int DEFAULT_HEIGHT = GameConstants.MAP_HEIGHT;
 
     private String saveName = DEFAULT_SAVE_NAME;
     private long autosaveInterval = DEFAULT_INTERVAL;
     private MapGenerator mapGenerator = new ChunkedMapGenerator();
+    private int width = DEFAULT_WIDTH;
+    private int height = DEFAULT_HEIGHT;
 
     public String getSaveName() {
         return saveName;
@@ -26,6 +31,14 @@ public final class GameServerConfig {
 
     public MapGenerator getMapGenerator() {
         return mapGenerator;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public int getHeight() {
+        return height;
     }
 
     public static Builder builder() {
@@ -47,6 +60,16 @@ public final class GameServerConfig {
 
         public Builder mapGenerator(final MapGenerator generator) {
             config.mapGenerator = generator;
+            return this;
+        }
+
+        public Builder width(final int w) {
+            config.width = w;
+            return this;
+        }
+
+        public Builder height(final int h) {
+            config.height = h;
             return this;
         }
 

--- a/server/src/main/java/net/lapidist/colony/server/services/MapService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/MapService.java
@@ -1,8 +1,8 @@
 package net.lapidist.colony.server.services;
 
-import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.PlayerPosition;
+import net.lapidist.colony.components.state.CameraPosition;
 import net.lapidist.colony.io.Paths;
 import net.lapidist.colony.map.MapGenerator;
 import net.lapidist.colony.map.MapChunkData;
@@ -23,10 +23,14 @@ public final class MapService {
 
     private final MapGenerator mapGenerator;
     private final String saveName;
+    private final int width;
+    private final int height;
 
-    public MapService(final MapGenerator generator, final String name) {
+    public MapService(final MapGenerator generator, final String name, final int mapWidth, final int mapHeight) {
         this.mapGenerator = generator;
         this.saveName = name;
+        this.width = mapWidth;
+        this.height = mapHeight;
     }
 
     public MapState load() throws IOException {
@@ -49,16 +53,19 @@ public final class MapService {
     }
 
     private MapState generateMap() {
-        int width = (int) Math.ceil(GameConstants.MAP_WIDTH / (double) MapChunkData.CHUNK_SIZE)
+        int alignedWidth = (int) Math.ceil(width / (double) MapChunkData.CHUNK_SIZE)
                 * MapChunkData.CHUNK_SIZE;
-        int height = (int) Math.ceil(GameConstants.MAP_HEIGHT / (double) MapChunkData.CHUNK_SIZE)
+        int alignedHeight = (int) Math.ceil(height / (double) MapChunkData.CHUNK_SIZE)
                 * MapChunkData.CHUNK_SIZE;
-        MapState state = mapGenerator.generate(width, height);
+        MapState state = mapGenerator.generate(alignedWidth, alignedHeight);
         return state.toBuilder()
-                .width(GameConstants.MAP_WIDTH)
-                .height(GameConstants.MAP_HEIGHT)
-                .playerPos(new PlayerPosition(width / 2, height / 2))
-                .cameraPos(new net.lapidist.colony.components.state.CameraPosition(width / 2f, height / 2f))
+                .width(width)
+                .height(height)
+                .playerPos(new PlayerPosition(alignedWidth / 2, alignedHeight / 2))
+                .cameraPos(new CameraPosition(
+                        alignedWidth / 2f,
+                        alignedHeight / 2f
+                ))
                 .build();
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerConfigTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerConfigTest.java
@@ -13,13 +13,19 @@ public class GameServerConfigTest {
     @Test
     public void builderSetsAllValues() {
         MapGenerator gen = mock(MapGenerator.class);
+        final int w = 99;
+        final int h = 66;
         GameServerConfig cfg = GameServerConfig.builder()
                 .saveName("save")
                 .autosaveInterval(INTERVAL)
                 .mapGenerator(gen)
+                .width(w)
+                .height(h)
                 .build();
         assertEquals("save", cfg.getSaveName());
         assertEquals(INTERVAL, cfg.getAutosaveInterval());
         assertSame(gen, cfg.getMapGenerator());
+        assertEquals(w, cfg.getWidth());
+        assertEquals(h, cfg.getHeight());
     }
 }


### PR DESCRIPTION
## Summary
- support configurable map dimensions in `GameServerConfig`
- propagate map width/height through `GameServer` and `MapService`
- update MapService generation logic to use provided dimensions
- cover new builder options in tests

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684d33d6c278832895f634185643c50c