### PR TITLE
refactor: remove map dimension constants

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/Colony.java
+++ b/client/src/main/java/net/lapidist/colony/client/Colony.java
@@ -13,7 +13,7 @@ import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.server.GameServerConfig;
 import net.lapidist.colony.server.io.GameStateIO;
 import net.lapidist.colony.config.ColonyConfig;
-import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.events.Events;
 import net.lapidist.colony.client.events.GameInitEvent;
 import net.lapidist.colony.mod.GameMod;
@@ -42,12 +42,13 @@ public final class Colony extends Game {
 
     /**
      * Starts or resumes a game using the dimensions stored in the autosave file.
-     * Defaults to {@link GameConstants#MAP_WIDTH} and {@link GameConstants#MAP_HEIGHT}
+     * Defaults to {@link net.lapidist.colony.components.state.MapState#DEFAULT_WIDTH}
+     * and {@link net.lapidist.colony.components.state.MapState#DEFAULT_HEIGHT}
      * when no save exists.
      */
     public void startGame(final String saveName) {
-        int width = GameConstants.MAP_WIDTH;
-        int height = GameConstants.MAP_HEIGHT;
+        int width = MapState.DEFAULT_WIDTH;
+        int height = MapState.DEFAULT_HEIGHT;
         try {
             java.nio.file.Path file = Paths.get().getAutosave(saveName);
             if (java.nio.file.Files.exists(file)) {

--- a/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
+++ b/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
@@ -60,8 +60,8 @@ public final class GameClient extends AbstractMessageEndpoint {
     private java.util.Map<TilePos, TileData> tileBuffer;
     private int expectedChunks;
     private int receivedChunks;
-    private int mapWidth = GameConstants.MAP_WIDTH;
-    private int mapHeight = GameConstants.MAP_HEIGHT;
+    private int mapWidth = MapState.DEFAULT_WIDTH;
+    private int mapHeight = MapState.DEFAULT_HEIGHT;
     private java.util.function.Consumer<Float> loadProgressListener;
     private java.util.function.Consumer<String> loadMessageListener;
 

--- a/client/src/main/java/net/lapidist/colony/client/render/MapRenderDataBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/render/MapRenderDataBuilder.java
@@ -10,7 +10,7 @@ import net.lapidist.colony.components.entities.BuildingComponent;
 import net.lapidist.colony.components.maps.MapComponent;
 import net.lapidist.colony.components.maps.TileComponent;
 import net.lapidist.colony.components.resources.ResourceComponent;
-import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.components.state.MapState;
 
 /** Utility to convert {@link MapComponent} to {@link MapRenderData}. */
 public final class MapRenderDataBuilder {
@@ -18,7 +18,7 @@ public final class MapRenderDataBuilder {
     }
 
     public static MapRenderData fromMap(final MapComponent map, final World world) {
-        return fromMap(map, world, GameConstants.MAP_WIDTH, GameConstants.MAP_HEIGHT);
+        return fromMap(map, world, MapState.DEFAULT_WIDTH, MapState.DEFAULT_HEIGHT);
     }
 
     public static MapRenderData fromMap(

--- a/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
@@ -12,7 +12,7 @@ import net.lapidist.colony.client.util.CameraUtils;
 import net.lapidist.colony.client.render.data.RenderTile;
 import net.lapidist.colony.client.render.MapRenderData;
 import net.lapidist.colony.client.TileRotationUtil;
-import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.maps.TileComponent;
 
 /**
@@ -79,8 +79,8 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
                 tmpEnd
         );
 
-        int mapWidth = client != null ? client.getMapWidth() : GameConstants.MAP_WIDTH;
-        int mapHeight = client != null ? client.getMapHeight() : GameConstants.MAP_HEIGHT;
+        int mapWidth = client != null ? client.getMapWidth() : MapState.DEFAULT_WIDTH;
+        int mapHeight = client != null ? client.getMapHeight() : MapState.DEFAULT_HEIGHT;
 
         int startX = Math.max(0, (int) start.x - 1);
         int startY = Math.max(0, (int) start.y - 1);

--- a/client/src/main/java/net/lapidist/colony/client/screens/NewGameScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/NewGameScreen.java
@@ -9,7 +9,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.TextField;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import net.lapidist.colony.client.Colony;
 import net.lapidist.colony.i18n.I18n;
-import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.components.state.MapState;
 
 import java.util.UUID;
 
@@ -26,8 +26,8 @@ public final class NewGameScreen extends BaseScreen {
             "newGame.sizeLarge"
     };
     private final Colony colony;
-    private int width = GameConstants.MAP_WIDTH;
-    private int height = GameConstants.MAP_HEIGHT;
+    private int width = MapState.DEFAULT_WIDTH;
+    private int height = MapState.DEFAULT_HEIGHT;
     private int sizeIndex = 0;
 
     public NewGameScreen(final Colony game) {

--- a/client/src/main/java/net/lapidist/colony/client/systems/MapRenderDataSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/MapRenderDataSystem.java
@@ -72,10 +72,10 @@ public final class MapRenderDataSystem extends BaseSystem {
         if (map != null) {
             int width = client != null
                     ? client.getMapWidth()
-                    : net.lapidist.colony.components.GameConstants.MAP_WIDTH;
+                    : net.lapidist.colony.components.state.MapState.DEFAULT_WIDTH;
             int height = client != null
                     ? client.getMapHeight()
-                    : net.lapidist.colony.components.GameConstants.MAP_HEIGHT;
+                    : net.lapidist.colony.components.state.MapState.DEFAULT_HEIGHT;
             renderData = MapRenderDataBuilder.fromMap(map, world, width, height);
             lastVersion = map.getVersion();
             rebuildSelectedIndices();
@@ -93,10 +93,10 @@ public final class MapRenderDataSystem extends BaseSystem {
         if (renderData == null) {
             int width = client != null
                     ? client.getMapWidth()
-                    : net.lapidist.colony.components.GameConstants.MAP_WIDTH;
+                    : net.lapidist.colony.components.state.MapState.DEFAULT_WIDTH;
             int height = client != null
                     ? client.getMapHeight()
-                    : net.lapidist.colony.components.GameConstants.MAP_HEIGHT;
+                    : net.lapidist.colony.components.state.MapState.DEFAULT_HEIGHT;
             renderData = MapRenderDataBuilder.fromMap(map, world, width, height);
             lastVersion = map.getVersion();
             rebuildSelectedIndices();

--- a/client/src/main/java/net/lapidist/colony/client/systems/PlayerCameraSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/PlayerCameraSystem.java
@@ -10,6 +10,7 @@ import com.badlogic.gdx.utils.viewport.ExtendViewport;
 import com.badlogic.gdx.utils.viewport.Viewport;
 import net.lapidist.colony.client.util.CameraUtils;
 import net.lapidist.colony.components.entities.PlayerComponent;
+import net.lapidist.colony.components.state.MapState;
 import com.artemis.ComponentMapper;
 import com.artemis.Entity;
 
@@ -69,8 +70,8 @@ public final class PlayerCameraSystem extends BaseSystem implements CameraProvid
     }
 
     public Vector2 getWorldCenter() {
-        int width = client != null ? client.getMapWidth() : net.lapidist.colony.components.GameConstants.MAP_WIDTH;
-        int height = client != null ? client.getMapHeight() : net.lapidist.colony.components.GameConstants.MAP_HEIGHT;
+        int width = client != null ? client.getMapWidth() : MapState.DEFAULT_WIDTH;
+        int height = client != null ? client.getMapHeight() : MapState.DEFAULT_HEIGHT;
         return CameraUtils.getWorldCenter(width, height);
     }
 

--- a/client/src/main/java/net/lapidist/colony/client/systems/PlayerInitSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/PlayerInitSystem.java
@@ -43,9 +43,9 @@ public final class PlayerInitSystem extends BaseSystem {
             pr.setFood(initialResources.food());
             PlayerComponent pc = new PlayerComponent();
             int width = client != null ? client.getMapWidth()
-                    : net.lapidist.colony.components.GameConstants.MAP_WIDTH;
+                    : net.lapidist.colony.components.state.MapState.DEFAULT_WIDTH;
             int height = client != null ? client.getMapHeight()
-                    : net.lapidist.colony.components.GameConstants.MAP_HEIGHT;
+                    : net.lapidist.colony.components.state.MapState.DEFAULT_HEIGHT;
             var pos = initialPosition != null
                     ? CameraUtils.tileCoordsToWorldCoords(initialPosition.x(), initialPosition.y())
                     : CameraUtils.getWorldCenter(width, height);

--- a/client/src/main/java/net/lapidist/colony/client/systems/PlayerMovementSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/PlayerMovementSystem.java
@@ -6,6 +6,7 @@ import com.artemis.Entity;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.math.MathUtils;
 import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.entities.PlayerComponent;
 import net.lapidist.colony.settings.KeyAction;
 import net.lapidist.colony.settings.KeyBindings;
@@ -67,8 +68,8 @@ public final class PlayerMovementSystem extends BaseSystem {
     }
 
     private void clampPosition(final PlayerComponent pc) {
-        float mapWidth = client != null ? client.getMapWidth() : GameConstants.MAP_WIDTH;
-        float mapHeight = client != null ? client.getMapHeight() : GameConstants.MAP_HEIGHT;
+        float mapWidth = client != null ? client.getMapWidth() : MapState.DEFAULT_WIDTH;
+        float mapHeight = client != null ? client.getMapHeight() : MapState.DEFAULT_HEIGHT;
         float maxX = mapWidth * GameConstants.TILE_SIZE;
         float maxY = mapHeight * GameConstants.TILE_SIZE;
         pc.setX(MathUtils.clamp(pc.getX(), 0, maxX));

--- a/client/src/main/java/net/lapidist/colony/client/systems/input/KeyboardInputHandler.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/input/KeyboardInputHandler.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.utils.viewport.ExtendViewport;
 import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
 import net.lapidist.colony.settings.KeyAction;
 import net.lapidist.colony.settings.KeyBindings;
@@ -64,8 +65,8 @@ public final class KeyboardInputHandler {
             return;
         }
         final Vector3 position = cameraSystem.getCamera().position;
-        float width = client != null ? client.getMapWidth() : GameConstants.MAP_WIDTH;
-        float height = client != null ? client.getMapHeight() : GameConstants.MAP_HEIGHT;
+        float width = client != null ? client.getMapWidth() : MapState.DEFAULT_WIDTH;
+        float height = client != null ? client.getMapHeight() : MapState.DEFAULT_HEIGHT;
         final float mapWidth = width * GameConstants.TILE_SIZE;
         final float mapHeight = height * GameConstants.TILE_SIZE;
 

--- a/client/src/main/java/net/lapidist/colony/client/ui/MinimapActor.java
+++ b/client/src/main/java/net/lapidist/colony/client/ui/MinimapActor.java
@@ -9,6 +9,7 @@ import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
 import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.client.core.io.FileLocation;
 import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.client.core.io.TextureAtlasResourceLoader;
@@ -68,11 +69,11 @@ public final class MinimapActor extends Actor implements Disposable {
         }
 
         if (mapWidthWorld == 0) {
-            int width = client != null ? client.getMapWidth() : GameConstants.MAP_WIDTH;
+            int width = client != null ? client.getMapWidth() : MapState.DEFAULT_WIDTH;
             mapWidthWorld = width * GameConstants.TILE_SIZE;
         }
         if (mapHeightWorld == 0) {
-            int height = client != null ? client.getMapHeight() : GameConstants.MAP_HEIGHT;
+            int height = client != null ? client.getMapHeight() : MapState.DEFAULT_HEIGHT;
             mapHeightWorld = height * GameConstants.TILE_SIZE;
         }
     }

--- a/client/src/main/java/net/lapidist/colony/client/util/CameraUtils.java
+++ b/client/src/main/java/net/lapidist/colony/client/util/CameraUtils.java
@@ -8,6 +8,7 @@ import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.viewport.ExtendViewport;
 import com.badlogic.gdx.utils.viewport.Viewport;
 import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.components.state.MapState;
 
 /**
  * Utility methods for converting between tile, world and screen coordinates.
@@ -128,7 +129,7 @@ public final class CameraUtils {
     }
 
     public static Vector2 getWorldCenter() {
-        return getWorldCenter(GameConstants.MAP_WIDTH, GameConstants.MAP_HEIGHT);
+        return getWorldCenter(MapState.DEFAULT_WIDTH, MapState.DEFAULT_HEIGHT);
     }
 
     public static Rectangle getViewBounds(

--- a/core/src/main/java/net/lapidist/colony/components/GameConstants.java
+++ b/core/src/main/java/net/lapidist/colony/components/GameConstants.java
@@ -5,9 +5,6 @@ import net.lapidist.colony.config.ColonyConfig;
 public final class GameConstants {
     private GameConstants() { }
 
-    // Default map size used before metadata is loaded
-    public static final int MAP_WIDTH = 30;
-    public static final int MAP_HEIGHT = 30;
     public static final int TILE_SIZE = ColonyConfig.get().getInt("game.tileSize");
     public static final int CHUNK_LOAD_RADIUS = ColonyConfig.get().getInt("game.chunkLoadRadius");
     public static final int NETWORK_BUFFER_SIZE = ColonyConfig.get().getInt("game.networkBufferSize");

--- a/core/src/main/java/net/lapidist/colony/components/state/MapState.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/MapState.java
@@ -2,7 +2,6 @@ package net.lapidist.colony.components.state;
 
 import net.lapidist.colony.serialization.KryoType;
 import net.lapidist.colony.save.SaveVersion;
-import net.lapidist.colony.components.GameConstants;
 
 import net.lapidist.colony.map.MapChunkData;
 
@@ -28,6 +27,8 @@ public record MapState(
         int height
 ) {
     public static final int CURRENT_VERSION = SaveVersion.CURRENT.number();
+    public static final int DEFAULT_WIDTH = 30;
+    public static final int DEFAULT_HEIGHT = 30;
 
     public MapState() {
         this(
@@ -39,10 +40,10 @@ public record MapState(
                 new HashMap<>(),
                 new ArrayList<>(),
                 new ResourceData(),
-                new PlayerPosition(GameConstants.MAP_WIDTH / 2, GameConstants.MAP_HEIGHT / 2),
-                new CameraPosition(GameConstants.MAP_WIDTH / 2f, GameConstants.MAP_HEIGHT / 2f),
-                GameConstants.MAP_WIDTH,
-                GameConstants.MAP_HEIGHT
+                new PlayerPosition(DEFAULT_WIDTH / 2, DEFAULT_HEIGHT / 2),
+                new CameraPosition(DEFAULT_WIDTH / 2f, DEFAULT_HEIGHT / 2f),
+                DEFAULT_WIDTH,
+                DEFAULT_HEIGHT
         );
     }
 

--- a/core/src/main/java/net/lapidist/colony/save/V10ToV11Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V10ToV11Migration.java
@@ -1,6 +1,5 @@
 package net.lapidist.colony.save;
 
-import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.components.state.CameraPosition;
 import net.lapidist.colony.components.state.MapState;
 
@@ -20,8 +19,8 @@ public final class V10ToV11Migration implements MapStateMigration {
     public MapState apply(final MapState state) {
         return state.toBuilder()
                 .cameraPos(new CameraPosition(
-                        GameConstants.MAP_WIDTH / 2f,
-                        GameConstants.MAP_HEIGHT / 2f))
+                        MapState.DEFAULT_WIDTH / 2f,
+                        MapState.DEFAULT_HEIGHT / 2f))
                 .version(toVersion())
                 .build();
     }

--- a/core/src/main/java/net/lapidist/colony/save/V13ToV14Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V13ToV14Migration.java
@@ -1,6 +1,5 @@
 package net.lapidist.colony.save;
 
-import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.components.state.MapState;
 
 /** Migration from save version 13 to 14 adding map dimensions. */
@@ -18,8 +17,8 @@ public final class V13ToV14Migration implements MapStateMigration {
     @Override
     public MapState apply(final MapState state) {
         return state.toBuilder()
-                .width(GameConstants.MAP_WIDTH)
-                .height(GameConstants.MAP_HEIGHT)
+                .width(MapState.DEFAULT_WIDTH)
+                .height(MapState.DEFAULT_HEIGHT)
                 .version(toVersion())
                 .build();
     }

--- a/core/src/main/java/net/lapidist/colony/save/V7ToV8Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V7ToV8Migration.java
@@ -1,6 +1,5 @@
 package net.lapidist.colony.save;
 
-import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.PlayerPosition;
 
@@ -20,8 +19,8 @@ public final class V7ToV8Migration implements MapStateMigration {
     public MapState apply(final MapState state) {
         return state.toBuilder()
                 .playerPos(new PlayerPosition(
-                        GameConstants.MAP_WIDTH / 2,
-                        GameConstants.MAP_HEIGHT / 2))
+                        MapState.DEFAULT_WIDTH / 2,
+                        MapState.DEFAULT_HEIGHT / 2))
                 .version(toVersion())
                 .build();
     }

--- a/server/src/main/java/net/lapidist/colony/server/GameServerConfig.java
+++ b/server/src/main/java/net/lapidist/colony/server/GameServerConfig.java
@@ -1,7 +1,7 @@
 package net.lapidist.colony.server;
 
 import net.lapidist.colony.config.ColonyConfig;
-import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.map.ChunkedMapGenerator;
 import net.lapidist.colony.map.MapGenerator;
 
@@ -12,8 +12,8 @@ public final class GameServerConfig {
 
     static final String DEFAULT_SAVE_NAME = ColonyConfig.get().getString("game.defaultSaveName");
     static final long DEFAULT_INTERVAL = ColonyConfig.get().getLong("game.autosaveInterval");
-    static final int DEFAULT_WIDTH = GameConstants.MAP_WIDTH;
-    static final int DEFAULT_HEIGHT = GameConstants.MAP_HEIGHT;
+    static final int DEFAULT_WIDTH = MapState.DEFAULT_WIDTH;
+    static final int DEFAULT_HEIGHT = MapState.DEFAULT_HEIGHT;
 
     private String saveName = DEFAULT_SAVE_NAME;
     private long autosaveInterval = DEFAULT_INTERVAL;

--- a/tests/src/jmh/java/net/lapidist/colony/client/renderers/MapTileCacheBenchmark.java
+++ b/tests/src/jmh/java/net/lapidist/colony/client/renderers/MapTileCacheBenchmark.java
@@ -69,8 +69,8 @@ public class MapTileCacheBenchmark {
     private static CameraProvider createCamera() {
         OrthographicCamera cam = new OrthographicCamera();
         ExtendViewport vp = new ExtendViewport(
-                GameConstants.MAP_WIDTH * GameConstants.TILE_SIZE,
-                GameConstants.MAP_HEIGHT * GameConstants.TILE_SIZE,
+                MapState.DEFAULT_WIDTH * GameConstants.TILE_SIZE,
+                MapState.DEFAULT_HEIGHT * GameConstants.TILE_SIZE,
                 cam
         );
         vp.update((int) vp.getWorldWidth(), (int) vp.getWorldHeight(), true);

--- a/tests/src/jmh/java/net/lapidist/colony/tests/benchmarks/SpriteBatchRendererBenchmark.java
+++ b/tests/src/jmh/java/net/lapidist/colony/tests/benchmarks/SpriteBatchRendererBenchmark.java
@@ -84,8 +84,8 @@ public class SpriteBatchRendererBenchmark {
     private static CameraProvider createCamera() {
         OrthographicCamera cam = new OrthographicCamera();
         ExtendViewport vp = new ExtendViewport(
-                GameConstants.MAP_WIDTH * GameConstants.TILE_SIZE,
-                GameConstants.MAP_HEIGHT * GameConstants.TILE_SIZE,
+                MapState.DEFAULT_WIDTH * GameConstants.TILE_SIZE,
+                MapState.DEFAULT_HEIGHT * GameConstants.TILE_SIZE,
                 cam
         );
         vp.update((int) vp.getWorldWidth(), (int) vp.getWorldHeight(), true);

--- a/tests/src/test/java/net/lapidist/colony/client/renderers/MapTileCacheTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/renderers/MapTileCacheTest.java
@@ -21,7 +21,6 @@ import com.badlogic.gdx.utils.viewport.ExtendViewport;
 import net.lapidist.colony.components.maps.MapComponent;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.map.MapFactory;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
@@ -82,7 +81,7 @@ public class MapTileCacheTest {
                 .wood(0).stone(0).food(0)
                 .build();
         tiles.add(tile2);
-        RenderTile[][] grid = new RenderTile[GameConstants.MAP_WIDTH][GameConstants.MAP_HEIGHT];
+        RenderTile[][] grid = new RenderTile[MapState.DEFAULT_WIDTH][MapState.DEFAULT_HEIGHT];
         grid[0][0] = tile1;
         grid[1][0] = tile2;
         return new SimpleMapRenderData(tiles, new Array<RenderBuilding>(), grid);

--- a/tests/src/test/java/net/lapidist/colony/tests/client/input/KeyboardInputHandlerTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/input/KeyboardInputHandlerTest.java
@@ -8,6 +8,7 @@ import net.lapidist.colony.client.systems.input.KeyboardInputHandler;
 import net.lapidist.colony.settings.KeyAction;
 import net.lapidist.colony.settings.KeyBindings;
 import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,8 +42,8 @@ public class KeyboardInputHandlerTest {
         assertEquals(0f, cameraSystem.getCamera().position.y, TOL);
 
         cameraSystem.getCamera().position.set(
-                GameConstants.MAP_WIDTH * GameConstants.TILE_SIZE + OFFSET_X,
-                GameConstants.MAP_HEIGHT * GameConstants.TILE_SIZE + OFFSET_Y,
+                MapState.DEFAULT_WIDTH * GameConstants.TILE_SIZE + OFFSET_X,
+                MapState.DEFAULT_HEIGHT * GameConstants.TILE_SIZE + OFFSET_Y,
                 0f
         );
         handler.clampCameraPosition();
@@ -52,9 +53,9 @@ public class KeyboardInputHandlerTest {
         float halfW = viewport.getWorldWidth() * cam.zoom / 2f;
         float halfH = viewport.getWorldHeight() * cam.zoom / 2f;
 
-        assertEquals(GameConstants.MAP_WIDTH * GameConstants.TILE_SIZE - halfW,
+        assertEquals(MapState.DEFAULT_WIDTH * GameConstants.TILE_SIZE - halfW,
                 cameraSystem.getCamera().position.x, TOL);
-        assertEquals(GameConstants.MAP_HEIGHT * GameConstants.TILE_SIZE - halfH,
+        assertEquals(MapState.DEFAULT_HEIGHT * GameConstants.TILE_SIZE - halfH,
                 cameraSystem.getCamera().position.y, TOL);
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/render/data/MapRenderDataBuilderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/render/data/MapRenderDataBuilderTest.java
@@ -37,8 +37,7 @@ public class MapRenderDataBuilderTest {
 
         MapRenderData data = MapRenderDataBuilder.fromMap(map, world);
         assertEquals(
-                net.lapidist.colony.components.GameConstants.MAP_WIDTH
-                        * net.lapidist.colony.components.GameConstants.MAP_HEIGHT,
+                state.width() * state.height(),
                 data.getTiles().size
         );
         assertEquals(1, data.getBuildings().size);

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/BuildingRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/BuildingRendererTest.java
@@ -16,7 +16,7 @@ import net.lapidist.colony.client.render.data.RenderBuilding;
 import net.lapidist.colony.client.render.MapRenderData;
 import net.lapidist.colony.client.render.SimpleMapRenderData;
 import net.lapidist.colony.client.render.data.RenderTile;
-import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,7 +50,7 @@ public class BuildingRendererTest {
         buildings.add(building);
 
         MapRenderData map = new SimpleMapRenderData(new Array<RenderTile>(), buildings,
-                new RenderTile[GameConstants.MAP_WIDTH][GameConstants.MAP_HEIGHT]);
+                new RenderTile[MapState.DEFAULT_WIDTH][MapState.DEFAULT_HEIGHT]);
 
         renderer.render(map);
 
@@ -80,7 +80,7 @@ public class BuildingRendererTest {
         buildings.add(building);
 
         MapRenderData map = new SimpleMapRenderData(new Array<RenderTile>(), buildings,
-                new RenderTile[GameConstants.MAP_WIDTH][GameConstants.MAP_HEIGHT]);
+                new RenderTile[MapState.DEFAULT_WIDTH][MapState.DEFAULT_HEIGHT]);
 
         renderer.render(map);
         renderer.render(map);
@@ -123,7 +123,7 @@ public class BuildingRendererTest {
         buildings.add(building);
 
         MapRenderData map = new SimpleMapRenderData(new Array<RenderTile>(), buildings,
-                new RenderTile[GameConstants.MAP_WIDTH][GameConstants.MAP_HEIGHT]);
+                new RenderTile[MapState.DEFAULT_WIDTH][MapState.DEFAULT_HEIGHT]);
 
         renderer.render(map);
 

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/ResourceRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/ResourceRendererTest.java
@@ -14,7 +14,7 @@ import net.lapidist.colony.client.render.MapRenderData;
 import net.lapidist.colony.client.render.SimpleMapRenderData;
 import net.lapidist.colony.client.render.data.RenderBuilding;
 import net.lapidist.colony.client.systems.MapRenderDataSystem;
-import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,7 +55,7 @@ public class ResourceRendererTest {
                 .build();
         tiles.add(tile);
 
-        RenderTile[][] grid = new RenderTile[GameConstants.MAP_WIDTH][GameConstants.MAP_HEIGHT];
+        RenderTile[][] grid = new RenderTile[MapState.DEFAULT_WIDTH][MapState.DEFAULT_HEIGHT];
         grid[0][0] = tile;
         MapRenderData map = new SimpleMapRenderData(tiles, new Array<RenderBuilding>(), grid);
 
@@ -99,7 +99,7 @@ public class ResourceRendererTest {
                 .build();
         tiles.add(tile);
 
-        RenderTile[][] grid = new RenderTile[GameConstants.MAP_WIDTH][GameConstants.MAP_HEIGHT];
+        RenderTile[][] grid = new RenderTile[MapState.DEFAULT_WIDTH][MapState.DEFAULT_HEIGHT];
         grid[0][0] = tile;
         MapRenderData map = new SimpleMapRenderData(tiles, new Array<RenderBuilding>(), grid);
 
@@ -143,7 +143,7 @@ public class ResourceRendererTest {
                 .build();
         tiles.add(tile2);
 
-        RenderTile[][] grid2 = new RenderTile[GameConstants.MAP_WIDTH][GameConstants.MAP_HEIGHT];
+        RenderTile[][] grid2 = new RenderTile[MapState.DEFAULT_WIDTH][MapState.DEFAULT_HEIGHT];
         grid2[0][0] = tile2;
         MapRenderData map2 = new SimpleMapRenderData(tiles, new Array<RenderBuilding>(), grid2);
 
@@ -192,7 +192,7 @@ public class ResourceRendererTest {
                     .build());
         }
 
-        RenderTile[][] grid = new RenderTile[GameConstants.MAP_WIDTH][GameConstants.MAP_HEIGHT];
+        RenderTile[][] grid = new RenderTile[MapState.DEFAULT_WIDTH][MapState.DEFAULT_HEIGHT];
         grid[0][0] = tiles.first();
         MapRenderData map = new SimpleMapRenderData(tiles, new Array<RenderBuilding>(), grid);
 

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/TileRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/TileRendererTest.java
@@ -14,7 +14,7 @@ import net.lapidist.colony.client.render.data.RenderTile;
 import net.lapidist.colony.client.render.MapRenderData;
 import net.lapidist.colony.client.render.SimpleMapRenderData;
 import net.lapidist.colony.client.render.data.RenderBuilding;
-import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -70,7 +70,7 @@ public class TileRendererTest {
                 .build();
         tiles.add(tile2);
 
-        RenderTile[][] grid = new RenderTile[GameConstants.MAP_WIDTH][GameConstants.MAP_HEIGHT];
+        RenderTile[][] grid = new RenderTile[MapState.DEFAULT_WIDTH][MapState.DEFAULT_HEIGHT];
         grid[0][0] = tile;
         grid[1][1] = tile2;
         MapRenderData map = new SimpleMapRenderData(tiles, new Array<RenderBuilding>(), grid);
@@ -120,7 +120,7 @@ public class TileRendererTest {
                 .build();
         tiles.add(tile);
 
-        RenderTile[][] grid = new RenderTile[GameConstants.MAP_WIDTH][GameConstants.MAP_HEIGHT];
+        RenderTile[][] grid = new RenderTile[MapState.DEFAULT_WIDTH][MapState.DEFAULT_HEIGHT];
         grid[0][0] = tile;
         MapRenderData map = new SimpleMapRenderData(tiles, new Array<RenderBuilding>(), grid);
 
@@ -174,7 +174,7 @@ public class TileRendererTest {
                 .build();
         tiles.add(tile);
 
-        RenderTile[][] grid = new RenderTile[GameConstants.MAP_WIDTH][GameConstants.MAP_HEIGHT];
+        RenderTile[][] grid = new RenderTile[MapState.DEFAULT_WIDTH][MapState.DEFAULT_HEIGHT];
         grid[0][0] = tile;
         MapRenderData map = new SimpleMapRenderData(tiles, new Array<RenderBuilding>(), grid);
 
@@ -226,7 +226,7 @@ public class TileRendererTest {
                 .build();
         tiles.add(tile2);
 
-        RenderTile[][] grid = new RenderTile[GameConstants.MAP_WIDTH][GameConstants.MAP_HEIGHT];
+        RenderTile[][] grid = new RenderTile[MapState.DEFAULT_WIDTH][MapState.DEFAULT_HEIGHT];
         grid[0][0] = tile1;
         grid[1][0] = tile2;
         MapRenderData map = new SimpleMapRenderData(tiles, new Array<RenderBuilding>(), grid);

--- a/tests/src/test/java/net/lapidist/colony/tests/map/MapUtilsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/map/MapUtilsTest.java
@@ -40,8 +40,7 @@ public class MapUtilsTest {
         assertTrue(MapUtils.findMapEntity(world).isPresent());
         MapComponent map = MapUtils.findMap(world).orElse(null);
         assertNotNull(map);
-        int expected = net.lapidist.colony.components.GameConstants.MAP_WIDTH
-                * net.lapidist.colony.components.GameConstants.MAP_HEIGHT;
+        int expected = state.width() * state.height();
         assertEquals(expected, map.getTiles().size);
         assertTrue(map.getTileMap().containsKey(new TilePos(0, 0)));
     }

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationCameraTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationCameraTest.java
@@ -38,8 +38,8 @@ public class GameSimulationCameraTest {
         sim.step();
 
         final float epsilon = 0.01f;
-        float expectedX = max(0, min(GameConstants.MAP_WIDTH * GameConstants.TILE_SIZE, startX - deltaX));
-        float expectedY = max(0, min(GameConstants.MAP_HEIGHT * GameConstants.TILE_SIZE, startY + deltaY));
+        float expectedX = max(0, min(MapState.DEFAULT_WIDTH * GameConstants.TILE_SIZE, startX - deltaX));
+        float expectedY = max(0, min(MapState.DEFAULT_HEIGHT * GameConstants.TILE_SIZE, startY + deltaY));
 
         assertEquals(expectedX, sim.getCamera().getCamera().position.x, epsilon);
         assertEquals(expectedY, sim.getCamera().getCamera().position.y, epsilon);

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationMapLoadNetworkTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationMapLoadNetworkTest.java
@@ -38,8 +38,8 @@ public class GameSimulationMapLoadNetworkTest {
         MapState state = client.getMapState();
         assertNotNull(state);
         assertEquals(server.getMapState().name(), state.name());
-        assertEquals(net.lapidist.colony.components.GameConstants.MAP_WIDTH, client.getMapWidth());
-        assertEquals(net.lapidist.colony.components.GameConstants.MAP_HEIGHT, client.getMapHeight());
+        assertEquals(MapState.DEFAULT_WIDTH, client.getMapWidth());
+        assertEquals(MapState.DEFAULT_HEIGHT, client.getMapHeight());
 
         GameSimulation sim = new GameSimulation(state, client);
         sim.step();

--- a/tests/src/test/java/net/lapidist/colony/tests/server/NetworkServiceTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/NetworkServiceTest.java
@@ -39,8 +39,8 @@ public class NetworkServiceTest {
         ArgumentCaptor<MapMetadata> metaCaptor = ArgumentCaptor.forClass(MapMetadata.class);
         verify(connection).sendTCP(metaCaptor.capture());
         MapMetadata meta = metaCaptor.getValue();
-        assertEquals(net.lapidist.colony.components.GameConstants.MAP_WIDTH, meta.width());
-        assertEquals(net.lapidist.colony.components.GameConstants.MAP_HEIGHT, meta.height());
+        assertEquals(MapState.DEFAULT_WIDTH, meta.width());
+        assertEquals(MapState.DEFAULT_HEIGHT, meta.height());
         verify(connection, atLeastOnce()).sendTCP(isA(MapChunkBytes.class));
     }
 

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/MapInitSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/MapInitSystemTest.java
@@ -46,8 +46,7 @@ public class MapInitSystemTest {
         assertEquals(1, maps.size());
         MapComponent map = world.getMapper(MapComponent.class).get(maps.get(0));
         assertEquals(
-                net.lapidist.colony.components.GameConstants.MAP_WIDTH
-                        * net.lapidist.colony.components.GameConstants.MAP_HEIGHT,
+                state.width() * state.height(),
                 map.getTileMap().size()
         );
     }

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/MapLoadSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/MapLoadSystemTest.java
@@ -44,8 +44,7 @@ public class MapLoadSystemTest {
 
         Entity map = world.getEntity(maps.get(0));
         MapComponent mapComponent = world.getMapper(MapComponent.class).get(map);
-        int expected = net.lapidist.colony.components.GameConstants.MAP_WIDTH
-                * net.lapidist.colony.components.GameConstants.MAP_HEIGHT;
+        int expected = state.width() * state.height();
         assertEquals(expected, mapComponent.getTiles().size);
         assertEquals(expected, mapComponent.getTileMap().size());
         assertEquals(1, mapComponent.getEntities().size);

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/MapRenderDataSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/MapRenderDataSystemTest.java
@@ -40,8 +40,7 @@ public class MapRenderDataSystemTest {
 
         MapRenderDataSystem system = world.getSystem(MapRenderDataSystem.class);
         assertNotNull(system.getRenderData());
-        int expected = net.lapidist.colony.components.GameConstants.MAP_WIDTH
-                * net.lapidist.colony.components.GameConstants.MAP_HEIGHT;
+        int expected = state.width() * state.height();
         assertEquals(expected, system.getRenderData().getTiles().size);
         assertEquals(0, system.getRenderData().getBuildings().size);
 


### PR DESCRIPTION
## Summary
- drop MAP_WIDTH and MAP_HEIGHT from `GameConstants`
- rely on `MapState.DEFAULT_WIDTH` and `MapState.DEFAULT_HEIGHT`
- pass map dimensions through systems and renderers
- update tests and benchmarks

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`

------
https://chatgpt.com/codex/tasks/task_e_684d5394466c8328b50232fe1931b188