### PR TITLE
feat(server): log map metadata details on connection

### DIFF
--- a/server/src/main/java/net/lapidist/colony/server/services/NetworkService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/NetworkService.java
@@ -91,7 +91,12 @@ public final class NetworkService {
                 chunkCount
         );
         connection.sendTCP(meta);
-        LOGGER.info("Sent map metadata with {} chunks to connection {}", chunkCount, connection.getID());
+        LOGGER.info(
+                "Sent map metadata with {} chunks to connection {}: {}",
+                chunkCount,
+                connection.getID(),
+                meta
+        );
     }
 
     private void sendInitialChunks(final Connection connection, final MapState state) {


### PR DESCRIPTION
## Summary
- when clients connect, log the entire `MapMetadata` being sent

## Testing
- `./gradlew clean test check`

------
https://chatgpt.com/codex/tasks/task_e_684d40a7cf2c8328a105944abf657ffe