### PR TITLE
feat: add NetworkConfig for host and ports

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
+++ b/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
@@ -20,7 +20,7 @@ import net.lapidist.colony.serialization.KryoRegistry;
 import net.lapidist.colony.network.AbstractMessageEndpoint;
 import net.lapidist.colony.network.DispatchListener;
 import net.lapidist.colony.network.MessageHandler;
-import net.lapidist.colony.server.GameServer;
+import net.lapidist.colony.config.NetworkConfig;
 import net.lapidist.colony.client.network.handlers.MapMetadataHandler;
 import net.lapidist.colony.client.network.handlers.MapChunkHandler;
 import net.lapidist.colony.client.network.handlers.QueueingMessageHandler;
@@ -41,7 +41,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Handles all network communication with a {@link GameServer} instance.
+ * Handles all network communication with a {@link net.lapidist.colony.server.GameServer} instance.
  * <p>
  * The client is responsible for receiving world updates, queuing messages for
  * later processing and loading the initial map state.
@@ -202,7 +202,11 @@ public final class GameClient extends AbstractMessageEndpoint implements AutoClo
             }
         });
         try {
-            client.connect(CONNECT_TIMEOUT, "localhost", GameServer.TCP_PORT, GameServer.UDP_PORT);
+            client.connect(
+                    CONNECT_TIMEOUT,
+                    NetworkConfig.getHost(),
+                    NetworkConfig.getTcpPort(),
+                    NetworkConfig.getUdpPort());
         } catch (IOException e) {
             LOGGER.error("Failed to connect to server", e);
             client.stop();
@@ -216,7 +220,7 @@ public final class GameClient extends AbstractMessageEndpoint implements AutoClo
 
     @Override
     /**
-     * Starts the client and connects to the local {@link GameServer} using
+     * Starts the client and connects to the local {@link net.lapidist.colony.server.GameServer} using
      * the default callback.
      */
     public void start() {

--- a/core/src/main/java/net/lapidist/colony/config/NetworkConfig.java
+++ b/core/src/main/java/net/lapidist/colony/config/NetworkConfig.java
@@ -1,0 +1,25 @@
+package net.lapidist.colony.config;
+
+public final class NetworkConfig {
+
+    private static final int TCP_PORT = ColonyConfig.get().getInt("game.server.tcpPort");
+    private static final int UDP_PORT = ColonyConfig.get().getInt("game.server.udpPort");
+    private static final String HOST = ColonyConfig.get().hasPath("game.server.host")
+            ? ColonyConfig.get().getString("game.server.host")
+            : "localhost";
+
+    private NetworkConfig() {
+    }
+
+    public static int getTcpPort() {
+        return TCP_PORT;
+    }
+
+    public static int getUdpPort() {
+        return UDP_PORT;
+    }
+
+    public static String getHost() {
+        return HOST;
+    }
+}

--- a/core/src/main/resources/game.conf
+++ b/core/src/main/resources/game.conf
@@ -5,6 +5,7 @@ game {
   defaultSaveName = "autosave"
   networkBufferSize = 8388608
   server {
+    host = "localhost"
     tcpPort = 54555
     udpPort = 54777
   }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,7 @@
 # Configuration
 
 Default settings are read from `core/src/main/resources/game.conf`.
-The file controls the network buffer size, autosave interval and server ports.
+The file controls the network buffer size, autosave interval, server host and ports.
 Map size is determined when creating a game or loading a save:
 
 ```hocon
@@ -11,6 +11,7 @@ game {
   defaultSaveName = "autosave"
     networkBufferSize = 8388608
   server {
+    host = "localhost"
     tcpPort = 54555
     udpPort = 54777
   }

--- a/server/src/main/java/net/lapidist/colony/server/GameServer.java
+++ b/server/src/main/java/net/lapidist/colony/server/GameServer.java
@@ -2,7 +2,7 @@ package net.lapidist.colony.server;
 
 import com.esotericsoftware.kryonet.Server;
 import net.lapidist.colony.components.state.MapState;
-import net.lapidist.colony.config.ColonyConfig;
+import net.lapidist.colony.config.NetworkConfig;
 import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.events.Events;
 import net.lapidist.colony.serialization.KryoRegistry;
@@ -43,8 +43,6 @@ import java.io.IOException;
  * lock instance and are responsible for locking when reading or modifying state.
  */
 public final class GameServer extends AbstractMessageEndpoint implements AutoCloseable {
-    public static final int TCP_PORT = ColonyConfig.get().getInt("game.server.tcpPort");
-    public static final int UDP_PORT = ColonyConfig.get().getInt("game.server.udpPort");
 
     // Buffer size for Kryo serialization configured via game.networkBufferSize.
     private static final Logger LOGGER = LoggerFactory.getLogger(GameServer.class);
@@ -104,7 +102,7 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
         this.handlers = handlersToUse;
         this.commandHandlers = commandHandlersToUse;
         this.mapService = new MapService(mapGenerator, saveName, mapWidth, mapHeight, stateLock);
-        this.networkService = new NetworkService(server, TCP_PORT, UDP_PORT);
+        this.networkService = new NetworkService(server, NetworkConfig.getTcpPort(), NetworkConfig.getUdpPort());
         this.autosaveService = new AutosaveService(autosaveInterval, saveName, () -> mapState, stateLock);
         this.resourceProductionService = new ResourceProductionService(
                 autosaveInterval,


### PR DESCRIPTION
## Summary
- add `NetworkConfig` to centralize TCP/UDP port and host settings
- load host and port defaults from `game.conf`
- use `NetworkConfig` in server and client modules
- document `game.server.host` configuration key

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684d7415989c83289aebfe29a25e4eb8