### PR TITLE
feat(client): toggle map UI buttons

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/MapUiBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapUiBuilder.java
@@ -68,9 +68,9 @@ public final class MapUiBuilder {
         buildButton.setName("buildButton");
         TextButton removeButton = new TextButton("", skin, "toggle");
         removeButton.setName("removeButton");
-        TextButton mapButton = new TextButton("", skin);
+        TextButton mapButton = new TextButton("", skin, "toggle");
         mapButton.setName("mapButton");
-        TextButton minimapButton = new TextButton("", skin);
+        TextButton minimapButton = new TextButton("", skin, "toggle");
         minimapButton.setName("minimapButton");
         GraphicsSettings graphics = colony.getSettings().getGraphicsSettings();
         MinimapActor minimapActor = new MinimapActor(world, graphics, client);
@@ -91,6 +91,10 @@ public final class MapUiBuilder {
 
         BuildPlacementSystem buildSystem = world.getSystem(BuildPlacementSystem.class);
         PlayerCameraSystem cameraSystem = world.getSystem(PlayerCameraSystem.class);
+        if (cameraSystem != null) {
+            mapButton.setChecked(!cameraSystem.isPlayerMode());
+        }
+        minimapButton.setChecked(minimapActor.isVisible());
 
         buildButton.addListener(new ChangeListener() {
             @Override
@@ -125,14 +129,16 @@ public final class MapUiBuilder {
         mapButton.addListener(new ChangeListener() {
             @Override
             public void changed(final ChangeEvent event, final Actor actor) {
-                cameraSystem.toggleMode();
+                if (cameraSystem != null) {
+                    cameraSystem.toggleMode();
+                }
             }
         });
 
         minimapButton.addListener(new ChangeListener() {
             @Override
             public void changed(final ChangeEvent event, final Actor actor) {
-                minimapActor.setVisible(!minimapActor.isVisible());
+                minimapActor.setVisible(minimapButton.isChecked());
             }
         });
 
@@ -157,6 +163,7 @@ public final class MapUiBuilder {
                 }
                 if (keycode == keyBindings.getKey(KeyAction.MINIMAP)) {
                     minimapActor.setVisible(!minimapActor.isVisible());
+                    minimapButton.setChecked(minimapActor.isVisible());
                     return true;
                 }
                 return false;

--- a/tests/src/test/java/net/lapidist/colony/client/screens/MapUiButtonStateTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/screens/MapUiButtonStateTest.java
@@ -66,4 +66,41 @@ public class MapUiButtonStateTest {
         assertFalse(buildSystem.isRemoveMode());
         assertFalse(removeButton.isChecked());
     }
+
+    @Test
+    public void mapAndMinimapButtonsToggle() {
+        Stage stage = new Stage(new ScreenViewport(), mock(Batch.class));
+        Settings settings = new Settings();
+        BuildPlacementSystem buildSystem = new BuildPlacementSystem(
+                mock(GameClient.class),
+                settings.getKeyBindings()
+        );
+        World world = new World(new WorldConfigurationBuilder()
+                .with(
+                        new PlayerCameraSystem(),
+                        new CameraInputSystem(settings.getKeyBindings()),
+                        buildSystem
+                )
+                .build());
+        GameClient client = mock(GameClient.class);
+        Colony colony = mock(Colony.class);
+        when(colony.getSettings()).thenReturn(settings);
+
+        MapUi ui = MapUiBuilder.build(stage, world, client, colony);
+
+        TextButton mapButton = stage.getRoot().findActor("mapButton");
+        TextButton minimapButton = stage.getRoot().findActor("minimapButton");
+
+        PlayerCameraSystem cameraSystem = world.getSystem(PlayerCameraSystem.class);
+        assertTrue(mapButton.isChecked());
+
+        mapButton.toggle();
+        assertTrue(cameraSystem.isPlayerMode());
+        assertFalse(mapButton.isChecked());
+
+        assertTrue(minimapButton.isChecked());
+        minimapButton.toggle();
+        assertFalse(ui.getMinimapActor().isVisible());
+        assertFalse(minimapButton.isChecked());
+    }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MapUiBuilderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MapUiBuilderTest.java
@@ -60,14 +60,17 @@ public class MapUiBuilderTest {
         assertEquals(expectedButton, minimapButton.getText().toString());
 
         boolean initial = ui.getMinimapActor().isVisible();
+        assertEquals(initial, minimapButton.isChecked());
 
         stage.keyDown(settings.getKeyBindings().getKey(KeyAction.MINIMAP));
 
         assertEquals(!initial, ui.getMinimapActor().isVisible());
+        assertEquals(!initial, minimapButton.isChecked());
 
         stage.keyDown(settings.getKeyBindings().getKey(KeyAction.MINIMAP));
 
         assertEquals(initial, ui.getMinimapActor().isVisible());
+        assertEquals(initial, minimapButton.isChecked());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- support toggling map and minimap buttons
- test toggle behaviour for map and minimap buttons
- verify minimap button reflects keyboard toggle

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684d5c65b2bc83288a6ae01ee67ed798