### PR TITLE
feat(client): handle escape key on menu screens

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/KeybindsScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/KeybindsScreen.java
@@ -91,6 +91,17 @@ public final class KeybindsScreen extends BaseScreen {
                 return false;
             }
         });
+
+        getStage().addListener(new InputListener() {
+            @Override
+            public boolean keyDown(final InputEvent event, final int keycode) {
+                if (awaiting == null && keycode == Input.Keys.ESCAPE) {
+                    colony.setScreen(new SettingsScreen(colony));
+                    return true;
+                }
+                return false;
+            }
+        });
     }
 
     private void updateButtons() {

--- a/client/src/main/java/net/lapidist/colony/client/screens/LoadGameScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/LoadGameScreen.java
@@ -1,6 +1,9 @@
 package net.lapidist.colony.client.screens;
 
+import com.badlogic.gdx.Input;
 import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.scenes.scene2d.InputEvent;
+import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
@@ -84,6 +87,17 @@ public final class LoadGameScreen extends BaseScreen {
             @Override
             public void changed(final ChangeEvent event, final Actor actor) {
                 colony.setScreen(new MainMenuScreen(colony));
+            }
+        });
+
+        getStage().addListener(new InputListener() {
+            @Override
+            public boolean keyDown(final InputEvent event, final int keycode) {
+                if (keycode == Input.Keys.ESCAPE) {
+                    colony.setScreen(new MainMenuScreen(colony));
+                    return true;
+                }
+                return false;
             }
         });
     }

--- a/client/src/main/java/net/lapidist/colony/client/screens/NewGameScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/NewGameScreen.java
@@ -1,6 +1,9 @@
 package net.lapidist.colony.client.screens;
 
+import com.badlogic.gdx.Input;
 import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.scenes.scene2d.InputEvent;
+import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
@@ -82,6 +85,17 @@ public final class NewGameScreen extends BaseScreen {
             @Override
             public void changed(final ChangeEvent event, final Actor actor) {
                 colony.setScreen(new MainMenuScreen(colony));
+            }
+        });
+
+        getStage().addListener(new InputListener() {
+            @Override
+            public boolean keyDown(final InputEvent event, final int keycode) {
+                if (keycode == Input.Keys.ESCAPE) {
+                    colony.setScreen(new MainMenuScreen(colony));
+                    return true;
+                }
+                return false;
             }
         });
     }

--- a/client/src/main/java/net/lapidist/colony/client/screens/SettingsScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/SettingsScreen.java
@@ -1,6 +1,9 @@
 package net.lapidist.colony.client.screens;
 
+import com.badlogic.gdx.Input;
 import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.scenes.scene2d.InputEvent;
+import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import net.lapidist.colony.client.Colony;
@@ -67,6 +70,17 @@ public final class SettingsScreen extends BaseScreen {
             @Override
             public void changed(final ChangeEvent event, final Actor actor) {
                 colony.setScreen(new MainMenuScreen(colony));
+            }
+        });
+
+        getStage().addListener(new InputListener() {
+            @Override
+            public boolean keyDown(final InputEvent event, final int keycode) {
+                if (keycode == Input.Keys.ESCAPE) {
+                    colony.setScreen(new MainMenuScreen(colony));
+                    return true;
+                }
+                return false;
             }
         });
     }

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/KeybindsScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/KeybindsScreenTest.java
@@ -2,15 +2,18 @@ package net.lapidist.colony.tests.screens;
 
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.utils.viewport.ScreenViewport;
 import net.lapidist.colony.client.Colony;
 import net.lapidist.colony.client.screens.KeybindsScreen;
+import net.lapidist.colony.client.screens.SettingsScreen;
 import net.lapidist.colony.settings.KeyAction;
 import net.lapidist.colony.settings.Settings;
 import net.lapidist.colony.tests.GdxTestRunner;
+import org.mockito.MockedConstruction;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -19,6 +22,10 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.ArgumentMatchers.isA;
 
 @RunWith(GdxTestRunner.class)
 public class KeybindsScreenTest {
@@ -52,5 +59,19 @@ public class KeybindsScreenTest {
         stage.keyDown(Input.Keys.G);
 
         assertEquals(Input.Keys.G, settings.getKeyBindings().getKey(KeyAction.GATHER));
+    }
+
+    @Test
+    public void escapeReturnsToSettings() {
+        Colony colony = mock(Colony.class);
+        when(colony.getSettings()).thenReturn(new Settings());
+        try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
+            Stage stage = new Stage(new ScreenViewport(), mock(Batch.class));
+            KeybindsScreen screen = new KeybindsScreen(colony, stage);
+
+            stage.keyDown(Input.Keys.ESCAPE);
+
+            verify(colony).setScreen(isA(SettingsScreen.class));
+        }
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/LoadGameScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/LoadGameScreenTest.java
@@ -1,6 +1,8 @@
 package net.lapidist.colony.tests.screens;
 
+import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
@@ -39,6 +41,12 @@ public class LoadGameScreenTest {
         return (Table) scroll.getActor();
     }
 
+    private static Stage getStage(final LoadGameScreen screen) throws Exception {
+        Field f = screen.getClass().getSuperclass().getDeclaredField("stage");
+        f.setAccessible(true);
+        return (Stage) f.get(screen);
+    }
+
     @Test
     public void backButtonReturnsToMainMenu() throws Exception {
         Colony colony = mock(Colony.class);
@@ -47,6 +55,18 @@ public class LoadGameScreenTest {
             Table root = getRoot(screen);
             TextButton back = (TextButton) root.getChildren().peek();
             back.fire(new ChangeListener.ChangeEvent());
+            verify(colony).setScreen(isA(MainMenuScreen.class));
+            screen.dispose();
+        }
+    }
+
+    @Test
+    public void escapeReturnsToMainMenu() throws Exception {
+        Colony colony = mock(Colony.class);
+        try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
+            LoadGameScreen screen = new LoadGameScreen(colony);
+            Stage stage = getStage(screen);
+            stage.keyDown(Input.Keys.ESCAPE);
             verify(colony).setScreen(isA(MainMenuScreen.class));
             screen.dispose();
         }

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/NewGameScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/NewGameScreenTest.java
@@ -1,6 +1,8 @@
 package net.lapidist.colony.tests.screens;
 
+import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
@@ -47,6 +49,12 @@ public class NewGameScreenTest {
         return (Table) root.getChildren().get(BUTTON_TABLE_INDEX);
     }
 
+    private static Stage getStage(final NewGameScreen screen) throws Exception {
+        Field f = screen.getClass().getSuperclass().getDeclaredField("stage");
+        f.setAccessible(true);
+        return (Stage) f.get(screen);
+    }
+
     @Test
     public void startButtonBeginsGameWithEnteredName() throws Exception {
         Colony colony = mock(Colony.class);
@@ -73,6 +81,18 @@ public class NewGameScreenTest {
             Table buttons = getButtons(screen);
             TextButton back = (TextButton) buttons.getChildren().get(BACK_BUTTON_INDEX);
             back.fire(new ChangeListener.ChangeEvent());
+            verify(colony).setScreen(isA(MainMenuScreen.class));
+            screen.dispose();
+        }
+    }
+
+    @Test
+    public void escapeReturnsToMainMenu() throws Exception {
+        Colony colony = mock(Colony.class);
+        try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
+            NewGameScreen screen = new NewGameScreen(colony);
+            Stage stage = getStage(screen);
+            stage.keyDown(Input.Keys.ESCAPE);
             verify(colony).setScreen(isA(MainMenuScreen.class));
             screen.dispose();
         }

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/SettingsScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/SettingsScreenTest.java
@@ -1,6 +1,8 @@
 package net.lapidist.colony.tests.screens;
 
+import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
@@ -31,6 +33,12 @@ public class SettingsScreenTest {
         return (Table) f.get(screen);
     }
 
+    private static Stage getStage(final SettingsScreen screen) throws Exception {
+        Field f = screen.getClass().getSuperclass().getDeclaredField("stage");
+        f.setAccessible(true);
+        return (Stage) f.get(screen);
+    }
+
     @Test
     public void keybindsButtonOpensKeybindsScreen() throws Exception {
         Colony colony = mock(Colony.class);
@@ -52,6 +60,19 @@ public class SettingsScreenTest {
             SettingsScreen screen = new SettingsScreen(colony);
             TextButton back = (TextButton) getRoot(screen).getChildren().get(BACK_BUTTON_INDEX);
             back.fire(new ChangeListener.ChangeEvent());
+            verify(colony).setScreen(isA(MainMenuScreen.class));
+            screen.dispose();
+        }
+    }
+
+    @Test
+    public void escapeReturnsToMainMenu() throws Exception {
+        Colony colony = mock(Colony.class);
+        when(colony.getSettings()).thenReturn(new Settings());
+        try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
+            SettingsScreen screen = new SettingsScreen(colony);
+            Stage stage = getStage(screen);
+            stage.keyDown(Input.Keys.ESCAPE);
             verify(colony).setScreen(isA(MainMenuScreen.class));
             screen.dispose();
         }


### PR DESCRIPTION
## Summary
- add ESC listener for SettingsScreen
- add ESC listener for KeybindsScreen
- add ESC listener for NewGameScreen
- add ESC listener for LoadGameScreen
- test ESC key closes respective screens

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`

------
https://chatgpt.com/codex/tasks/task_e_684d5af260608328919a15d38b98572c