### PR TITLE
feat: show autosave progress

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/MapUiBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapUiBuilder.java
@@ -17,6 +17,7 @@ import net.lapidist.colony.client.ui.MinimapActor;
 import net.lapidist.colony.client.ui.ChatBox;
 import net.lapidist.colony.client.ui.PlayerResourcesActor;
 import net.lapidist.colony.client.ui.AutosaveLabel;
+import net.lapidist.colony.client.ui.AutosaveProgressBar;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.client.systems.BuildPlacementSystem;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
@@ -161,6 +162,13 @@ public final class MapUiBuilder {
         savingTable.top().right();
         savingTable.add(savingLabel).pad(PADDING);
         stage.addActor(savingTable);
+
+        AutosaveProgressBar progressBar = new AutosaveProgressBar(skin);
+        Table progressTable = new Table();
+        progressTable.setFillParent(true);
+        progressTable.bottom().right();
+        progressTable.add(progressBar).pad(PADDING);
+        stage.addActor(progressTable);
 
         stage.addListener(new InputListener() {
             @Override

--- a/client/src/main/java/net/lapidist/colony/client/ui/AutosaveProgressBar.java
+++ b/client/src/main/java/net/lapidist/colony/client/ui/AutosaveProgressBar.java
@@ -1,0 +1,66 @@
+package net.lapidist.colony.client.ui;
+
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.scenes.scene2d.ui.ProgressBar;
+import com.badlogic.gdx.scenes.scene2d.ui.ProgressBar.ProgressBarStyle;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import net.lapidist.colony.events.Events;
+import net.lapidist.colony.server.events.AutosaveEvent;
+import net.lapidist.colony.server.events.AutosaveStartEvent;
+import net.mostlyoriginal.api.event.common.Subscribe;
+
+/** Progress bar displayed while the game state is being autosaved. */
+public final class AutosaveProgressBar extends ProgressBar {
+    private static final float STEP = 0.01f;
+    private static final float DISPLAY_TIME = 2f;
+    private float timer;
+    private boolean running;
+
+    public AutosaveProgressBar(final Skin skin) {
+        super(0f, 1f, STEP, false, createStyle(skin));
+        setName("autosaveProgress");
+        setVisible(false);
+        if (Events.getInstance() != null) {
+            Events.getInstance().registerEvents(this);
+        }
+    }
+
+    private static ProgressBarStyle createStyle(final Skin skin) {
+        ProgressBarStyle style = new ProgressBarStyle();
+        style.background = skin.newDrawable("white_pixel", Color.DARK_GRAY);
+        style.knobBefore = skin.newDrawable("white_pixel", Color.GREEN);
+        style.knob = skin.newDrawable("white_pixel", Color.GREEN);
+        return style;
+    }
+
+    @Subscribe
+    private void onAutosaveStart(final AutosaveStartEvent event) {
+        setValue(0f);
+        timer = 0f;
+        running = true;
+        setVisible(true);
+    }
+
+    @Subscribe
+    private void onAutosaveComplete(final AutosaveEvent event) {
+        setValue(1f);
+        timer = DISPLAY_TIME;
+        running = false;
+    }
+
+    @Override
+    public void act(final float delta) {
+        super.act(delta);
+        if (!isVisible()) {
+            return;
+        }
+        if (running) {
+            setValue(Math.min(1f, getValue() + delta));
+        } else {
+            timer -= delta;
+            if (timer <= 0f) {
+                setVisible(false);
+            }
+        }
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
@@ -31,6 +31,7 @@ public final class SaveMigrator {
         register(new V15ToV16Migration());
         register(new V16ToV17Migration());
         register(new V17ToV18Migration());
+        register(new V18ToV19Migration());
     }
 
     private SaveMigrator() {

--- a/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
@@ -21,9 +21,10 @@ public enum SaveVersion {
     V15(15),
     V16(16),
     V17(17),
-    V18(18);
+    V18(18),
+    V19(19);
 
-    public static final SaveVersion CURRENT = V18;
+    public static final SaveVersion CURRENT = V19;
 
     private final int number;
 

--- a/core/src/main/java/net/lapidist/colony/save/V18ToV19Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V18ToV19Migration.java
@@ -1,0 +1,23 @@
+package net.lapidist.colony.save;
+
+import net.lapidist.colony.components.state.MapState;
+
+/** Migration from save version 18 to 19 with no data changes. */
+public final class V18ToV19Migration implements MapStateMigration {
+    @Override
+    public int fromVersion() {
+        return SaveVersion.V18.number();
+    }
+
+    @Override
+    public int toVersion() {
+        return SaveVersion.V19.number();
+    }
+
+    @Override
+    public MapState apply(final MapState state) {
+        return state.toBuilder()
+                .version(toVersion())
+                .build();
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,9 +34,10 @@ public enum SaveVersion {
     V1(1),
     V2(2),
     // ...
-    V18(18);
+    V18(18),
+    V19(19);
 
-    public static final SaveVersion CURRENT = V18;
+    public static final SaveVersion CURRENT = V19;
 }
 ```
 

--- a/server/src/main/java/net/lapidist/colony/server/events/AutosaveStartEvent.java
+++ b/server/src/main/java/net/lapidist/colony/server/events/AutosaveStartEvent.java
@@ -1,0 +1,25 @@
+package net.lapidist.colony.server.events;
+
+import net.mostlyoriginal.api.event.common.Event;
+
+import java.nio.file.Path;
+
+/** Event fired when the server starts writing a game state autosave file. */
+public record AutosaveStartEvent(Path location) implements Event {
+
+    /**
+     * Creates a new {@code AutosaveStartEvent}.
+     */
+    public AutosaveStartEvent {
+        // explicit constructor for future validation
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "%s(location=%s)",
+                getClass().getSimpleName(),
+                location
+        );
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/server/services/AutosaveService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/AutosaveService.java
@@ -4,6 +4,7 @@ import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.events.Events;
 import net.lapidist.colony.io.Paths;
 import net.lapidist.colony.server.events.AutosaveEvent;
+import net.lapidist.colony.server.events.AutosaveStartEvent;
 import net.lapidist.colony.server.events.ShutdownSaveEvent;
 import net.mostlyoriginal.api.event.common.Event;
 import net.lapidist.colony.server.io.GameStateIO;
@@ -84,6 +85,8 @@ public final class AutosaveService {
         }
         try {
             Path file = Paths.get().getAutosave(saveName);
+            Events.dispatch(new AutosaveStartEvent(file));
+            Events.update();
             GameStateIO.save(mapState, file);
             long size = Files.size(file);
             Events.dispatch(creator.apply(file, size));

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV18Test.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV18Test.java
@@ -1,0 +1,41 @@
+package net.lapidist.colony.tests.server;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Output;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.serialization.KryoRegistry;
+import net.lapidist.colony.save.SaveData;
+import net.lapidist.colony.save.SaveVersion;
+import net.lapidist.colony.serialization.SerializationRegistrar;
+import net.lapidist.colony.server.io.GameStateIO;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+
+public class GameStateIOMigrationV18Test {
+
+    @Test
+    public void migratesV18ToCurrent() throws Exception {
+        Path file = Files.createTempFile("state", ".dat");
+        MapState state = MapState.builder()
+                .version(SaveVersion.V18.number())
+                .build();
+        Kryo kryo = new Kryo();
+        KryoRegistry.register(kryo);
+        try (Output output = new Output(Files.newOutputStream(file))) {
+            SaveData data = new SaveData(
+                    SaveVersion.V18.number(),
+                    SerializationRegistrar.registrationHash(),
+                    state
+            );
+            kryo.writeObject(output, data);
+        }
+
+        MapState loaded = GameStateIO.load(file);
+        Files.deleteIfExists(file);
+        assertEquals(SaveVersion.CURRENT.number(), loaded.version());
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/ui/AutosaveProgressBarTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/ui/AutosaveProgressBarTest.java
@@ -1,0 +1,46 @@
+package net.lapidist.colony.tests.ui;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import net.lapidist.colony.client.ui.AutosaveProgressBar;
+import net.lapidist.colony.events.Events;
+import net.lapidist.colony.server.events.AutosaveEvent;
+import net.lapidist.colony.server.events.AutosaveStartEvent;
+import net.lapidist.colony.tests.GdxTestRunner;
+import net.mostlyoriginal.api.event.common.EventSystem;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.nio.file.Path;
+
+import static org.junit.Assert.*;
+
+/** Tests for {@link AutosaveProgressBar}. */
+@RunWith(GdxTestRunner.class)
+public class AutosaveProgressBarTest {
+
+    private static final float ADVANCE = 2.5f;
+
+    @Test
+    public void showsProgressDuringAutosave() {
+        EventSystem system = new EventSystem();
+        Events.init(system);
+        Skin skin = new Skin(Gdx.files.internal("skin/default.json"));
+        AutosaveProgressBar bar = new AutosaveProgressBar(skin);
+
+        Events.dispatch(new AutosaveStartEvent(Path.of("tmp")));
+        Events.update();
+        assertTrue(bar.isVisible());
+        assertEquals(0f, bar.getValue(), 0f);
+
+        bar.act(1f);
+        assertTrue(bar.getValue() > 0f);
+
+        Events.dispatch(new AutosaveEvent(Path.of("tmp"), 1L));
+        Events.update();
+        assertEquals(1f, bar.getValue(), 0f);
+
+        bar.act(ADVANCE);
+        assertFalse(bar.isVisible());
+    }
+}


### PR DESCRIPTION
## Summary
- bump save version and add V18->V19 migration
- dispatch AutosaveStartEvent when autosaving begins
- add AutosaveProgressBar widget and integrate into map UI
- show autosave progress bar and saving label
- document new SaveVersion
- test save migration and progress bar

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684d76916bdc83288127237950cdb7d9