### PR TITLE
docs: describe save version workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,8 @@ Thank you for your interest in contributing to Colony! This project follows the 
 - Fork the repository and create a feature branch.
 - Ensure all tests pass and no Checkstyle violations remain.
 - Add new tests when introducing functionality or modifying behaviour.
+- When modifying the save data structures, follow the
+  [Save Format guide](docs/save-format.md) and add a migration.
 - Open a pull request describing your changes.
 
 By contributing to this project you agree that your contributions are licensed under the MIT License.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ This directory contains all guides for the Colony project. References are groupe
 - [Networking Guide](networking.md) – client and server message flow examples.
 - [Localization Guide](i18n.md)
 - [Configuration Guide](configuration.md)
+- [Save Format](save-format.md) – steps for adding a save version and migration.
 - [Contributing Guide](../CONTRIBUTING.md) – coding conventions and contribution process.
  - [Performance Notes](performance.md) – benchmarking of data structures and renderer performance.
    Update the numbers whenever benchmarks change and strive to keep them from increasing.

--- a/docs/save-format.md
+++ b/docs/save-format.md
@@ -1,0 +1,9 @@
+# Save Format
+
+This guide explains how to update the save game version whenever the serialized state changes.
+
+1. Add the next constant in `SaveVersion` and update `CURRENT` to the new value.
+2. Implement a `MapStateMigration` that converts the old data to the new structure.
+3. Register the migration in `SaveMigrator` so it is applied during loading.
+4. Run `SerializationRegistrar.registrationHash()` and set `REGISTRATION_HASH` to the new value.
+5. Write tests covering the migration to ensure old saves load correctly.


### PR DESCRIPTION
## Summary
- add a save format guide describing the migration workflow
- update docs index with link to the new guide
- mention the save format process in CONTRIBUTING

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684d67144eec83289a137eb89a341495