### PR TITLE
feat: make map and minimap buttons toggles

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/MapUiBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapUiBuilder.java
@@ -68,12 +68,13 @@ public final class MapUiBuilder {
         buildButton.setName("buildButton");
         TextButton removeButton = new TextButton("", skin, "toggle");
         removeButton.setName("removeButton");
-        TextButton mapButton = new TextButton("", skin);
+        TextButton mapButton = new TextButton("", skin, "toggle");
         mapButton.setName("mapButton");
-        TextButton minimapButton = new TextButton("", skin);
+        TextButton minimapButton = new TextButton("", skin, "toggle");
         minimapButton.setName("minimapButton");
         GraphicsSettings graphics = colony.getSettings().getGraphicsSettings();
         MinimapActor minimapActor = new MinimapActor(world, graphics, client);
+        minimapButton.setChecked(minimapActor.isVisible());
         ChatBox chatBox = new ChatBox(skin, client);
         PlayerResourcesActor resourcesActor = new PlayerResourcesActor(skin, world);
 
@@ -91,6 +92,9 @@ public final class MapUiBuilder {
 
         BuildPlacementSystem buildSystem = world.getSystem(BuildPlacementSystem.class);
         PlayerCameraSystem cameraSystem = world.getSystem(PlayerCameraSystem.class);
+        if (cameraSystem != null) {
+            mapButton.setChecked(cameraSystem.getMode() == PlayerCameraSystem.Mode.MAP_OVERVIEW);
+        }
 
         buildButton.addListener(new ChangeListener() {
             @Override
@@ -125,14 +129,16 @@ public final class MapUiBuilder {
         mapButton.addListener(new ChangeListener() {
             @Override
             public void changed(final ChangeEvent event, final Actor actor) {
-                cameraSystem.toggleMode();
+                if (cameraSystem != null) {
+                    cameraSystem.toggleMode();
+                }
             }
         });
 
         minimapButton.addListener(new ChangeListener() {
             @Override
             public void changed(final ChangeEvent event, final Actor actor) {
-                minimapActor.setVisible(!minimapActor.isVisible());
+                minimapActor.setVisible(minimapButton.isChecked());
             }
         });
 
@@ -156,7 +162,11 @@ public final class MapUiBuilder {
                     return true;
                 }
                 if (keycode == keyBindings.getKey(KeyAction.MINIMAP)) {
-                    minimapActor.setVisible(!minimapActor.isVisible());
+                    boolean visible = !minimapActor.isVisible();
+                    minimapActor.setVisible(visible);
+                    minimapButton.setProgrammaticChangeEvents(false);
+                    minimapButton.setChecked(visible);
+                    minimapButton.setProgrammaticChangeEvents(true);
                     return true;
                 }
                 return false;

--- a/tests/src/test/java/net/lapidist/colony/client/screens/MapUiButtonStateTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/screens/MapUiButtonStateTest.java
@@ -66,4 +66,43 @@ public class MapUiButtonStateTest {
         assertFalse(buildSystem.isRemoveMode());
         assertFalse(removeButton.isChecked());
     }
+
+    @Test
+    public void mapAndMinimapButtonsToggleStates() {
+        Stage stage = new Stage(new ScreenViewport(), mock(Batch.class));
+        Settings settings = new Settings();
+        World world = new World(new WorldConfigurationBuilder()
+                .with(
+                        new PlayerCameraSystem(),
+                        new CameraInputSystem(settings.getKeyBindings())
+                )
+                .build());
+        GameClient client = mock(GameClient.class);
+        Colony colony = mock(Colony.class);
+        when(colony.getSettings()).thenReturn(settings);
+
+        MapUi ui = MapUiBuilder.build(stage, world, client, colony);
+
+        PlayerCameraSystem cameraSystem = world.getSystem(PlayerCameraSystem.class);
+        TextButton mapButton = stage.getRoot().findActor("mapButton");
+        TextButton minimapButton = stage.getRoot().findActor("minimapButton");
+
+        // toggle map view
+        mapButton.toggle();
+        assertEquals(PlayerCameraSystem.Mode.PLAYER, cameraSystem.getMode());
+        assertFalse(mapButton.isChecked());
+        mapButton.toggle();
+        assertEquals(PlayerCameraSystem.Mode.MAP_OVERVIEW, cameraSystem.getMode());
+        assertTrue(mapButton.isChecked());
+
+        // toggle minimap visibility
+        boolean initial = ui.getMinimapActor().isVisible();
+        boolean initialChecked = minimapButton.isChecked();
+        minimapButton.toggle();
+        assertEquals(!initial, ui.getMinimapActor().isVisible());
+        assertEquals(!initialChecked, minimapButton.isChecked());
+        minimapButton.toggle();
+        assertEquals(initial, ui.getMinimapActor().isVisible());
+        assertEquals(initialChecked, minimapButton.isChecked());
+    }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MapUiBuilderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MapUiBuilderTest.java
@@ -60,14 +60,18 @@ public class MapUiBuilderTest {
         assertEquals(expectedButton, minimapButton.getText().toString());
 
         boolean initial = ui.getMinimapActor().isVisible();
+        boolean initialChecked = minimapButton.isChecked();
+        assertEquals(initial, initialChecked);
 
         stage.keyDown(settings.getKeyBindings().getKey(KeyAction.MINIMAP));
 
         assertEquals(!initial, ui.getMinimapActor().isVisible());
+        assertEquals(!initialChecked, minimapButton.isChecked());
 
         stage.keyDown(settings.getKeyBindings().getKey(KeyAction.MINIMAP));
 
         assertEquals(initial, ui.getMinimapActor().isVisible());
+        assertEquals(initialChecked, minimapButton.isChecked());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- convert Map and Minimap buttons to toggle style
- sync buttons with visibility and camera mode
- adjust tests for new toggle behaviour

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684d5f165ed08328a01d1ef70ca514d8