### PR TITLE
docs: add map generation and save format guides

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,8 @@ This directory contains all guides for the Colony project. References are groupe
 - [Networking Guide](networking.md) – client and server message flow examples.
 - [Localization Guide](i18n.md)
 - [Configuration Guide](configuration.md)
+- [Map Generation](map_generation.md) – overview of `MapGenerator` implementations.
+- [Save Format](save_format.md) – versioning and migration workflow.
 - [Contributing Guide](../CONTRIBUTING.md) – coding conventions and contribution process.
  - [Performance Notes](performance.md) – benchmarking of data structures and renderer performance.
    Update the numbers whenever benchmarks change and strive to keep them from increasing.

--- a/docs/map_generation.md
+++ b/docs/map_generation.md
@@ -1,0 +1,29 @@
+# Map Generation
+
+Colony builds new worlds through the `MapGenerator` interface. Implementations return a fully initialized `MapState` for the given dimensions.
+
+## MapGenerator
+
+```java
+MapState generate(int width, int height);
+```
+
+`MapService` invokes the configured generator when no save file exists. The default server configuration uses `ChunkedMapGenerator`.
+
+## ChunkedMapGenerator
+
+`ChunkedMapGenerator` creates the world in 32×32 tile regions called `MapChunkData`. Tiles are generated lazily using a Perlin noise algorithm and stored in their chunk. Basic resources and a starting building are populated in the center of the map.
+
+## Creating a Custom Generator
+
+Custom terrain algorithms can be plugged in by providing a different `MapGenerator` when building the server configuration:
+
+```java
+MapGenerator generator = new MyGenerator();
+GameServerConfig config = GameServerConfig.builder()
+        .mapGenerator(generator)
+        .build();
+```
+
+`MapService` will call the supplied generator to produce the initial state. This approach keeps map creation separate from the rest of the server logic.
+

--- a/docs/save_format.md
+++ b/docs/save_format.md
@@ -1,0 +1,19 @@
+# Save Format
+
+Game state is serialized into a `SaveData` record containing the save version, a Kryo registration hash and the `MapState`. Files are written and read via `GameStateIO`.
+
+## SaveVersion
+
+`SaveVersion` enumerates each supported format and exposes `CURRENT` for the newest one. The version number is stored in every save so old files can be migrated.
+
+## SaveMigrator Workflow
+
+`DefaultSaveMigrationStrategy` checks the file version when loading a save. If it is older than `SaveVersion.CURRENT`, it calls `SaveMigrator.migrate`. `SaveMigrator` applies each `MapStateMigration` step in order and returns an updated `MapState` with the target version.
+
+The repository's root `AGENTS.md` outlines the required steps whenever the save format changes:
+
+1. Add the next constant in `SaveVersion`.
+2. Implement migration logic in `SaveMigrator`.
+3. Add tests covering the migration.
+4. Update the Kryo registration hash to detect mismatches.
+


### PR DESCRIPTION
## Summary
- document MapGenerator usage and defaults
- explain SaveVersion and SaveMigrator workflows
- link to the new docs from docs/README

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684d663b96f08328994192895a14bea0