### PR TITLE
docs: add scenario test harness guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,5 +13,6 @@ This directory contains all guides for the Colony project. References are groupe
 - [Localization Guide](i18n.md)
 - [Configuration Guide](configuration.md)
 - [Contributing Guide](../CONTRIBUTING.md) – coding conventions and contribution process.
- - [Performance Notes](performance.md) – benchmarking of data structures and renderer performance.
-   Update the numbers whenever benchmarks change and strive to keep them from increasing.
+- [Performance Notes](performance.md) – benchmarking of data structures and renderer performance.
+  Update the numbers whenever benchmarks change and strive to keep them from increasing.
+- [Scenario Test Harness](tests.md) – explains `GameSimulation` and the headless test setup.

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -1,0 +1,13 @@
+# Scenario Test Harness
+
+`GameSimulation` boots a LibGDX application in headless mode so gameplay systems can be
+verified without a graphical window. The helper loads a `MapState` through
+`MapLoadSystem` and attaches the client networking systems that react to server
+messages.
+
+`tests/scenario/GameSimulationTileUpdateTest.java` shows a typical flow. A
+`GameServer` and two `GameClient` instances are started. Once the receiver
+obtains the initial map state it constructs `GameSimulation` with that state and
+the client. The test sends a tile selection request via the sender, waits for the
+server broadcast and then calls `GameSimulation.step()`. Assertions inspect the
+ECS world to confirm the tile update was applied just like during normal play.


### PR DESCRIPTION
## Summary
- document how GameSimulation boots a headless world
- link new document from docs README

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684d663a8bec83288dfa3c33149ac1df