### PR TITLE
fix(ui): center new game buttons

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/NewGameScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/NewGameScreen.java
@@ -49,8 +49,12 @@ public final class NewGameScreen extends BaseScreen {
         ScrollPane scroll = new ScrollPane(options, getSkin());
         scroll.setScrollingDisabled(true, false);
         getRoot().add(scroll).expand().fill().row();
-        getRoot().add(backButton).padRight(PADDING);
-        getRoot().add(startButton).row();
+
+        Table buttons = new Table();
+        buttons.add(backButton).padRight(PADDING);
+        buttons.add(startButton);
+
+        getRoot().add(buttons).padBottom(PADDING).bottom();
 
         startButton.addListener(new ChangeListener() {
             @Override

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/NewGameScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/NewGameScreenTest.java
@@ -25,8 +25,9 @@ public class NewGameScreenTest {
     private static final int SCROLL_INDEX = 0;
     private static final int NAME_FIELD_INDEX = 1;
     private static final int SIZE_BUTTON_INDEX = 3;
-    private static final int BACK_BUTTON_INDEX = 1;
-    private static final int START_BUTTON_INDEX = 2;
+    private static final int BUTTON_TABLE_INDEX = 1;
+    private static final int BACK_BUTTON_INDEX = 0;
+    private static final int START_BUTTON_INDEX = 1;
     private static final int MEDIUM_SIZE = 60;
 
     private static Table getRoot(final NewGameScreen screen) throws Exception {
@@ -41,6 +42,11 @@ public class NewGameScreenTest {
         return (Table) scroll.getActor();
     }
 
+    private static Table getButtons(final NewGameScreen screen) throws Exception {
+        Table root = getRoot(screen);
+        return (Table) root.getChildren().get(BUTTON_TABLE_INDEX);
+    }
+
     @Test
     public void startButtonBeginsGameWithEnteredName() throws Exception {
         Colony colony = mock(Colony.class);
@@ -49,7 +55,8 @@ public class NewGameScreenTest {
             Table options = getOptions(screen);
             TextField field = (TextField) options.getChildren().get(NAME_FIELD_INDEX);
             TextButton size = (TextButton) options.getChildren().get(SIZE_BUTTON_INDEX);
-            TextButton start = (TextButton) getRoot(screen).getChildren().get(START_BUTTON_INDEX);
+            Table buttons = getButtons(screen);
+            TextButton start = (TextButton) buttons.getChildren().get(START_BUTTON_INDEX);
             field.setText("mysave");
             size.fire(new ChangeListener.ChangeEvent());
             start.fire(new ChangeListener.ChangeEvent());
@@ -63,7 +70,8 @@ public class NewGameScreenTest {
         Colony colony = mock(Colony.class);
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
             NewGameScreen screen = new NewGameScreen(colony);
-            TextButton back = (TextButton) getRoot(screen).getChildren().get(BACK_BUTTON_INDEX);
+            Table buttons = getButtons(screen);
+            TextButton back = (TextButton) buttons.getChildren().get(BACK_BUTTON_INDEX);
             back.fire(new ChangeListener.ChangeEvent());
             verify(colony).setScreen(isA(MainMenuScreen.class));
             screen.dispose();


### PR DESCRIPTION
## Summary
- center Start/Back buttons horizontally at the bottom of the New Game screen
- adjust tests to handle the new button table layout

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684d4525c5cc83289ac32f6a0e6910eb