### PR TITLE
feat(ui): add resource icons

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/ui/PlayerResourcesActor.java
+++ b/client/src/main/java/net/lapidist/colony/client/ui/PlayerResourcesActor.java
@@ -4,22 +4,52 @@ import com.artemis.Aspect;
 import com.artemis.ComponentMapper;
 import com.artemis.Entity;
 import com.artemis.World;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
 import net.lapidist.colony.components.resources.PlayerResourceComponent;
 
 /** Displays the player's resource counts. */
 public final class PlayerResourcesActor extends Table {
+    private static final float ICON_SIZE = 16f;
+    private static final float PAD_SMALL = 2f;
+    private static final float PAD_LARGE = 6f;
+
     private final World world;
-    private final Label label;
+    private final Label woodLabel;
+    private final Label stoneLabel;
+    private final Label foodLabel;
     private ComponentMapper<PlayerResourceComponent> mapper;
     private Entity player;
+    private final Image woodIcon;
+    private final Image stoneIcon;
+    private final Image foodIcon;
 
     public PlayerResourcesActor(final Skin skin, final World worldToUse) {
         this.world = worldToUse;
-        this.label = new Label("", skin);
-        add(label);
+
+        woodLabel = new Label("", skin);
+        stoneLabel = new Label("", skin);
+        foodLabel = new Label("", skin);
+
+        woodIcon = new Image(new TextureRegionDrawable(new Texture(Gdx.files.internal("textures/wood.png"))));
+        stoneIcon = new Image(new TextureRegionDrawable(new Texture(Gdx.files.internal("textures/stone.png"))));
+        foodIcon = new Image(new TextureRegionDrawable(new Texture(Gdx.files.internal("textures/food.png"))));
+
+        woodIcon.setSize(ICON_SIZE, ICON_SIZE);
+        stoneIcon.setSize(ICON_SIZE, ICON_SIZE);
+        foodIcon.setSize(ICON_SIZE, ICON_SIZE);
+
+        add(woodIcon).size(ICON_SIZE, ICON_SIZE).padRight(PAD_SMALL);
+        add(woodLabel).padRight(PAD_LARGE);
+        add(stoneIcon).size(ICON_SIZE, ICON_SIZE).padRight(PAD_SMALL);
+        add(stoneLabel).padRight(PAD_LARGE);
+        add(foodIcon).size(ICON_SIZE, ICON_SIZE).padRight(PAD_SMALL);
+        add(foodLabel);
     }
 
     @Override
@@ -38,7 +68,9 @@ public final class PlayerResourcesActor extends Table {
         }
         if (player != null) {
             PlayerResourceComponent pr = mapper.get(player);
-            label.setText("W:" + pr.getWood() + " S:" + pr.getStone() + " F:" + pr.getFood());
+            woodLabel.setText(String.valueOf(pr.getWood()));
+            stoneLabel.setText(String.valueOf(pr.getStone()));
+            foodLabel.setText(String.valueOf(pr.getFood()));
         }
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/ui/PlayerResourcesActorTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/ui/PlayerResourcesActorTest.java
@@ -38,9 +38,17 @@ public class PlayerResourcesActorTest {
         PlayerResourcesActor actor = new PlayerResourcesActor(skin, world);
         actor.act(0f);
 
-        Field labelField = PlayerResourcesActor.class.getDeclaredField("label");
-        labelField.setAccessible(true);
-        Label label = (Label) labelField.get(actor);
-        assertEquals("W:" + WOOD + " S:" + STONE + " F:" + FOOD, label.getText().toString());
+        Field woodField = PlayerResourcesActor.class.getDeclaredField("woodLabel");
+        Field stoneField = PlayerResourcesActor.class.getDeclaredField("stoneLabel");
+        Field foodField = PlayerResourcesActor.class.getDeclaredField("foodLabel");
+        woodField.setAccessible(true);
+        stoneField.setAccessible(true);
+        foodField.setAccessible(true);
+        Label wood = (Label) woodField.get(actor);
+        Label stone = (Label) stoneField.get(actor);
+        Label food = (Label) foodField.get(actor);
+        assertEquals(String.valueOf(WOOD), wood.getText().toString());
+        assertEquals(String.valueOf(STONE), stone.getText().toString());
+        assertEquals(String.valueOf(FOOD), food.getText().toString());
     }
 }


### PR DESCRIPTION
## Summary
- use new wood/stone/food textures in the UI
- show each player resource with an icon and numeric label
- update PlayerResourcesActor test

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684d4d588f58832890940a7f201bf33a