### PR TITLE
feat: make map dimensions dynamic

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/render/MapRenderDataBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/render/MapRenderDataBuilder.java
@@ -18,12 +18,21 @@ public final class MapRenderDataBuilder {
     }
 
     public static MapRenderData fromMap(final MapComponent map, final World world) {
+        return fromMap(map, world, GameConstants.MAP_WIDTH, GameConstants.MAP_HEIGHT);
+    }
+
+    public static MapRenderData fromMap(
+            final MapComponent map,
+            final World world,
+            final int width,
+            final int height
+    ) {
         ComponentMapper<TileComponent> tileMapper = world.getMapper(TileComponent.class);
         ComponentMapper<ResourceComponent> resourceMapper = world.getMapper(ResourceComponent.class);
         ComponentMapper<BuildingComponent> buildingMapper = world.getMapper(BuildingComponent.class);
 
         Array<RenderTile> tiles = new Array<>();
-        RenderTile[][] grid = new RenderTile[GameConstants.MAP_WIDTH][GameConstants.MAP_HEIGHT];
+        RenderTile[][] grid = new RenderTile[width][height];
         Array<Entity> mapTiles = map.getTiles();
         for (int i = 0; i < mapTiles.size; i++) {
             Entity entity = mapTiles.get(i);
@@ -31,8 +40,8 @@ public final class MapRenderDataBuilder {
             ResourceComponent rc = resourceMapper.get(entity);
             RenderTile tile = toTile(tc, rc);
             tiles.add(tile);
-            if (tc.getX() >= 0 && tc.getX() < GameConstants.MAP_WIDTH
-                    && tc.getY() >= 0 && tc.getY() < GameConstants.MAP_HEIGHT) {
+            if (tc.getX() >= 0 && tc.getX() < width
+                    && tc.getY() >= 0 && tc.getY() < height) {
                 grid[tc.getX()][tc.getY()] = tile;
             }
         }

--- a/client/src/main/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRenderer.java
@@ -53,11 +53,17 @@ public final class LoadingSpriteMapRenderer implements MapRenderer, Disposable {
             if (!done) {
                 return;
             }
+            net.lapidist.colony.client.network.GameClient gc = null;
+            MapRenderDataSystem ds = world.getSystem(MapRenderDataSystem.class);
+            if (ds != null) {
+                gc = ds.getClient();
+            }
             TileRenderer tileRenderer = new TileRenderer(
                     spriteBatch,
                     resourceLoader,
                     cameraSystem,
-                    new DefaultAssetResolver()
+                    new DefaultAssetResolver(),
+                    gc
             );
             BuildingRenderer buildingRenderer = new BuildingRenderer(
                     spriteBatch,

--- a/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
@@ -19,6 +19,7 @@ import net.lapidist.colony.components.maps.TileComponent;
  * Renders tile entities.
  */
 public final class TileRenderer implements EntityRenderer<RenderTile> {
+    private final net.lapidist.colony.client.network.GameClient client;
 
     private final SpriteBatch spriteBatch;
     private final ResourceLoader resourceLoader;
@@ -40,8 +41,10 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
             final SpriteBatch spriteBatchToSet,
             final ResourceLoader resourceLoaderToSet,
             final CameraProvider cameraSystemToSet,
-            final AssetResolver resolverToSet
+            final AssetResolver resolverToSet,
+            final net.lapidist.colony.client.network.GameClient clientToUse
     ) {
+        this.client = clientToUse;
         this.spriteBatch = spriteBatchToSet;
         this.resourceLoader = resourceLoaderToSet;
         this.cameraSystem = cameraSystemToSet;
@@ -76,10 +79,13 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
                 tmpEnd
         );
 
+        int mapWidth = client != null ? client.getMapWidth() : GameConstants.MAP_WIDTH;
+        int mapHeight = client != null ? client.getMapHeight() : GameConstants.MAP_HEIGHT;
+
         int startX = Math.max(0, (int) start.x - 1);
         int startY = Math.max(0, (int) start.y - 1);
-        int endX = Math.min(GameConstants.MAP_WIDTH - 1, (int) end.x + 1);
-        int endY = Math.min(GameConstants.MAP_HEIGHT - 1, (int) end.y + 1);
+        int endX = Math.min(mapWidth - 1, (int) end.x + 1);
+        int endY = Math.min(mapHeight - 1, (int) end.y + 1);
 
 
         for (int x = startX; x <= endX; x++) {

--- a/client/src/main/java/net/lapidist/colony/client/screens/MapScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapScreen.java
@@ -30,6 +30,10 @@ public final class MapScreen implements Screen {
                 colony.getSettings(),
                 state.cameraPos()
         );
+        var cameraSystem = world.getSystem(net.lapidist.colony.client.systems.PlayerCameraSystem.class);
+        if (cameraSystem != null) {
+            cameraSystem.setClient(client);
+        }
         MapUi ui = MapUiBuilder.build(stage, world, client, colony);
         minimapActor = ui.getMinimapActor();
         events = new MapScreenEventHandler();

--- a/client/src/main/java/net/lapidist/colony/client/screens/MapUiBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapUiBuilder.java
@@ -72,7 +72,7 @@ public final class MapUiBuilder {
         TextButton minimapButton = new TextButton(I18n.get("map.minimap"), skin);
         minimapButton.setName("minimapButton");
         GraphicsSettings graphics = colony.getSettings().getGraphicsSettings();
-        MinimapActor minimapActor = new MinimapActor(world, graphics);
+        MinimapActor minimapActor = new MinimapActor(world, graphics, client);
         ChatBox chatBox = new ChatBox(skin, client);
         PlayerResourcesActor resourcesActor = new PlayerResourcesActor(skin, world);
 

--- a/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -117,11 +117,11 @@ public final class MapWorldBuilder {
             final PlayerPosition playerPos,
             final net.lapidist.colony.components.state.CameraPosition cameraPos
     ) {
-        CameraInputSystem cameraInputSystem = new CameraInputSystem(keyBindings);
+        CameraInputSystem cameraInputSystem = new CameraInputSystem(client, keyBindings);
         cameraInputSystem.addProcessor(stage);
         SelectionSystem selectionSystem = new SelectionSystem(client, keyBindings);
         BuildPlacementSystem buildPlacementSystem = new BuildPlacementSystem(client, keyBindings);
-        PlayerMovementSystem movementSystem = new PlayerMovementSystem(keyBindings);
+        PlayerMovementSystem movementSystem = new PlayerMovementSystem(client, keyBindings);
 
         WorldConfigurationBuilder builder = new WorldConfigurationBuilder()
                 .with(
@@ -130,7 +130,7 @@ public final class MapWorldBuilder {
                         cameraInputSystem,
                         selectionSystem,
                         buildPlacementSystem,
-                        new PlayerInitSystem(playerResources, playerPos),
+                        new PlayerInitSystem(client, playerResources, playerPos),
                         movementSystem,
                         new TileUpdateSystem(client),
                         new BuildingUpdateSystem(client),
@@ -144,7 +144,7 @@ public final class MapWorldBuilder {
         if (provider != null) {
             builder.with(
                     new MapInitSystem(provider),
-                    new MapRenderDataSystem()
+                    new MapRenderDataSystem(client)
             );
         }
 

--- a/client/src/main/java/net/lapidist/colony/client/systems/CameraInputSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/CameraInputSystem.java
@@ -17,6 +17,7 @@ import net.lapidist.colony.settings.KeyAction;
 public final class CameraInputSystem extends BaseSystem {
 
     private final KeyBindings keyBindings;
+    private final net.lapidist.colony.client.network.GameClient client;
     private final InputMultiplexer multiplexer = new InputMultiplexer();
 
     private PlayerCameraSystem cameraSystem;
@@ -24,6 +25,14 @@ public final class CameraInputSystem extends BaseSystem {
     private GestureInputHandler gestureHandler;
 
     public CameraInputSystem(final KeyBindings bindings) {
+        this(null, bindings);
+    }
+
+    public CameraInputSystem(
+            final net.lapidist.colony.client.network.GameClient clientToUse,
+            final KeyBindings bindings
+    ) {
+        this.client = clientToUse;
         this.keyBindings = bindings;
     }
 
@@ -38,7 +47,7 @@ public final class CameraInputSystem extends BaseSystem {
     @Override
     public void initialize() {
         cameraSystem = world.getSystem(PlayerCameraSystem.class);
-        keyboardHandler = new KeyboardInputHandler(cameraSystem, keyBindings);
+        keyboardHandler = new KeyboardInputHandler(client, cameraSystem, keyBindings);
         gestureHandler = new GestureInputHandler(cameraSystem);
         GestureDetector detector = new GestureDetector(new CameraGestureListener());
         multiplexer.addProcessor(detector);

--- a/client/src/main/java/net/lapidist/colony/client/systems/MapRenderDataSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/MapRenderDataSystem.java
@@ -19,6 +19,7 @@ import net.lapidist.colony.map.MapUtils;
  * Maintains the {@link MapRenderData} used for rendering.
  */
 public final class MapRenderDataSystem extends BaseSystem {
+    private final net.lapidist.colony.client.network.GameClient client;
     private MapRenderData renderData;
     private MapComponent map;
     private int lastVersion;
@@ -28,6 +29,18 @@ public final class MapRenderDataSystem extends BaseSystem {
     private final IntArray selectedTileIndices = new IntArray();
     private final IntArray dirtyIndices = new IntArray();
     private final IntArray updatedIndices = new IntArray();
+
+    public net.lapidist.colony.client.network.GameClient getClient() {
+        return client;
+    }
+
+    public MapRenderDataSystem() {
+        this(null);
+    }
+
+    public MapRenderDataSystem(final net.lapidist.colony.client.network.GameClient clientToUse) {
+        this.client = clientToUse;
+    }
 
     public MapRenderData getRenderData() {
         return renderData;
@@ -57,7 +70,13 @@ public final class MapRenderDataSystem extends BaseSystem {
         buildingMapper = world.getMapper(BuildingComponent.class);
         map = MapUtils.findMap(world).orElse(null);
         if (map != null) {
-            renderData = MapRenderDataBuilder.fromMap(map, world);
+            int width = client != null
+                    ? client.getMapWidth()
+                    : net.lapidist.colony.components.GameConstants.MAP_WIDTH;
+            int height = client != null
+                    ? client.getMapHeight()
+                    : net.lapidist.colony.components.GameConstants.MAP_HEIGHT;
+            renderData = MapRenderDataBuilder.fromMap(map, world, width, height);
             lastVersion = map.getVersion();
             rebuildSelectedIndices();
         }
@@ -72,7 +91,13 @@ public final class MapRenderDataSystem extends BaseSystem {
             }
         }
         if (renderData == null) {
-            renderData = MapRenderDataBuilder.fromMap(map, world);
+            int width = client != null
+                    ? client.getMapWidth()
+                    : net.lapidist.colony.components.GameConstants.MAP_WIDTH;
+            int height = client != null
+                    ? client.getMapHeight()
+                    : net.lapidist.colony.components.GameConstants.MAP_HEIGHT;
+            renderData = MapRenderDataBuilder.fromMap(map, world, width, height);
             lastVersion = map.getVersion();
             rebuildSelectedIndices();
             return;

--- a/client/src/main/java/net/lapidist/colony/client/systems/PlayerCameraSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/PlayerCameraSystem.java
@@ -14,6 +14,7 @@ import com.artemis.ComponentMapper;
 import com.artemis.Entity;
 
 public final class PlayerCameraSystem extends BaseSystem implements CameraProvider {
+    private net.lapidist.colony.client.network.GameClient client;
 
     public enum Mode { MAP_OVERVIEW, PLAYER }
 
@@ -30,6 +31,11 @@ public final class PlayerCameraSystem extends BaseSystem implements CameraProvid
     private ExtendViewport viewport;
 
     public PlayerCameraSystem() {
+        this(null);
+    }
+
+    public PlayerCameraSystem(final net.lapidist.colony.client.network.GameClient clientToUse) {
+        this.client = clientToUse;
         camera = new OrthographicCamera();
         viewport = new ExtendViewport(Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), camera);
 
@@ -37,6 +43,10 @@ public final class PlayerCameraSystem extends BaseSystem implements CameraProvid
         moveCameraToWorldCoords(getWorldCenter());
 
         viewport.apply();
+    }
+
+    public void setClient(final net.lapidist.colony.client.network.GameClient clientToSet) {
+        this.client = clientToSet;
     }
 
     @Override
@@ -59,7 +69,9 @@ public final class PlayerCameraSystem extends BaseSystem implements CameraProvid
     }
 
     public Vector2 getWorldCenter() {
-        return CameraUtils.getWorldCenter();
+        int width = client != null ? client.getMapWidth() : net.lapidist.colony.components.GameConstants.MAP_WIDTH;
+        int height = client != null ? client.getMapHeight() : net.lapidist.colony.components.GameConstants.MAP_HEIGHT;
+        return CameraUtils.getWorldCenter(width, height);
     }
 
     public Vector2 cameraCoordsFromWorldCoords(

--- a/client/src/main/java/net/lapidist/colony/client/systems/PlayerInitSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/PlayerInitSystem.java
@@ -13,16 +13,22 @@ public final class PlayerInitSystem extends BaseSystem {
     private boolean created;
     private final ResourceData initialResources;
     private final PlayerPosition initialPosition;
+    private final net.lapidist.colony.client.network.GameClient client;
 
     public PlayerInitSystem() {
-        this(new ResourceData(), null);
+        this(null, new ResourceData(), null);
     }
 
     public PlayerInitSystem(final ResourceData resources) {
-        this(resources, null);
+        this(null, resources, null);
     }
 
-    public PlayerInitSystem(final ResourceData resources, final PlayerPosition position) {
+    public PlayerInitSystem(
+            final net.lapidist.colony.client.network.GameClient clientToUse,
+            final ResourceData resources,
+            final PlayerPosition position
+    ) {
+        this.client = clientToUse;
         this.initialResources = resources;
         this.initialPosition = position;
     }
@@ -36,9 +42,13 @@ public final class PlayerInitSystem extends BaseSystem {
             pr.setStone(initialResources.stone());
             pr.setFood(initialResources.food());
             PlayerComponent pc = new PlayerComponent();
+            int width = client != null ? client.getMapWidth()
+                    : net.lapidist.colony.components.GameConstants.MAP_WIDTH;
+            int height = client != null ? client.getMapHeight()
+                    : net.lapidist.colony.components.GameConstants.MAP_HEIGHT;
             var pos = initialPosition != null
                     ? CameraUtils.tileCoordsToWorldCoords(initialPosition.x(), initialPosition.y())
-                    : CameraUtils.getWorldCenter();
+                    : CameraUtils.getWorldCenter(width, height);
             pc.setX(pos.x);
             pc.setY(pos.y);
             player.edit().add(pr).add(pc);

--- a/client/src/main/java/net/lapidist/colony/client/systems/PlayerMovementSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/PlayerMovementSystem.java
@@ -12,6 +12,7 @@ import net.lapidist.colony.settings.KeyBindings;
 
 /** Handles player movement when player camera mode is active. */
 public final class PlayerMovementSystem extends BaseSystem {
+    private final net.lapidist.colony.client.network.GameClient client;
     private static final float SPEED = 400f; // units per second
 
     private final KeyBindings keyBindings;
@@ -20,6 +21,14 @@ public final class PlayerMovementSystem extends BaseSystem {
     private Entity player;
 
     public PlayerMovementSystem(final KeyBindings bindings) {
+        this(null, bindings);
+    }
+
+    public PlayerMovementSystem(
+            final net.lapidist.colony.client.network.GameClient clientToUse,
+            final KeyBindings bindings
+    ) {
+        this.client = clientToUse;
         this.keyBindings = bindings;
     }
 
@@ -58,8 +67,10 @@ public final class PlayerMovementSystem extends BaseSystem {
     }
 
     private void clampPosition(final PlayerComponent pc) {
-        float maxX = GameConstants.MAP_WIDTH * GameConstants.TILE_SIZE;
-        float maxY = GameConstants.MAP_HEIGHT * GameConstants.TILE_SIZE;
+        float mapWidth = client != null ? client.getMapWidth() : GameConstants.MAP_WIDTH;
+        float mapHeight = client != null ? client.getMapHeight() : GameConstants.MAP_HEIGHT;
+        float maxX = mapWidth * GameConstants.TILE_SIZE;
+        float maxY = mapHeight * GameConstants.TILE_SIZE;
         pc.setX(MathUtils.clamp(pc.getX(), 0, maxX));
         pc.setY(MathUtils.clamp(pc.getY(), 0, maxY));
     }

--- a/client/src/main/java/net/lapidist/colony/client/systems/input/KeyboardInputHandler.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/input/KeyboardInputHandler.java
@@ -19,11 +19,21 @@ public final class KeyboardInputHandler {
 
     private final PlayerCameraSystem cameraSystem;
     private final KeyBindings keyBindings;
+    private final net.lapidist.colony.client.network.GameClient client;
 
     public KeyboardInputHandler(
             final PlayerCameraSystem cameraSystemToSet,
             final KeyBindings bindings
     ) {
+        this(null, cameraSystemToSet, bindings);
+    }
+
+    public KeyboardInputHandler(
+            final net.lapidist.colony.client.network.GameClient clientToUse,
+            final PlayerCameraSystem cameraSystemToSet,
+            final KeyBindings bindings
+    ) {
+        this.client = clientToUse;
         this.cameraSystem = cameraSystemToSet;
         this.keyBindings = bindings;
     }
@@ -54,8 +64,10 @@ public final class KeyboardInputHandler {
             return;
         }
         final Vector3 position = cameraSystem.getCamera().position;
-        final float mapWidth = GameConstants.MAP_WIDTH * GameConstants.TILE_SIZE;
-        final float mapHeight = GameConstants.MAP_HEIGHT * GameConstants.TILE_SIZE;
+        float width = client != null ? client.getMapWidth() : GameConstants.MAP_WIDTH;
+        float height = client != null ? client.getMapHeight() : GameConstants.MAP_HEIGHT;
+        final float mapWidth = width * GameConstants.TILE_SIZE;
+        final float mapHeight = height * GameConstants.TILE_SIZE;
 
         var camera = (OrthographicCamera) cameraSystem.getCamera();
         var viewport = (ExtendViewport) cameraSystem.getViewport();

--- a/client/src/main/java/net/lapidist/colony/client/ui/MinimapActor.java
+++ b/client/src/main/java/net/lapidist/colony/client/ui/MinimapActor.java
@@ -33,6 +33,7 @@ public final class MinimapActor extends Actor implements Disposable {
     private static final Logger LOGGER = LoggerFactory.getLogger(MinimapActor.class);
 
     private final World world;
+    private final net.lapidist.colony.client.network.GameClient client;
     private final ResourceLoader resourceLoader = new TextureAtlasResourceLoader();
     private ViewportOverlayRenderer overlayRenderer;
     private MinimapOutlineRenderer outlineRenderer;
@@ -67,10 +68,12 @@ public final class MinimapActor extends Actor implements Disposable {
         }
 
         if (mapWidthWorld == 0) {
-            mapWidthWorld = GameConstants.MAP_WIDTH * GameConstants.TILE_SIZE;
+            int width = client != null ? client.getMapWidth() : GameConstants.MAP_WIDTH;
+            mapWidthWorld = width * GameConstants.TILE_SIZE;
         }
         if (mapHeightWorld == 0) {
-            mapHeightWorld = GameConstants.MAP_HEIGHT * GameConstants.TILE_SIZE;
+            int height = client != null ? client.getMapHeight() : GameConstants.MAP_HEIGHT;
+            mapHeightWorld = height * GameConstants.TILE_SIZE;
         }
     }
 
@@ -95,14 +98,23 @@ public final class MinimapActor extends Actor implements Disposable {
 
 
     public MinimapActor(final World worldToSet) {
-        this(worldToSet, Settings.load().getGraphicsSettings());
+        this(worldToSet, Settings.load().getGraphicsSettings(), null);
     }
 
     public MinimapActor(
             final World worldToSet,
             final GraphicsSettings graphicsSettings
     ) {
+        this(worldToSet, graphicsSettings, null);
+    }
+
+    public MinimapActor(
+            final World worldToSet,
+            final GraphicsSettings graphicsSettings,
+            final net.lapidist.colony.client.network.GameClient clientToUse
+    ) {
         this.world = worldToSet;
+        this.client = clientToUse;
         setSize(DEFAULT_SIZE, DEFAULT_SIZE);
         try {
             resourceLoader.loadTextures(FileLocation.INTERNAL, "textures/textures.atlas", graphicsSettings);

--- a/client/src/main/java/net/lapidist/colony/client/util/CameraUtils.java
+++ b/client/src/main/java/net/lapidist/colony/client/util/CameraUtils.java
@@ -120,11 +120,15 @@ public final class CameraUtils {
         return !(tmp.x > Gdx.graphics.getWidth() || tmp.y > Gdx.graphics.getHeight());
     }
 
-    public static Vector2 getWorldCenter() {
+    public static Vector2 getWorldCenter(final int mapWidth, final int mapHeight) {
         return new Vector2(
-                (GameConstants.TILE_SIZE * GameConstants.MAP_WIDTH + GameConstants.TILE_SIZE) / 2f,
-                (GameConstants.TILE_SIZE * GameConstants.MAP_HEIGHT + GameConstants.TILE_SIZE) / 2f
+                (GameConstants.TILE_SIZE * mapWidth + GameConstants.TILE_SIZE) / 2f,
+                (GameConstants.TILE_SIZE * mapHeight + GameConstants.TILE_SIZE) / 2f
         );
+    }
+
+    public static Vector2 getWorldCenter() {
+        return getWorldCenter(GameConstants.MAP_WIDTH, GameConstants.MAP_HEIGHT);
     }
 
     public static Rectangle getViewBounds(

--- a/tests/src/jmh/java/net/lapidist/colony/tests/benchmarks/SpriteBatchRendererBenchmark.java
+++ b/tests/src/jmh/java/net/lapidist/colony/tests/benchmarks/SpriteBatchRendererBenchmark.java
@@ -61,7 +61,7 @@ public class SpriteBatchRendererBenchmark {
         resolver = new DefaultAssetResolver();
         camera = createCamera();
         SpriteBatch batch = mock(SpriteBatch.class);
-        TileRenderer tileRenderer = new TileRenderer(batch, loader, camera, resolver);
+        TileRenderer tileRenderer = new TileRenderer(batch, loader, camera, resolver, null);
         BuildingRenderer buildingRenderer = new BuildingRenderer(batch, loader, camera, resolver);
         ResourceRenderer resourceRenderer = mock(ResourceRenderer.class);
         PlayerRenderer playerRenderer = mock(PlayerRenderer.class);

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/RendererEnumMapTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/RendererEnumMapTest.java
@@ -26,7 +26,13 @@ public class RendererEnumMapTest {
         SpriteBatch batch = mock(SpriteBatch.class);
         ResourceLoader loader = mock(ResourceLoader.class);
         when(loader.findRegion(anyString())).thenReturn(new TextureRegion());
-        TileRenderer renderer = new TileRenderer(batch, loader, mock(CameraProvider.class), new DefaultAssetResolver());
+        TileRenderer renderer = new TileRenderer(
+                batch,
+                loader,
+                mock(CameraProvider.class),
+                new DefaultAssetResolver(),
+                null
+        );
 
         Field f = TileRenderer.class.getDeclaredField("tileRegions");
         f.setAccessible(true);

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/TileRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/TileRendererTest.java
@@ -44,7 +44,7 @@ public class TileRendererTest {
         when(camera.getViewport()).thenReturn(viewport);
         when(camera.getCamera()).thenReturn(cam);
 
-        TileRenderer renderer = new TileRenderer(batch, loader, camera, new DefaultAssetResolver());
+        TileRenderer renderer = new TileRenderer(batch, loader, camera, new DefaultAssetResolver(), null);
         reset(loader);
 
         Array<RenderTile> tiles = new Array<>();
@@ -105,7 +105,7 @@ public class TileRendererTest {
         when(camera.getViewport()).thenReturn(viewport);
         when(camera.getCamera()).thenReturn(cam);
 
-        TileRenderer renderer = new TileRenderer(batch, loader, camera, new DefaultAssetResolver());
+        TileRenderer renderer = new TileRenderer(batch, loader, camera, new DefaultAssetResolver(), null);
         reset(loader);
 
         Array<RenderTile> tiles = new Array<>();
@@ -151,7 +151,7 @@ public class TileRendererTest {
         when(resolver.tileAsset(anyString())).thenReturn("dirt0");
         when(resolver.hasTileAsset(anyString())).thenReturn(false);
 
-        TileRenderer renderer = new TileRenderer(batch, loader, camera, resolver);
+        TileRenderer renderer = new TileRenderer(batch, loader, camera, resolver, null);
 
         java.lang.reflect.Field fontField = TileRenderer.class.getDeclaredField("font");
         fontField.setAccessible(true);
@@ -200,7 +200,7 @@ public class TileRendererTest {
         when(camera.getViewport()).thenReturn(viewport);
         when(camera.getCamera()).thenReturn(cam);
 
-        TileRenderer renderer = new TileRenderer(batch, loader, camera, new DefaultAssetResolver());
+        TileRenderer renderer = new TileRenderer(batch, loader, camera, new DefaultAssetResolver(), null);
         reset(loader);
 
         Array<RenderTile> tiles = new Array<>();


### PR DESCRIPTION
## Summary
- derive render grid sizes from map metadata
- pass GameClient into systems needing map size
- look up GameClient when creating renderers
- clamp camera and player movement using state dimensions
- expose world center helper with custom sizes

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test check`
- `./gradlew codeCoverageReport`

------
https://chatgpt.com/codex/tasks/task_e_684d35a35e6483289adac38f5c5f0457