### PR TITLE
Remove map size from default config

### DIFF
--- a/core/src/main/java/net/lapidist/colony/components/GameConstants.java
+++ b/core/src/main/java/net/lapidist/colony/components/GameConstants.java
@@ -5,8 +5,9 @@ import net.lapidist.colony.config.ColonyConfig;
 public final class GameConstants {
     private GameConstants() { }
 
-    public static final int MAP_WIDTH = ColonyConfig.get().getInt("game.mapWidth");
-    public static final int MAP_HEIGHT = ColonyConfig.get().getInt("game.mapHeight");
+    // Default map size used before metadata is loaded
+    public static final int MAP_WIDTH = 30;
+    public static final int MAP_HEIGHT = 30;
     public static final int TILE_SIZE = ColonyConfig.get().getInt("game.tileSize");
     public static final int CHUNK_LOAD_RADIUS = ColonyConfig.get().getInt("game.chunkLoadRadius");
     public static final int NETWORK_BUFFER_SIZE = ColonyConfig.get().getInt("game.networkBufferSize");

--- a/core/src/main/resources/game.conf
+++ b/core/src/main/resources/game.conf
@@ -1,6 +1,4 @@
 game {
-  mapWidth = 30
-  mapHeight = 30
   tileSize = 32
   chunkLoadRadius = 1
   autosaveInterval = 600000

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,12 +1,11 @@
 # Configuration
 
-Default settings are read from `core/src/main/resources/game.conf`. The file
-controls the initial map size, network buffer size, autosave interval and server ports:
+Default settings are read from `core/src/main/resources/game.conf`.
+The file controls the network buffer size, autosave interval and server ports.
+Map size is determined when creating a game or loading a save:
 
 ```hocon
 game {
-  mapWidth = 30
-  mapHeight = 30
   tileSize = 32
   autosaveInterval = 600000
   defaultSaveName = "autosave"


### PR DESCRIPTION
## Summary
- delete deprecated mapWidth/mapHeight options from game.conf
- document that map size is chosen when a game is created or a save is loaded
- use fixed defaults for MAP_WIDTH and MAP_HEIGHT

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684d51f159188328968376a20ca935fd