### PR TITLE
feat(ui): update new game screen map size selection

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/NewGameScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/NewGameScreen.java
@@ -2,6 +2,7 @@ package net.lapidist.colony.client.screens;
 
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.ButtonGroup;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.ui.TextField;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
@@ -16,7 +17,6 @@ public final class NewGameScreen extends BaseScreen {
     private static final int SMALL_SIZE = 30;
     private static final int MEDIUM_SIZE = 60;
     private static final int LARGE_SIZE = 90;
-    private static final int HUGE_SIZE = 120;
     private final Colony colony;
     private int width = GameConstants.MAP_WIDTH;
     private int height = GameConstants.MAP_HEIGHT;
@@ -24,21 +24,25 @@ public final class NewGameScreen extends BaseScreen {
     public NewGameScreen(final Colony game) {
         this.colony = game;
 
-        Label label = new Label(I18n.get("newGame.saveName"), getSkin());
+        Label nameLabel = new Label(I18n.get("newGame.saveName"), getSkin());
         TextField nameField = new TextField("", getSkin());
         TextButton smallButton = new TextButton(I18n.get("newGame.sizeSmall"), getSkin());
         TextButton mediumButton = new TextButton(I18n.get("newGame.sizeMedium"), getSkin());
         TextButton largeButton = new TextButton(I18n.get("newGame.sizeLarge"), getSkin());
-        TextButton hugeButton = new TextButton(I18n.get("newGame.sizeHuge"), getSkin());
         TextButton startButton = new TextButton(I18n.get("newGame.start"), getSkin());
         TextButton backButton = new TextButton(I18n.get("common.back"), getSkin());
 
-        getRoot().add(label).row();
+        ButtonGroup<TextButton> sizeGroup = new ButtonGroup<>(smallButton, mediumButton, largeButton);
+        sizeGroup.setMaxCheckCount(1);
+        sizeGroup.setMinCheckCount(1);
+        sizeGroup.setUncheckLast(true);
+        smallButton.setChecked(true);
+
+        getRoot().add(nameLabel);
         getRoot().add(nameField).width(FIELD_WIDTH).row();
-        getRoot().add(smallButton).row();
-        getRoot().add(mediumButton).row();
+        getRoot().add(smallButton);
+        getRoot().add(mediumButton);
         getRoot().add(largeButton).row();
-        getRoot().add(hugeButton).row();
         getRoot().add(startButton).row();
         getRoot().add(backButton).row();
 
@@ -56,34 +60,33 @@ public final class NewGameScreen extends BaseScreen {
         smallButton.addListener(new ChangeListener() {
             @Override
             public void changed(final ChangeEvent event, final Actor actor) {
-                width = SMALL_SIZE;
-                height = SMALL_SIZE;
+                if (smallButton.isChecked()) {
+                    width = SMALL_SIZE;
+                    height = SMALL_SIZE;
+                }
             }
         });
 
         mediumButton.addListener(new ChangeListener() {
             @Override
             public void changed(final ChangeEvent event, final Actor actor) {
-                width = MEDIUM_SIZE;
-                height = MEDIUM_SIZE;
+                if (mediumButton.isChecked()) {
+                    width = MEDIUM_SIZE;
+                    height = MEDIUM_SIZE;
+                }
             }
         });
 
         largeButton.addListener(new ChangeListener() {
             @Override
             public void changed(final ChangeEvent event, final Actor actor) {
-                width = LARGE_SIZE;
-                height = LARGE_SIZE;
+                if (largeButton.isChecked()) {
+                    width = LARGE_SIZE;
+                    height = LARGE_SIZE;
+                }
             }
         });
 
-        hugeButton.addListener(new ChangeListener() {
-            @Override
-            public void changed(final ChangeEvent event, final Actor actor) {
-                width = HUGE_SIZE;
-                height = HUGE_SIZE;
-            }
-        });
 
         backButton.addListener(new ChangeListener() {
             @Override

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -9,7 +9,6 @@ newGame.start=Start
 newGame.sizeSmall=Small
 newGame.sizeMedium=Medium
 newGame.sizeLarge=Large
-newGame.sizeHuge=Huge
 common.back=Back
 loadGame.delete=Delete
 loadGame.dialogTitle=Delete Save

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -8,7 +8,6 @@ newGame.start=Starten
 newGame.sizeSmall=Klein
 newGame.sizeMedium=Mittel
 newGame.sizeLarge=Groß
-newGame.sizeHuge=Riesig
 common.back=Zurück
 loadGame.delete=Löschen
 loadGame.dialogTitle=Speicher löschen

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -8,7 +8,6 @@ newGame.start=Iniciar
 newGame.sizeSmall=Pequeño
 newGame.sizeMedium=Mediano
 newGame.sizeLarge=Grande
-newGame.sizeHuge=Enorme
 common.back=Atrás
 loadGame.delete=Eliminar
 loadGame.dialogTitle=Eliminar guardado

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -8,7 +8,6 @@ newGame.start=Démarrer
 newGame.sizeSmall=Petit
 newGame.sizeMedium=Moyen
 newGame.sizeLarge=Grand
-newGame.sizeHuge=Énorme
 common.back=Retour
 loadGame.delete=Supprimer
 loadGame.dialogTitle=Supprimer la sauvegarde

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/NewGameScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/NewGameScreenTest.java
@@ -23,8 +23,8 @@ public class NewGameScreenTest {
 
     private static final int NAME_FIELD_INDEX = 1;
     private static final int MEDIUM_BUTTON_INDEX = 3;
-    private static final int START_BUTTON_INDEX = 6;
-    private static final int BACK_BUTTON_INDEX = 7;
+    private static final int START_BUTTON_INDEX = 5;
+    private static final int BACK_BUTTON_INDEX = 6;
     private static final int MEDIUM_SIZE = 60;
 
     private static Table getRoot(final NewGameScreen screen) throws Exception {
@@ -43,6 +43,7 @@ public class NewGameScreenTest {
             TextButton medium = (TextButton) root.getChildren().get(MEDIUM_BUTTON_INDEX);
             TextButton start = (TextButton) root.getChildren().get(START_BUTTON_INDEX);
             field.setText("mysave");
+            medium.setChecked(true);
             medium.fire(new ChangeListener.ChangeEvent());
             start.fire(new ChangeListener.ChangeEvent());
             verify(colony).startGame("mysave", MEDIUM_SIZE, MEDIUM_SIZE);


### PR DESCRIPTION
## Summary
- remove huge map option from NewGameScreen
- toggle small/medium/large buttons as a single group
- align map size buttons horizontally
- show label next to save name field
- adjust NewGameScreen tests
- drop unused `newGame.sizeHuge` translations

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684d402ecde08328972a0a5997fa4f33