### PR TITLE
feat: redesign new game screen layout

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/NewGameScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/NewGameScreen.java
@@ -2,7 +2,8 @@ package net.lapidist.colony.client.screens;
 
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
-import com.badlogic.gdx.scenes.scene2d.ui.ButtonGroup;
+import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.ui.TextField;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
@@ -17,34 +18,39 @@ public final class NewGameScreen extends BaseScreen {
     private static final int SMALL_SIZE = 30;
     private static final int MEDIUM_SIZE = 60;
     private static final int LARGE_SIZE = 90;
+    private static final float PADDING = 10f;
+    private static final int[] SIZES = {SMALL_SIZE, MEDIUM_SIZE, LARGE_SIZE};
+    private static final String[] SIZE_KEYS = {
+            "newGame.sizeSmall",
+            "newGame.sizeMedium",
+            "newGame.sizeLarge"
+    };
     private final Colony colony;
     private int width = GameConstants.MAP_WIDTH;
     private int height = GameConstants.MAP_HEIGHT;
+    private int sizeIndex = 0;
 
     public NewGameScreen(final Colony game) {
         this.colony = game;
 
         Label nameLabel = new Label(I18n.get("newGame.saveName"), getSkin());
         TextField nameField = new TextField("", getSkin());
-        TextButton smallButton = new TextButton(I18n.get("newGame.sizeSmall"), getSkin());
-        TextButton mediumButton = new TextButton(I18n.get("newGame.sizeMedium"), getSkin());
-        TextButton largeButton = new TextButton(I18n.get("newGame.sizeLarge"), getSkin());
+        Label sizeLabel = new Label(I18n.get("newGame.mapSize"), getSkin());
+        TextButton sizeButton = new TextButton(I18n.get(SIZE_KEYS[sizeIndex]), getSkin());
         TextButton startButton = new TextButton(I18n.get("newGame.start"), getSkin());
         TextButton backButton = new TextButton(I18n.get("common.back"), getSkin());
 
-        ButtonGroup<TextButton> sizeGroup = new ButtonGroup<>(smallButton, mediumButton, largeButton);
-        sizeGroup.setMaxCheckCount(1);
-        sizeGroup.setMinCheckCount(1);
-        sizeGroup.setUncheckLast(true);
-        smallButton.setChecked(true);
+        Table options = new Table();
+        options.add(nameLabel);
+        options.add(nameField).width(FIELD_WIDTH).row();
+        options.add(sizeLabel);
+        options.add(sizeButton).row();
 
-        getRoot().add(nameLabel);
-        getRoot().add(nameField).width(FIELD_WIDTH).row();
-        getRoot().add(smallButton);
-        getRoot().add(mediumButton);
-        getRoot().add(largeButton).row();
+        ScrollPane scroll = new ScrollPane(options, getSkin());
+        scroll.setScrollingDisabled(true, false);
+        getRoot().add(scroll).expand().fill().row();
+        getRoot().add(backButton).padRight(PADDING);
         getRoot().add(startButton).row();
-        getRoot().add(backButton).row();
 
         startButton.addListener(new ChangeListener() {
             @Override
@@ -57,33 +63,13 @@ public final class NewGameScreen extends BaseScreen {
             }
         });
 
-        smallButton.addListener(new ChangeListener() {
+        sizeButton.addListener(new ChangeListener() {
             @Override
             public void changed(final ChangeEvent event, final Actor actor) {
-                if (smallButton.isChecked()) {
-                    width = SMALL_SIZE;
-                    height = SMALL_SIZE;
-                }
-            }
-        });
-
-        mediumButton.addListener(new ChangeListener() {
-            @Override
-            public void changed(final ChangeEvent event, final Actor actor) {
-                if (mediumButton.isChecked()) {
-                    width = MEDIUM_SIZE;
-                    height = MEDIUM_SIZE;
-                }
-            }
-        });
-
-        largeButton.addListener(new ChangeListener() {
-            @Override
-            public void changed(final ChangeEvent event, final Actor actor) {
-                if (largeButton.isChecked()) {
-                    width = LARGE_SIZE;
-                    height = LARGE_SIZE;
-                }
+                sizeIndex = (sizeIndex + 1) % SIZES.length;
+                sizeButton.setText(I18n.get(SIZE_KEYS[sizeIndex]));
+                width = SIZES[sizeIndex];
+                height = SIZES[sizeIndex];
             }
         });
 

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -5,6 +5,7 @@ main.loadGame=Load Game
 main.exit=Exit
 main.settings=Settings
 newGame.saveName=Save name
+newGame.mapSize=Map size
 newGame.start=Start
 newGame.sizeSmall=Small
 newGame.sizeMedium=Medium

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -4,6 +4,7 @@ main.loadGame=Spiel Laden
 main.exit=Beenden
 main.settings=Einstellungen
 newGame.saveName=Speichername
+newGame.mapSize=Kartengröße
 newGame.start=Starten
 newGame.sizeSmall=Klein
 newGame.sizeMedium=Mittel

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -4,6 +4,7 @@ main.loadGame=Cargar Partida
 main.exit=Salir
 main.settings=Ajustes
 newGame.saveName=Nombre de guardado
+newGame.mapSize=Tamaño del mapa
 newGame.start=Iniciar
 newGame.sizeSmall=Pequeño
 newGame.sizeMedium=Mediano

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -4,6 +4,7 @@ main.loadGame=Charger Partie
 main.exit=Quitter
 main.settings=Paramètres
 newGame.saveName=Nom de la sauvegarde
+newGame.mapSize=Taille de la carte
 newGame.start=Démarrer
 newGame.sizeSmall=Petit
 newGame.sizeMedium=Moyen

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/NewGameScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/NewGameScreenTest.java
@@ -2,6 +2,7 @@ package net.lapidist.colony.tests.screens;
 
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.ui.TextField;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
@@ -21,10 +22,11 @@ import static org.mockito.Mockito.*;
 @RunWith(GdxTestRunner.class)
 public class NewGameScreenTest {
 
+    private static final int SCROLL_INDEX = 0;
     private static final int NAME_FIELD_INDEX = 1;
-    private static final int MEDIUM_BUTTON_INDEX = 3;
-    private static final int START_BUTTON_INDEX = 5;
-    private static final int BACK_BUTTON_INDEX = 6;
+    private static final int SIZE_BUTTON_INDEX = 3;
+    private static final int BACK_BUTTON_INDEX = 1;
+    private static final int START_BUTTON_INDEX = 2;
     private static final int MEDIUM_SIZE = 60;
 
     private static Table getRoot(final NewGameScreen screen) throws Exception {
@@ -33,18 +35,23 @@ public class NewGameScreenTest {
         return (Table) f.get(screen);
     }
 
+    private static Table getOptions(final NewGameScreen screen) throws Exception {
+        Table root = getRoot(screen);
+        ScrollPane scroll = (ScrollPane) root.getChildren().get(SCROLL_INDEX);
+        return (Table) scroll.getActor();
+    }
+
     @Test
     public void startButtonBeginsGameWithEnteredName() throws Exception {
         Colony colony = mock(Colony.class);
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
             NewGameScreen screen = new NewGameScreen(colony);
-            Table root = getRoot(screen);
-            TextField field = (TextField) root.getChildren().get(NAME_FIELD_INDEX);
-            TextButton medium = (TextButton) root.getChildren().get(MEDIUM_BUTTON_INDEX);
-            TextButton start = (TextButton) root.getChildren().get(START_BUTTON_INDEX);
+            Table options = getOptions(screen);
+            TextField field = (TextField) options.getChildren().get(NAME_FIELD_INDEX);
+            TextButton size = (TextButton) options.getChildren().get(SIZE_BUTTON_INDEX);
+            TextButton start = (TextButton) getRoot(screen).getChildren().get(START_BUTTON_INDEX);
             field.setText("mysave");
-            medium.setChecked(true);
-            medium.fire(new ChangeListener.ChangeEvent());
+            size.fire(new ChangeListener.ChangeEvent());
             start.fire(new ChangeListener.ChangeEvent());
             verify(colony).startGame("mysave", MEDIUM_SIZE, MEDIUM_SIZE);
             screen.dispose();


### PR DESCRIPTION
## Summary
- show map size label and cycle button on NewGameScreen
- keep start/back fixed below scrollable options
- support new translation key `newGame.mapSize`
- adjust tests for new layout

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684d42f74e088328ac238026777db979