### PR TITLE
fix(client): enable mipmap loading

### DIFF
--- a/tests/src/test/java/net/lapidist/colony/tests/core/io/ResourceLoaderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/io/ResourceLoaderTest.java
@@ -48,6 +48,7 @@ public class ResourceLoaderTest {
         for (Texture texture : resourceLoader.getAtlas().getTextures()) {
             assertEquals(Texture.TextureFilter.MipMapLinearLinear, texture.getMinFilter());
             assertTrue(texture.getAnisotropicFilter() >= 1f);
+            assertTrue(texture.getTextureData().useMipMaps());
         }
     }
 


### PR DESCRIPTION
## Summary
- enable mipmap generation when graphics setting is enabled
- assert mipmap textures in resource loader test

## Testing
- `./gradlew clean test`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_684d600cac848328965324de288a68e6