### PR TITLE
refactor(client): consolidate world builder logic

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -67,7 +67,10 @@ public final class MapWorldBuilder {
             final KeyBindings keyBindings,
             final ResourceData playerResources
     ) {
-        return createBuilder(client, stage, keyBindings, null, playerResources, null, null);
+        MapState state = MapState.builder()
+                .playerResources(playerResources)
+                .build();
+        return createBuilder(client, stage, keyBindings, null, state);
     }
 
     /**
@@ -85,7 +88,7 @@ public final class MapWorldBuilder {
             final Stage stage,
             final KeyBindings keyBindings
     ) {
-        return createBuilder(client, stage, keyBindings, provider, new ResourceData(), null, null);
+        return createBuilder(client, stage, keyBindings, provider, new MapState());
     }
 
     /**
@@ -102,9 +105,7 @@ public final class MapWorldBuilder {
                 stage,
                 keyBindings,
                 new ProvidedMapStateProvider(state),
-                state.playerResources(),
-                state.playerPos(),
-                state.cameraPos()
+                state
         );
     }
 
@@ -113,10 +114,11 @@ public final class MapWorldBuilder {
             final Stage stage,
             final KeyBindings keyBindings,
             final MapStateProvider provider,
-            final ResourceData playerResources,
-            final PlayerPosition playerPos,
-            final net.lapidist.colony.components.state.CameraPosition cameraPos
+            final MapState state
     ) {
+        ResourceData playerResources = state.playerResources();
+        PlayerPosition playerPos = state.playerPos();
+        net.lapidist.colony.components.state.CameraPosition cameraPos = state.cameraPos();
         CameraInputSystem cameraInputSystem = new CameraInputSystem(client, keyBindings);
         cameraInputSystem.addProcessor(stage);
         SelectionSystem selectionSystem = new SelectionSystem(client, keyBindings);

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MapWorldBuilderConfigurationTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MapWorldBuilderConfigurationTest.java
@@ -139,6 +139,37 @@ public class MapWorldBuilderConfigurationTest {
     }
 
     @Test
+    public void baseBuilderUsesProvidedResources() {
+        ResourceData resources = new ResourceData(WOOD, STONE, FOOD);
+        Batch batch = mock(Batch.class);
+        when(batch.getTransformMatrix()).thenReturn(new com.badlogic.gdx.math.Matrix4());
+        when(batch.getProjectionMatrix()).thenReturn(new com.badlogic.gdx.math.Matrix4());
+        Stage stage = new Stage(new ScreenViewport(), batch);
+        GameClient client = mock(GameClient.class);
+        KeyBindings keys = new KeyBindings();
+        try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
+            World world = MapWorldBuilder.build(
+                    MapWorldBuilder.baseBuilder(client, stage, keys, resources),
+                    null,
+                    new net.lapidist.colony.settings.Settings(),
+                    null
+            );
+            world.process();
+
+            var players = world.getAspectSubscriptionManager()
+                    .get(Aspect.all(PlayerResourceComponent.class))
+                    .getEntities();
+            var comp = world.getMapper(PlayerResourceComponent.class)
+                    .get(world.getEntity(players.get(0)));
+            assertEquals(WOOD, comp.getWood());
+            assertEquals(STONE, comp.getStone());
+            assertEquals(FOOD, comp.getFood());
+
+            world.dispose();
+        }
+    }
+
+    @Test
     public void builderFromStateUsesPlayerPosition() {
         final int x = 2;
         final int y = 3;


### PR DESCRIPTION
## Summary
- consolidate shared builder logic in MapWorldBuilder
- add unit test for baseBuilder resource defaults

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684d670c46fc8328a2677f3702080b80