### PR TITLE
docs: add modding guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ This directory contains all guides for the Colony project. References are groupe
 - [Networking Guide](networking.md) – client and server message flow examples.
 - [Localization Guide](i18n.md)
 - [Configuration Guide](configuration.md)
+- [Modding Guide](mods.md)
 - [Contributing Guide](../CONTRIBUTING.md) – coding conventions and contribution process.
  - [Performance Notes](performance.md) – benchmarking of data structures and renderer performance.
    Update the numbers whenever benchmarks change and strive to keep them from increasing.

--- a/docs/mods.md
+++ b/docs/mods.md
@@ -1,0 +1,44 @@
+# Modding Overview
+
+This guide covers how to organize your `mods/` folder and how `ModLoader` discovers mod implementations.
+
+## Folder layout
+
+All mods live under the `mods/` directory inside the game folder.
+Each entry can be either a JAR file or a directory with the following structure:
+
+```
+mods/
+  example.jar
+  othermod/
+    mod.json
+    META-INF/
+      services/
+        net.lapidist.colony.mod.GameMod
+```
+
+Every directory must contain a `mod.json` file and the standard
+`META-INF/services` descriptor listing the implementing class of `GameMod`.
+JAR files embed these files within the archive.
+
+A minimal `mod.json` looks like:
+
+```json
+{
+  "id": "example",
+  "version": "1.0.0",
+  "dependencies": []
+}
+```
+
+`id` is the unique identifier used for dependency resolution.
+`version` is an arbitrary string.
+`dependencies` lists other mod IDs that must be loaded first.
+
+## How mods are discovered
+
+`ModLoader` scans the `mods/` folder and creates a `URLClassLoader` for every
+JAR or directory it finds. Each class loader is passed to Java's `ServiceLoader`
+to locate implementations of the `GameMod` interface. If a `mod.json` is
+missing, the entry is skipped.
+


### PR DESCRIPTION
## Summary
- document the expected `mods/` folder layout
- show a sample `mod.json` file and explain how `ModLoader` finds mods
- link the new guide from the docs index

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684d6639188c83289588a550168eccee