### PR TITLE
feat: add connection error callback

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/Colony.java
+++ b/client/src/main/java/net/lapidist/colony/client/Colony.java
@@ -6,6 +6,7 @@ import net.lapidist.colony.io.Paths;
 import net.lapidist.colony.client.screens.MapScreen;
 import net.lapidist.colony.client.screens.MainMenuScreen;
 import net.lapidist.colony.client.screens.LoadingScreen;
+import net.lapidist.colony.client.screens.ErrorScreen;
 import net.lapidist.colony.client.screens.NewGameScreen;
 import net.lapidist.colony.i18n.I18n;
 import net.lapidist.colony.settings.Settings;
@@ -75,6 +76,14 @@ public final class Colony extends Game {
             );
             server.start();
             client = new GameClient();
+            client.setConnectionErrorCallback(e -> Gdx.app.postRunnable(() -> {
+                client.stop();
+                if (server != null) {
+                    server.stop();
+                    server = null;
+                }
+                setScreen(new ErrorScreen(this, I18n.get("error.connectionFailed")));
+            }));
             LoadingScreen loading = new LoadingScreen();
             loading.setMessage(I18n.get("loading.connect"));
             client.setLoadProgressListener(p -> Gdx.app.postRunnable(() -> loading.setProgress(p)));

--- a/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
+++ b/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
@@ -69,6 +69,7 @@ public final class GameClient extends AbstractMessageEndpoint {
     private int mapHeight = MapState.DEFAULT_HEIGHT;
     private java.util.function.Consumer<Float> loadProgressListener;
     private java.util.function.Consumer<String> loadMessageListener;
+    private java.util.function.Consumer<Exception> connectionErrorCallback;
 
     private <T> Queue<T> registerQueue(final Class<T> type) {
         Queue<T> queue = new ConcurrentLinkedQueue<>();
@@ -111,6 +112,14 @@ public final class GameClient extends AbstractMessageEndpoint {
      */
     public void setLoadMessageListener(final java.util.function.Consumer<String> listener) {
         this.loadMessageListener = listener;
+    }
+
+    /**
+     * Register a callback for connection errors. If provided, it will be invoked when the
+     * initial connection attempt fails instead of throwing an exception.
+     */
+    public void setConnectionErrorCallback(final java.util.function.Consumer<Exception> callback) {
+        this.connectionErrorCallback = callback;
     }
 
     /**
@@ -175,7 +184,7 @@ public final class GameClient extends AbstractMessageEndpoint {
         this.handlers = handlersToUse;
     }
 
-    private void connect() throws IOException {
+    private void connect() {
         KryoRegistry.register(client.getKryo());
         client.start();
         LOGGER.info("Connecting to server...");
@@ -192,17 +201,25 @@ public final class GameClient extends AbstractMessageEndpoint {
                 playerId = connection.getID();
             }
         });
-        client.connect(CONNECT_TIMEOUT, "localhost", GameServer.TCP_PORT, GameServer.UDP_PORT);
+        try {
+            client.connect(CONNECT_TIMEOUT, "localhost", GameServer.TCP_PORT, GameServer.UDP_PORT);
+        } catch (IOException e) {
+            LOGGER.error("Failed to connect to server", e);
+            client.stop();
+            if (connectionErrorCallback != null) {
+                connectionErrorCallback.accept(e);
+            } else {
+                throw new RuntimeException(e);
+            }
+        }
     }
 
     @Override
     /**
      * Starts the client and connects to the local {@link GameServer} using
      * the default callback.
-     *
-     * @throws IOException if the connection cannot be established
      */
-    public void start() throws IOException {
+    public void start() {
         start(ms -> {
         });
     }
@@ -211,12 +228,13 @@ public final class GameClient extends AbstractMessageEndpoint {
      * Start the client and register a callback invoked once the initial map is loaded.
      *
      * @param callback called when the map has finished loading
-     * @throws IOException if network connection fails
      */
-    public void start(final Consumer<MapState> callback) throws IOException {
+    public void start(final Consumer<MapState> callback) {
         this.readyCallback = callback;
         connect();
-        startRequestExecutor();
+        if (client.isConnected()) {
+            startRequestExecutor();
+        }
     }
 
     /**

--- a/client/src/main/java/net/lapidist/colony/client/screens/ErrorScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/ErrorScreen.java
@@ -1,0 +1,26 @@
+package net.lapidist.colony.client.screens;
+
+import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
+import net.lapidist.colony.i18n.I18n;
+import net.lapidist.colony.client.Colony;
+
+/** Simple screen that displays an error message with a button to return to the main menu. */
+public final class ErrorScreen extends BaseScreen {
+    public ErrorScreen(final Colony colony, final String message) {
+        Label label = new Label(message, getSkin());
+        TextButton back = new TextButton(I18n.get("common.back"), getSkin());
+
+        getRoot().add(label).row();
+        getRoot().add(back).row();
+
+        back.addListener(new ChangeListener() {
+            @Override
+            public void changed(final ChangeEvent event, final Actor actor) {
+                colony.setScreen(new MainMenuScreen(colony));
+            }
+        });
+    }
+}

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -29,6 +29,7 @@ language.es=Español
 language.de=Deutsch
 ui.fpsSuffix= FPS
 error.preferencesUnavailable=Preferences unavailable
+error.connectionFailed=Could not connect to server
 chat.placeholder=Type a message
 chat.format=%d: %s
 settings.keybinds=Keybinds

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -28,6 +28,7 @@ language.es=Spanisch
 language.de=Deutsch
 ui.fpsSuffix= FPS
 error.preferencesUnavailable=Einstellungen nicht verfügbar
+error.connectionFailed=Keine Verbindung zum Server möglich
 chat.placeholder=Nachricht eingeben
 chat.format=%d: %s
 settings.keybinds=Tastenbelegung

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -28,6 +28,7 @@ language.es=Español
 language.de=Alemán
 ui.fpsSuffix= FPS
 error.preferencesUnavailable=Preferencias no disponibles
+error.connectionFailed=No se pudo conectar al servidor
 chat.placeholder=Escribe un mensaje
 chat.format=%d: %s
 settings.keybinds=Teclas

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -28,6 +28,7 @@ language.es=Espagnol
 language.de=Allemand
 ui.fpsSuffix= FPS
 error.preferencesUnavailable=Préférences indisponibles
+error.connectionFailed=Impossible de se connecter au serveur
 chat.placeholder=Entrez un message
 chat.format=%d: %s
 settings.keybinds=Touches

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -40,6 +40,20 @@ client.start(state -> {
 });
 ```
 
+### Handling Connection Errors
+
+`GameClient` exposes an optional error callback for failed connections. Register
+it before calling `start` to handle issues like the server not running:
+
+```java
+GameClient client = new GameClient();
+client.setConnectionErrorCallback(ex -> System.err.println(ex.getMessage()));
+client.start(state -> { /* loaded */ });
+```
+
+`Colony.startGame()` uses this callback to show an error screen when the client
+cannot connect.
+
 The client submits requests using methods such as `sendTileSelectionRequest`. Each update is later retrieved within an update system:
 
 ```java

--- a/tests/src/test/java/net/lapidist/colony/tests/network/GameClientConnectionErrorTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/network/GameClientConnectionErrorTest.java
@@ -1,0 +1,23 @@
+package net.lapidist.colony.tests.network;
+
+import net.lapidist.colony.client.network.GameClient;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertNull;
+
+public class GameClientConnectionErrorTest {
+
+    @Test
+    public void callbackInvokedWhenConnectionFails() throws Exception {
+        GameClient client = new GameClient();
+        CountDownLatch latch = new CountDownLatch(1);
+        client.setConnectionErrorCallback(e -> latch.countDown());
+        client.start();
+        latch.await(1, TimeUnit.SECONDS);
+        assertNull(client.getMapState());
+        client.stop();
+    }
+}


### PR DESCRIPTION
## Summary
- allow registering a `Consumer<Exception>` on `GameClient`
- handle connection failures through this callback
- show an `ErrorScreen` from `Colony.startGame` when connection fails
- add translations for `error.connectionFailed`
- document connection error handling in networking guide
- test that the callback runs if the server is unavailable

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684d6f781f8c8328be78ca50751c0c77