### PR TITLE
fix: correct chunk count metadata to prevent load stalls

### DIFF
--- a/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
@@ -29,6 +29,7 @@ public final class SaveMigrator {
         register(new V13ToV14Migration());
         register(new V14ToV15Migration());
         register(new V15ToV16Migration());
+        register(new V16ToV17Migration());
     }
 
     private SaveMigrator() {

--- a/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
@@ -19,9 +19,10 @@ public enum SaveVersion {
     V13(13),
     V14(14),
     V15(15),
-    V16(16);
+    V16(16),
+    V17(17);
 
-    public static final SaveVersion CURRENT = V16;
+    public static final SaveVersion CURRENT = V17;
 
     private final int number;
 

--- a/core/src/main/java/net/lapidist/colony/save/V16ToV17Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V16ToV17Migration.java
@@ -1,0 +1,23 @@
+package net.lapidist.colony.save;
+
+import net.lapidist.colony.components.state.MapState;
+
+/** Migration from save version 16 to 17 with no data changes. */
+public final class V16ToV17Migration implements MapStateMigration {
+    @Override
+    public int fromVersion() {
+        return SaveVersion.V16.number();
+    }
+
+    @Override
+    public int toVersion() {
+        return SaveVersion.V17.number();
+    }
+
+    @Override
+    public MapState apply(final MapState state) {
+        return state.toBuilder()
+                .version(toVersion())
+                .build();
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/server/services/NetworkService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/NetworkService.java
@@ -77,7 +77,9 @@ public final class NetworkService {
     }
 
     private void sendMapMetadata(final Connection connection, final MapState state) {
-        int chunkCount = state.chunks().size();
+        int chunkWidth = (int) Math.ceil(state.width() / (double) MapChunkData.CHUNK_SIZE);
+        int chunkHeight = (int) Math.ceil(state.height() / (double) MapChunkData.CHUNK_SIZE);
+        int chunkCount = chunkWidth * chunkHeight;
         MapMetadata meta = new MapMetadata(
                 state.version(),
                 state.name(),

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV16Test.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV16Test.java
@@ -1,0 +1,41 @@
+package net.lapidist.colony.tests.server;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Output;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.serialization.KryoRegistry;
+import net.lapidist.colony.save.SaveData;
+import net.lapidist.colony.save.SaveVersion;
+import net.lapidist.colony.serialization.SerializationRegistrar;
+import net.lapidist.colony.server.io.GameStateIO;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+
+public class GameStateIOMigrationV16Test {
+
+    @Test
+    public void migratesV16ToCurrent() throws Exception {
+        Path file = Files.createTempFile("state", ".dat");
+        MapState state = MapState.builder()
+                .version(SaveVersion.V16.number())
+                .build();
+        Kryo kryo = new Kryo();
+        KryoRegistry.register(kryo);
+        try (Output output = new Output(Files.newOutputStream(file))) {
+            SaveData data = new SaveData(
+                    SaveVersion.V16.number(),
+                    SerializationRegistrar.registrationHash(),
+                    state
+            );
+            kryo.writeObject(output, data);
+        }
+
+        MapState loaded = GameStateIO.load(file);
+        Files.deleteIfExists(file);
+        assertEquals(SaveVersion.CURRENT.number(), loaded.version());
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/server/NetworkServiceTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/NetworkServiceTest.java
@@ -41,6 +41,7 @@ public class NetworkServiceTest {
         MapMetadata meta = metaCaptor.getValue();
         assertEquals(MapState.DEFAULT_WIDTH, meta.width());
         assertEquals(MapState.DEFAULT_HEIGHT, meta.height());
+        assertEquals(1, meta.chunkCount());
         verify(connection, atLeastOnce()).sendTCP(isA(MapChunkBytes.class));
     }
 


### PR DESCRIPTION
## Summary
- compute chunk count from dimensions instead of chunk map size
- add save version V17 and migration
- register new migration step
- test new migration and chunk metadata

## Testing
- `./scripts/check.sh`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684d5a2eca248328a830ce6924c1d88a