### PR TITLE
feat: add network configuration for ports

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
+++ b/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
@@ -20,7 +20,7 @@ import net.lapidist.colony.serialization.KryoRegistry;
 import net.lapidist.colony.network.AbstractMessageEndpoint;
 import net.lapidist.colony.network.DispatchListener;
 import net.lapidist.colony.network.MessageHandler;
-import net.lapidist.colony.server.GameServer;
+import net.lapidist.colony.config.NetworkConfig;
 import net.lapidist.colony.client.network.handlers.MapMetadataHandler;
 import net.lapidist.colony.client.network.handlers.MapChunkHandler;
 import net.lapidist.colony.client.network.handlers.QueueingMessageHandler;
@@ -179,7 +179,12 @@ public final class GameClient extends AbstractMessageEndpoint {
                 playerId = connection.getID();
             }
         });
-        client.connect(CONNECT_TIMEOUT, "localhost", GameServer.TCP_PORT, GameServer.UDP_PORT);
+        client.connect(
+                CONNECT_TIMEOUT,
+                NetworkConfig.getHost(),
+                NetworkConfig.getTcpPort(),
+                NetworkConfig.getUdpPort()
+        );
     }
 
     @Override

--- a/core/src/main/java/net/lapidist/colony/config/NetworkConfig.java
+++ b/core/src/main/java/net/lapidist/colony/config/NetworkConfig.java
@@ -1,0 +1,31 @@
+package net.lapidist.colony.config;
+
+/**
+ * Provides network related configuration values.
+ */
+public final class NetworkConfig {
+
+    private NetworkConfig() {
+    }
+
+    /**
+     * Returns the default server host.
+     */
+    public static String getHost() {
+        return ColonyConfig.get().getString("game.server.host");
+    }
+
+    /**
+     * Returns the TCP port number used by the server.
+     */
+    public static int getTcpPort() {
+        return ColonyConfig.get().getInt("game.server.tcpPort");
+    }
+
+    /**
+     * Returns the UDP port number used by the server.
+     */
+    public static int getUdpPort() {
+        return ColonyConfig.get().getInt("game.server.udpPort");
+    }
+}

--- a/core/src/main/resources/game.conf
+++ b/core/src/main/resources/game.conf
@@ -5,6 +5,7 @@ game {
   defaultSaveName = "autosave"
   networkBufferSize = 8388608
   server {
+    host = "localhost"
     tcpPort = 54555
     udpPort = 54777
   }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,7 @@
 # Configuration
 
 Default settings are read from `core/src/main/resources/game.conf`.
-The file controls the network buffer size, autosave interval and server ports.
+The file controls the network buffer size, autosave interval and server host/ports.
 Map size is determined when creating a game or loading a save:
 
 ```hocon
@@ -11,11 +11,15 @@ game {
   defaultSaveName = "autosave"
     networkBufferSize = 8388608
   server {
+    host = "localhost"
     tcpPort = 54555
     udpPort = 54777
   }
 }
 ```
+
+The `game.server.host` key defines the hostname or IP address that clients
+should use when connecting to the server.
 
 Saves and user preferences are written to a platform specific directory. The
 exact locations are resolved by

--- a/server/src/main/java/net/lapidist/colony/server/GameServer.java
+++ b/server/src/main/java/net/lapidist/colony/server/GameServer.java
@@ -2,7 +2,7 @@ package net.lapidist.colony.server;
 
 import com.esotericsoftware.kryonet.Server;
 import net.lapidist.colony.components.state.MapState;
-import net.lapidist.colony.config.ColonyConfig;
+import net.lapidist.colony.config.NetworkConfig;
 import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.events.Events;
 import net.lapidist.colony.serialization.KryoRegistry;
@@ -37,8 +37,6 @@ import java.io.IOException;
 // because the server module runs headless without the Gdx runtime.
 
 public final class GameServer extends AbstractMessageEndpoint implements AutoCloseable {
-    public static final int TCP_PORT = ColonyConfig.get().getInt("game.server.tcpPort");
-    public static final int UDP_PORT = ColonyConfig.get().getInt("game.server.udpPort");
 
     // Buffer size for Kryo serialization configured via game.networkBufferSize.
     private static final Logger LOGGER = LoggerFactory.getLogger(GameServer.class);
@@ -79,7 +77,11 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
         this.handlers = handlersToUse;
         this.commandHandlers = commandHandlersToUse;
         this.mapService = new MapService(mapGenerator, saveName, mapWidth, mapHeight);
-        this.networkService = new NetworkService(server, TCP_PORT, UDP_PORT);
+        this.networkService = new NetworkService(
+                server,
+                NetworkConfig.getTcpPort(),
+                NetworkConfig.getUdpPort()
+        );
         this.autosaveService = new AutosaveService(autosaveInterval, saveName, () -> mapState);
         this.resourceProductionService = new ResourceProductionService(
                 autosaveInterval,


### PR DESCRIPTION
## Summary
- introduce `NetworkConfig` to centralize server host and ports
- use the new getters in server and client
- document `game.server.host`

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684d664d6a588328b3802bdc1a967f07