### PR TITLE
feat: load autosave metadata for map size

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Both the client and dedicated server can be started directly from Gradle:
 ./gradlew :server:run   # start the dedicated server
 ```
 
+`Colony.startGame(String)` now reads the map size from the selected autosave so
+servers use the correct dimensions when continuing a game.
+
 ## Controls
 Default keyboard mappings can be remapped in game. See
 [docs/controls.md](docs/controls.md) for the full list and instructions.

--- a/client/src/main/java/net/lapidist/colony/client/Colony.java
+++ b/client/src/main/java/net/lapidist/colony/client/Colony.java
@@ -11,6 +11,7 @@ import net.lapidist.colony.settings.Settings;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.server.GameServerConfig;
+import net.lapidist.colony.server.io.GameStateIO;
 import net.lapidist.colony.config.ColonyConfig;
 import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.events.Events;
@@ -39,8 +40,25 @@ public final class Colony extends Game {
         setScreen(new MainMenuScreen(this));
     }
 
+    /**
+     * Starts or resumes a game using the dimensions stored in the autosave file.
+     * Defaults to {@link GameConstants#MAP_WIDTH} and {@link GameConstants#MAP_HEIGHT}
+     * when no save exists.
+     */
     public void startGame(final String saveName) {
-        startGame(saveName, GameConstants.MAP_WIDTH, GameConstants.MAP_HEIGHT);
+        int width = GameConstants.MAP_WIDTH;
+        int height = GameConstants.MAP_HEIGHT;
+        try {
+            java.nio.file.Path file = Paths.get().getAutosave(saveName);
+            if (java.nio.file.Files.exists(file)) {
+                var meta = GameStateIO.readMetadata(file);
+                width = meta.width();
+                height = meta.height();
+            }
+        } catch (IOException e) {
+            // ignore and fall back to defaults
+        }
+        startGame(saveName, width, height);
     }
 
     public void startGame(final String saveName, final int width, final int height) {

--- a/client/src/main/java/net/lapidist/colony/client/screens/LoadGameScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/LoadGameScreen.java
@@ -10,6 +10,7 @@ import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import net.lapidist.colony.i18n.I18n;
 import net.lapidist.colony.client.Colony;
 import net.lapidist.colony.io.Paths;
+import net.lapidist.colony.server.io.GameStateIO;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -36,7 +37,12 @@ public final class LoadGameScreen extends BaseScreen {
             loadButton.addListener(new ChangeListener() {
                 @Override
                 public void changed(final ChangeEvent event, final Actor actor) {
-                    colony.startGame(save);
+                    try {
+                        var meta = GameStateIO.readMetadata(Paths.get().getAutosave(save));
+                        colony.startGame(save, meta.width(), meta.height());
+                    } catch (IOException e) {
+                        colony.startGame(save);
+                    }
                 }
             });
 

--- a/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
@@ -2,6 +2,7 @@ package net.lapidist.colony.save;
 
 import net.lapidist.colony.components.state.MapState;
 
+
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -26,6 +27,7 @@ public final class SaveMigrator {
         register(new V11ToV12Migration());
         register(new V12ToV13Migration());
         register(new V13ToV14Migration());
+        register(new V14ToV15Migration());
     }
 
     private SaveMigrator() {

--- a/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
@@ -17,9 +17,10 @@ public enum SaveVersion {
     V11(11),
     V12(12),
     V13(13),
-    V14(14);
+    V14(14),
+    V15(15);
 
-    public static final SaveVersion CURRENT = V14;
+    public static final SaveVersion CURRENT = V15;
 
     private final int number;
 

--- a/core/src/main/java/net/lapidist/colony/save/V14ToV15Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V14ToV15Migration.java
@@ -1,0 +1,23 @@
+package net.lapidist.colony.save;
+
+import net.lapidist.colony.components.state.MapState;
+
+/** Migration from save version 14 to 15 with no data changes. */
+public final class V14ToV15Migration implements MapStateMigration {
+    @Override
+    public int fromVersion() {
+        return SaveVersion.V14.number();
+    }
+
+    @Override
+    public int toVersion() {
+        return SaveVersion.V15.number();
+    }
+
+    @Override
+    public MapState apply(final MapState state) {
+        return state.toBuilder()
+                .version(toVersion())
+                .build();
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/server/io/AutosaveMetadata.java
+++ b/server/src/main/java/net/lapidist/colony/server/io/AutosaveMetadata.java
@@ -1,0 +1,6 @@
+package net.lapidist.colony.server.io;
+
+/**
+ * Minimal metadata read from an autosave file.
+ */
+public record AutosaveMetadata(int width, int height) { }

--- a/server/src/main/java/net/lapidist/colony/server/io/GameStateIO.java
+++ b/server/src/main/java/net/lapidist/colony/server/io/GameStateIO.java
@@ -43,5 +43,13 @@ public final class GameStateIO {
         }
     }
 
+    /**
+     * Reads only the map dimensions from the supplied autosave file.
+     */
+    public static AutosaveMetadata readMetadata(final Path file) throws IOException {
+        MapState state = load(file);
+        return new AutosaveMetadata(state.width(), state.height());
+    }
+
     // Class registration handled by KryoRegistry
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationLargeMapLoadTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationLargeMapLoadTest.java
@@ -1,0 +1,41 @@
+package net.lapidist.colony.tests.scenario;
+
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.server.GameServer;
+import net.lapidist.colony.server.GameServerConfig;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+/** Regression test ensuring larger maps load without hanging. */
+@RunWith(net.lapidist.colony.tests.GdxTestRunner.class)
+public class GameSimulationLargeMapLoadTest {
+
+    @Test
+    public void clientLoadsLargeMap() throws Exception {
+        final int size = 60;
+        GameServer server = new GameServer(GameServerConfig.builder()
+                .width(size)
+                .height(size)
+                .build());
+        server.start();
+
+        GameClient client = new GameClient();
+        CountDownLatch latch = new CountDownLatch(1);
+        client.start(state -> latch.countDown());
+        latch.await(2, TimeUnit.SECONDS);
+
+        assertTrue(client.isConnected());
+        MapState state = client.getMapState();
+        assertNotNull(state);
+
+
+        client.stop();
+        server.stop();
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/LoadGameScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/LoadGameScreenTest.java
@@ -9,6 +9,8 @@ import net.lapidist.colony.client.Colony;
 import net.lapidist.colony.client.screens.LoadGameScreen;
 import net.lapidist.colony.client.screens.MainMenuScreen;
 import net.lapidist.colony.io.Paths;
+import net.lapidist.colony.server.io.GameStateIO;
+import net.lapidist.colony.components.state.MapState;
 import org.mockito.MockedConstruction;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
@@ -53,9 +55,18 @@ public class LoadGameScreenTest {
     @Test
     public void loadButtonStartsGame() throws Exception {
         String save = "test-" + UUID.randomUUID();
-        Path folder = Path.of(System.getProperty("user.home"), ".colony", "saves");
+        Path folder = Path.of(
+                System.getProperty("user.home"),
+                ".colony",
+                "saves"
+        );
         Files.createDirectories(folder);
-        Files.createFile(folder.resolve(save + Paths.AUTOSAVE_SUFFIX));
+        final int size = 60;
+        MapState state = MapState.builder()
+                .width(size)
+                .height(size)
+                .build();
+        GameStateIO.save(state, folder.resolve(save + Paths.AUTOSAVE_SUFFIX));
 
         Colony colony = mock(Colony.class);
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
@@ -74,7 +85,7 @@ public class LoadGameScreenTest {
             TextButton load = (TextButton) row.getChildren().get(0);
             load.fire(new ChangeListener.ChangeEvent());
 
-            verify(colony).startGame(save);
+            verify(colony).startGame(save, size, size);
             Files.deleteIfExists(folder.resolve(save + Paths.AUTOSAVE_SUFFIX));
             screen.dispose();
         }

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV14Test.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV14Test.java
@@ -1,0 +1,41 @@
+package net.lapidist.colony.tests.server;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Output;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.serialization.KryoRegistry;
+import net.lapidist.colony.save.SaveData;
+import net.lapidist.colony.save.SaveVersion;
+import net.lapidist.colony.serialization.SerializationRegistrar;
+import net.lapidist.colony.server.io.GameStateIO;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+
+public class GameStateIOMigrationV14Test {
+
+    @Test
+    public void migratesV14ToCurrent() throws Exception {
+        Path file = Files.createTempFile("state", ".dat");
+        MapState state = MapState.builder()
+                .version(SaveVersion.V14.number())
+                .build();
+        Kryo kryo = new Kryo();
+        KryoRegistry.register(kryo);
+        try (Output output = new Output(Files.newOutputStream(file))) {
+            SaveData data = new SaveData(
+                    SaveVersion.V14.number(),
+                    SerializationRegistrar.registrationHash(),
+                    state
+            );
+            kryo.writeObject(output, data);
+        }
+
+        MapState loaded = GameStateIO.load(file);
+        Files.deleteIfExists(file);
+        assertEquals(SaveVersion.CURRENT.number(), loaded.version());
+    }
+}


### PR DESCRIPTION
## Summary
- load map dimensions from autosave metadata
- allow `LoadGameScreen` to pass dimensions to `startGame`
- bump save version and add migration
- document automatic dimension detection
- test map loading with larger dimensions

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`

------
https://chatgpt.com/codex/tasks/task_e_684d492b703083289f33de7035bb5312