### PR TITLE
feat(server): protect game state with lock

### DIFF
--- a/server/src/main/java/net/lapidist/colony/server/commands/GatherCommandHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/GatherCommandHandler.java
@@ -9,19 +9,23 @@ import net.lapidist.colony.map.MapChunkData;
 import net.lapidist.colony.server.services.NetworkService;
 
 import java.util.function.Supplier;
+import java.util.concurrent.locks.ReentrantLock;
 
 /** Applies a {@link GatherCommand} to the game state and broadcasts the change. */
 public final class GatherCommandHandler implements CommandHandler<GatherCommand> {
     private final Supplier<MapState> stateSupplier;
     private final java.util.function.Consumer<MapState> stateConsumer;
     private final NetworkService networkService;
+    private final ReentrantLock lock;
 
     public GatherCommandHandler(final Supplier<MapState> stateSupplierToUse,
                                final java.util.function.Consumer<MapState> stateConsumerToUse,
-                               final NetworkService networkServiceToUse) {
+                               final NetworkService networkServiceToUse,
+                               final ReentrantLock lockToUse) {
         this.stateSupplier = stateSupplierToUse;
         this.stateConsumer = stateConsumerToUse;
         this.networkService = networkServiceToUse;
+        this.lock = lockToUse;
     }
 
     @Override
@@ -31,42 +35,47 @@ public final class GatherCommandHandler implements CommandHandler<GatherCommand>
 
     @Override
     public void handle(final GatherCommand command) {
-        MapState state = stateSupplier.get();
-        TileData tile = state.getTile(command.x(), command.y());
-        TilePos pos = new TilePos(command.x(), command.y());
-        if (tile == null) {
-            return;
+        lock.lock();
+        try {
+            MapState state = stateSupplier.get();
+            TileData tile = state.getTile(command.x(), command.y());
+            TilePos pos = new TilePos(command.x(), command.y());
+            if (tile == null) {
+                return;
+            }
+            ResourceData res = tile.resources();
+            ResourceData updated;
+            switch (command.resourceType()) {
+                case WOOD -> updated = new ResourceData(Math.max(res.wood() - 1, 0), res.stone(), res.food());
+                case STONE -> updated = new ResourceData(res.wood(), Math.max(res.stone() - 1, 0), res.food());
+                case FOOD -> updated = new ResourceData(res.wood(), res.stone(), Math.max(res.food() - 1, 0));
+                default -> updated = res;
+            }
+            TileData newTile = tile.toBuilder().resources(updated).build();
+            int chunkX = Math.floorDiv(command.x(), MapChunkData.CHUNK_SIZE);
+            int chunkY = Math.floorDiv(command.y(), MapChunkData.CHUNK_SIZE);
+            int localX = Math.floorMod(command.x(), MapChunkData.CHUNK_SIZE);
+            int localY = Math.floorMod(command.y(), MapChunkData.CHUNK_SIZE);
+            state.getOrCreateChunk(chunkX, chunkY).getTiles().put(new TilePos(localX, localY), newTile);
+            ResourceData player = state.playerResources();
+            ResourceData newPlayer = new ResourceData(
+                    player.wood() + (res.wood() - updated.wood()),
+                    player.stone() + (res.stone() - updated.stone()),
+                    player.food() + (res.food() - updated.food())
+            );
+            MapState updatedState = state.toBuilder()
+                    .playerResources(newPlayer)
+                    .build();
+            stateConsumer.accept(updatedState);
+            networkService.broadcast(new ResourceUpdateData(
+                    pos.x(),
+                    pos.y(),
+                    updated.wood(),
+                    updated.stone(),
+                    updated.food()
+            ));
+        } finally {
+            lock.unlock();
         }
-        ResourceData res = tile.resources();
-        ResourceData updated;
-        switch (command.resourceType()) {
-            case WOOD -> updated = new ResourceData(Math.max(res.wood() - 1, 0), res.stone(), res.food());
-            case STONE -> updated = new ResourceData(res.wood(), Math.max(res.stone() - 1, 0), res.food());
-            case FOOD -> updated = new ResourceData(res.wood(), res.stone(), Math.max(res.food() - 1, 0));
-            default -> updated = res;
-        }
-        TileData newTile = tile.toBuilder().resources(updated).build();
-        int chunkX = Math.floorDiv(command.x(), MapChunkData.CHUNK_SIZE);
-        int chunkY = Math.floorDiv(command.y(), MapChunkData.CHUNK_SIZE);
-        int localX = Math.floorMod(command.x(), MapChunkData.CHUNK_SIZE);
-        int localY = Math.floorMod(command.y(), MapChunkData.CHUNK_SIZE);
-        state.getOrCreateChunk(chunkX, chunkY).getTiles().put(new TilePos(localX, localY), newTile);
-        ResourceData player = state.playerResources();
-        ResourceData newPlayer = new ResourceData(
-                player.wood() + (res.wood() - updated.wood()),
-                player.stone() + (res.stone() - updated.stone()),
-                player.food() + (res.food() - updated.food())
-        );
-        MapState updatedState = state.toBuilder()
-                .playerResources(newPlayer)
-                .build();
-        stateConsumer.accept(updatedState);
-        networkService.broadcast(new ResourceUpdateData(
-                pos.x(),
-                pos.y(),
-                updated.wood(),
-                updated.stone(),
-                updated.food()
-        ));
     }
 }

--- a/server/src/main/java/net/lapidist/colony/server/commands/RemoveBuildingCommandHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/RemoveBuildingCommandHandler.java
@@ -10,19 +10,23 @@ import net.lapidist.colony.server.services.NetworkService;
 import java.util.Iterator;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.concurrent.locks.ReentrantLock;
 
 /** Applies a {@link RemoveBuildingCommand} to the game state and broadcasts the change. */
 public final class RemoveBuildingCommandHandler implements CommandHandler<RemoveBuildingCommand> {
     private final Supplier<MapState> stateSupplier;
     private final Consumer<MapState> stateConsumer;
     private final NetworkService networkService;
+    private final ReentrantLock lock;
 
     public RemoveBuildingCommandHandler(final Supplier<MapState> stateSupplierToUse,
                                         final Consumer<MapState> stateConsumerToUse,
-                                        final NetworkService networkServiceToUse) {
+                                        final NetworkService networkServiceToUse,
+                                        final ReentrantLock lockToUse) {
         this.stateSupplier = stateSupplierToUse;
         this.stateConsumer = stateConsumerToUse;
         this.networkService = networkServiceToUse;
+        this.lock = lockToUse;
     }
 
     @Override
@@ -32,22 +36,27 @@ public final class RemoveBuildingCommandHandler implements CommandHandler<Remove
 
     @Override
     public void handle(final RemoveBuildingCommand command) {
-        MapState state = stateSupplier.get();
-        Iterator<BuildingData> it = state.buildings().iterator();
-        BuildingData target = null;
-        while (it.hasNext()) {
-            BuildingData bd = it.next();
-            if (bd.x() == command.x() && bd.y() == command.y()) {
-                target = bd;
-                it.remove();
-                break;
+        lock.lock();
+        try {
+            MapState state = stateSupplier.get();
+            Iterator<BuildingData> it = state.buildings().iterator();
+            BuildingData target = null;
+            while (it.hasNext()) {
+                BuildingData bd = it.next();
+                if (bd.x() == command.x() && bd.y() == command.y()) {
+                    target = bd;
+                    it.remove();
+                    break;
+                }
             }
+            if (target == null) {
+                return;
+            }
+            stateConsumer.accept(state);
+            Events.dispatch(new BuildingRemovedEvent(command.x(), command.y()));
+            networkService.broadcast(new BuildingRemovalData(command.x(), command.y()));
+        } finally {
+            lock.unlock();
         }
-        if (target == null) {
-            return;
-        }
-        stateConsumer.accept(state);
-        Events.dispatch(new BuildingRemovedEvent(command.x(), command.y()));
-        networkService.broadcast(new BuildingRemovalData(command.x(), command.y()));
     }
 }

--- a/server/src/main/java/net/lapidist/colony/server/commands/TileSelectionCommandHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/TileSelectionCommandHandler.java
@@ -10,6 +10,7 @@ import net.lapidist.colony.server.events.TileSelectionEvent;
 import net.lapidist.colony.server.services.NetworkService;
 
 import java.util.function.Supplier;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Applies a {@link TileSelectionCommand} to the game state and broadcasts the change.
@@ -17,11 +18,14 @@ import java.util.function.Supplier;
 public final class TileSelectionCommandHandler implements CommandHandler<TileSelectionCommand> {
     private final Supplier<MapState> stateSupplier;
     private final NetworkService networkService;
+    private final ReentrantLock lock;
 
     public TileSelectionCommandHandler(final Supplier<MapState> stateSupplierToUse,
-                                       final NetworkService networkServiceToUse) {
+                                       final NetworkService networkServiceToUse,
+                                       final ReentrantLock lockToUse) {
         this.stateSupplier = stateSupplierToUse;
         this.networkService = networkServiceToUse;
+        this.lock = lockToUse;
     }
 
     @Override
@@ -31,17 +35,22 @@ public final class TileSelectionCommandHandler implements CommandHandler<TileSel
 
     @Override
     public void handle(final TileSelectionCommand command) {
-        MapState state = stateSupplier.get();
-        TileData tile = state.getTile(command.x(), command.y());
-        if (tile != null) {
-            TileData updated = tile.toBuilder().selected(command.selected()).build();
-            int chunkX = Math.floorDiv(command.x(), MapChunkData.CHUNK_SIZE);
-            int chunkY = Math.floorDiv(command.y(), MapChunkData.CHUNK_SIZE);
-            int localX = Math.floorMod(command.x(), MapChunkData.CHUNK_SIZE);
-            int localY = Math.floorMod(command.y(), MapChunkData.CHUNK_SIZE);
-            state.getOrCreateChunk(chunkX, chunkY).getTiles().put(new TilePos(localX, localY), updated);
+        lock.lock();
+        try {
+            MapState state = stateSupplier.get();
+            TileData tile = state.getTile(command.x(), command.y());
+            if (tile != null) {
+                TileData updated = tile.toBuilder().selected(command.selected()).build();
+                int chunkX = Math.floorDiv(command.x(), MapChunkData.CHUNK_SIZE);
+                int chunkY = Math.floorDiv(command.y(), MapChunkData.CHUNK_SIZE);
+                int localX = Math.floorMod(command.x(), MapChunkData.CHUNK_SIZE);
+                int localY = Math.floorMod(command.y(), MapChunkData.CHUNK_SIZE);
+                state.getOrCreateChunk(chunkX, chunkY).getTiles().put(new TilePos(localX, localY), updated);
+            }
+            Events.dispatch(new TileSelectionEvent(command.x(), command.y(), command.selected()));
+            networkService.broadcast(new TileSelectionData(command.x(), command.y(), command.selected()));
+        } finally {
+            lock.unlock();
         }
-        Events.dispatch(new TileSelectionEvent(command.x(), command.y(), command.selected()));
-        networkService.broadcast(new TileSelectionData(command.x(), command.y(), command.selected()));
     }
 }

--- a/server/src/main/java/net/lapidist/colony/server/handlers/MapChunkRequestHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/handlers/MapChunkRequestHandler.java
@@ -6,24 +6,33 @@ import net.lapidist.colony.network.AbstractMessageHandler;
 import net.lapidist.colony.server.services.NetworkService;
 
 import java.util.function.Supplier;
+import java.util.concurrent.locks.ReentrantLock;
 
 /** Handles incoming {@link MapChunkRequest} messages by sending the requested chunk. */
 public final class MapChunkRequestHandler extends AbstractMessageHandler<MapChunkRequest> {
     private final Supplier<MapState> stateSupplier;
     private final NetworkService networkService;
+    private final ReentrantLock lock;
 
     public MapChunkRequestHandler(final Supplier<MapState> stateSupplierToUse,
-                                  final NetworkService networkServiceToUse) {
+                                  final NetworkService networkServiceToUse,
+                                  final ReentrantLock lockToUse) {
         super(MapChunkRequest.class);
         this.stateSupplier = stateSupplierToUse;
         this.networkService = networkServiceToUse;
+        this.lock = lockToUse;
     }
 
     @Override
     public void handle(final MapChunkRequest message) {
-        MapState state = stateSupplier.get();
-        if (state != null) {
-            networkService.broadcastChunk(state, message.chunkX(), message.chunkY());
+        lock.lock();
+        try {
+            MapState state = stateSupplier.get();
+            if (state != null) {
+                networkService.broadcastChunk(state, message.chunkX(), message.chunkY());
+            }
+        } finally {
+            lock.unlock();
         }
     }
 }

--- a/server/src/main/java/net/lapidist/colony/server/services/ResourceProductionService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/ResourceProductionService.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Periodically increases player food based on existing farms.
@@ -21,18 +22,21 @@ public final class ResourceProductionService {
     private final Supplier<MapState> supplier;
     private final Consumer<MapState> consumer;
     private final NetworkService networkService;
+    private final ReentrantLock lock;
     private ScheduledExecutorService executor;
 
     public ResourceProductionService(
             final long intervalToUse,
             final Supplier<MapState> stateSupplier,
             final Consumer<MapState> stateConsumer,
-            final NetworkService networkServiceToUse
+            final NetworkService networkServiceToUse,
+            final ReentrantLock lockToUse
     ) {
         this.interval = intervalToUse;
         this.supplier = stateSupplier;
         this.consumer = stateConsumer;
         this.networkService = networkServiceToUse;
+        this.lock = lockToUse;
     }
 
     /** Starts periodic production on a daemon thread. */
@@ -53,30 +57,36 @@ public final class ResourceProductionService {
     }
 
     private void produce() {
-        MapState state = supplier.get();
-        long farms = state.buildings().stream()
-                .map(BuildingData::buildingType)
-                .filter(t -> BuildingType.FARM.name().equals(t))
-                .count();
-        if (farms == 0) {
-            return;
+        MapState state;
+        lock.lock();
+        try {
+            state = supplier.get();
+            long farms = state.buildings().stream()
+                    .map(BuildingData::buildingType)
+                    .filter(t -> BuildingType.FARM.name().equals(t))
+                    .count();
+            if (farms == 0) {
+                return;
+            }
+            ResourceData player = state.playerResources();
+            ResourceData updated = new ResourceData(
+                    player.wood(),
+                    player.stone(),
+                    player.food() + (int) farms
+            );
+            MapState newState = state.toBuilder()
+                    .playerResources(updated)
+                    .build();
+            consumer.accept(newState);
+            networkService.broadcast(new ResourceUpdateData(
+                    -1,
+                    -1,
+                    updated.wood(),
+                    updated.stone(),
+                    updated.food()
+            ));
+        } finally {
+            lock.unlock();
         }
-        ResourceData player = state.playerResources();
-        ResourceData updated = new ResourceData(
-                player.wood(),
-                player.stone(),
-                player.food() + (int) farms
-        );
-        MapState newState = state.toBuilder()
-                .playerResources(updated)
-                .build();
-        consumer.accept(newState);
-        networkService.broadcast(new ResourceUpdateData(
-                -1,
-                -1,
-                updated.wood(),
-                updated.stone(),
-                updated.food()
-        ));
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/server/AutosaveServiceTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/AutosaveServiceTest.java
@@ -8,6 +8,7 @@ import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.io.Paths;
 import net.lapidist.colony.io.TestPathService;
 import net.lapidist.colony.server.services.AutosaveService;
+import java.util.concurrent.locks.ReentrantLock;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -34,7 +35,12 @@ public class AutosaveServiceTest {
 
         try (MockedStatic<Paths> mock = Mockito.mockStatic(Paths.class)) {
             mock.when(Paths::get).thenReturn(paths);
-            AutosaveService service = new AutosaveService(0, "err", MapState::new);
+            AutosaveService service = new AutosaveService(
+                    0,
+                    "err",
+                    MapState::new,
+                    new ReentrantLock()
+            );
             service.stop();
         }
 

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerConcurrencyTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerConcurrencyTest.java
@@ -1,0 +1,55 @@
+package net.lapidist.colony.tests.server;
+
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.components.state.BuildingPlacementData;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.ResourceData;
+import net.lapidist.colony.map.ChunkedMapGenerator;
+import net.lapidist.colony.map.MapGenerator;
+import net.lapidist.colony.server.GameServer;
+import net.lapidist.colony.server.GameServerConfig;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertTrue;
+
+public class GameServerConcurrencyTest {
+
+    private static final int WAIT_MS = 200;
+    private static final int AUTOSAVE_MS = 10;
+
+    @Test
+    public void autosaveRunsWhileProcessingCommands() throws Exception {
+        MapGenerator gen = (w, h) -> {
+            MapState state = new ChunkedMapGenerator().generate(w, h);
+            return state.toBuilder().playerResources(new ResourceData(1, 0, 0)).build();
+        };
+        GameServerConfig config = GameServerConfig.builder()
+                .saveName("concurrency")
+                .autosaveInterval(AUTOSAVE_MS)
+                .mapGenerator(gen)
+                .build();
+        net.lapidist.colony.io.Paths.get().deleteAutosave("concurrency");
+        GameServer server = new GameServer(config);
+        server.start();
+
+        GameClient client = new GameClient();
+        CountDownLatch latch = new CountDownLatch(1);
+        client.start(state -> latch.countDown());
+        latch.await(1, TimeUnit.SECONDS);
+
+        client.sendBuildRequest(new BuildingPlacementData(0, 0, "HOUSE"));
+        Thread.sleep(WAIT_MS);
+
+        assertTrue(server.getMapState().buildings().stream()
+                .anyMatch(b -> b.x() == 0 && b.y() == 0));
+        assertTrue(java.nio.file.Files.exists(
+                net.lapidist.colony.io.Paths.get().getAutosave("concurrency")));
+
+        client.stop();
+        server.stop();
+        Thread.sleep(WAIT_MS);
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/server/ResourceProductionServiceTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/ResourceProductionServiceTest.java
@@ -7,6 +7,7 @@ import net.lapidist.colony.components.state.ResourceUpdateData;
 import net.lapidist.colony.server.services.NetworkService;
 import net.lapidist.colony.server.services.ResourceProductionService;
 import org.junit.Test;
+import java.util.concurrent.locks.ReentrantLock;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -29,7 +30,8 @@ public class ResourceProductionServiceTest {
                 INTERVAL,
                 ref::get,
                 ref::set,
-                network
+                network,
+                new ReentrantLock()
         );
 
         service.start();


### PR DESCRIPTION
## Summary
- introduce `ReentrantLock` in `GameServer`
- lock map state access in services and handlers
- document locking rules in `GameServer`
- test concurrent autosave and command execution

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684d66dcee3c8328a61a1a5aecc7be5f