### PR TITLE
feat: sync player position across network

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
+++ b/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
@@ -146,7 +146,9 @@ public final class GameClient extends AbstractMessageEndpoint implements AutoClo
                             .width(meta.width())
                             .height(meta.height())
                             .buildings(new java.util.ArrayList<>(meta.buildings()))
-                            .playerResources(meta.playerResources());
+                            .playerResources(meta.playerResources())
+                            .playerPos(meta.playerPos())
+                            .cameraPos(meta.cameraPos());
                     tileBuffer = new java.util.HashMap<>();
                     expectedChunks = meta.chunkCount();
                     mapWidth = meta.width();
@@ -440,6 +442,13 @@ public final class GameClient extends AbstractMessageEndpoint implements AutoClo
      * Send a resource gather request to the server.
      */
     public void sendGatherRequest(final ResourceGatherRequestData data) {
+        send(data);
+    }
+
+    /**
+     * Send a player position update to the server.
+     */
+    public void sendPlayerPositionUpdate(final net.lapidist.colony.components.state.PlayerPositionUpdate data) {
         send(data);
     }
 

--- a/client/src/main/java/net/lapidist/colony/client/systems/PlayerMovementSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/PlayerMovementSystem.java
@@ -20,6 +20,8 @@ public final class PlayerMovementSystem extends BaseSystem {
     private PlayerCameraSystem cameraSystem;
     private ComponentMapper<PlayerComponent> playerMapper;
     private Entity player;
+    private int lastTileX;
+    private int lastTileY;
 
     public PlayerMovementSystem(final KeyBindings bindings) {
         this(null, bindings);
@@ -42,6 +44,9 @@ public final class PlayerMovementSystem extends BaseSystem {
                 .getEntities();
         if (players.size() > 0) {
             player = world.getEntity(players.get(0));
+            PlayerComponent pc = playerMapper.get(player);
+            lastTileX = Math.floorDiv((int) pc.getX(), GameConstants.TILE_SIZE);
+            lastTileY = Math.floorDiv((int) pc.getY(), GameConstants.TILE_SIZE);
         }
     }
 
@@ -65,6 +70,16 @@ public final class PlayerMovementSystem extends BaseSystem {
             pc.setX(pc.getX() + move);
         }
         clampPosition(pc);
+
+        int tileX = Math.floorDiv((int) pc.getX(), GameConstants.TILE_SIZE);
+        int tileY = Math.floorDiv((int) pc.getY(), GameConstants.TILE_SIZE);
+        if (client != null && (tileX != lastTileX || tileY != lastTileY)) {
+            lastTileX = tileX;
+            lastTileY = tileY;
+            client.sendPlayerPositionUpdate(
+                    new net.lapidist.colony.components.state.PlayerPositionUpdate(tileX, tileY)
+            );
+        }
     }
 
     private void clampPosition(final PlayerComponent pc) {

--- a/core/src/main/java/net/lapidist/colony/components/state/MapMetadata.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/MapMetadata.java
@@ -16,6 +16,8 @@ public record MapMetadata(
         String description,
         List<BuildingData> buildings,
         ResourceData playerResources,
+        PlayerPosition playerPos,
+        CameraPosition cameraPos,
         int width,
         int height,
         int chunkCount

--- a/core/src/main/java/net/lapidist/colony/components/state/PlayerPositionUpdate.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/PlayerPositionUpdate.java
@@ -1,0 +1,9 @@
+package net.lapidist.colony.components.state;
+
+import net.lapidist.colony.serialization.KryoType;
+
+/**
+ * Message sent by the client whenever the player changes tile position.
+ */
+@KryoType
+public record PlayerPositionUpdate(int x, int y) { }

--- a/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
@@ -31,6 +31,7 @@ public final class SaveMigrator {
         register(new V15ToV16Migration());
         register(new V16ToV17Migration());
         register(new V17ToV18Migration());
+        register(new V18ToV19Migration());
     }
 
     private SaveMigrator() {

--- a/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
@@ -21,9 +21,10 @@ public enum SaveVersion {
     V15(15),
     V16(16),
     V17(17),
-    V18(18);
+    V18(18),
+    V19(19);
 
-    public static final SaveVersion CURRENT = V18;
+    public static final SaveVersion CURRENT = V19;
 
     private final int number;
 

--- a/core/src/main/java/net/lapidist/colony/save/V18ToV19Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V18ToV19Migration.java
@@ -1,0 +1,23 @@
+package net.lapidist.colony.save;
+
+import net.lapidist.colony.components.state.MapState;
+
+/** Migration from save version 18 to 19 with no data changes. */
+public final class V18ToV19Migration implements MapStateMigration {
+    @Override
+    public int fromVersion() {
+        return SaveVersion.V18.number();
+    }
+
+    @Override
+    public int toVersion() {
+        return SaveVersion.V19.number();
+    }
+
+    @Override
+    public MapState apply(final MapState state) {
+        return state.toBuilder()
+                .version(toVersion())
+                .build();
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/serialization/SerializationRegistrar.java
+++ b/core/src/main/java/net/lapidist/colony/serialization/SerializationRegistrar.java
@@ -19,6 +19,7 @@ import net.lapidist.colony.components.state.MapChunkRequest;
 import net.lapidist.colony.save.SaveData;
 import net.lapidist.colony.components.state.PlayerPosition;
 import net.lapidist.colony.components.state.CameraPosition;
+import net.lapidist.colony.components.state.PlayerPositionUpdate;
 
 /**
  * Registers all serializable classes with a given Kryo instance.
@@ -59,7 +60,7 @@ public final class SerializationRegistrar {
     }
 
     /** Precomputed registration hash for quick access. */
-    public static final int REGISTRATION_HASH = 1490495894;
+    public static final int REGISTRATION_HASH = -308489516;
 
     private static final Class<?>[] REGISTERED_TYPES = {
             TileData.class,
@@ -82,6 +83,7 @@ public final class SerializationRegistrar {
             net.lapidist.colony.chat.ChatMessage.class,
             PlayerPosition.class,
             SaveData.class,
-            CameraPosition.class
+            CameraPosition.class,
+            PlayerPositionUpdate.class
     };
 }

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -65,7 +65,12 @@ sizes small. The client decompresses each chunk before applying it to the map
 state.
 
 `MapMetadata` provides initial game information including the map width and
-height. Clients use these dimensions to determine how many chunks to request
-when loading a new game.
+height. It now also includes the player's spawn tile (`playerPos`) and the
+starting camera position (`cameraPos`). Clients use these values to place the
+player and camera correctly and to determine how many chunks to request when
+loading a new game.
+
+`PlayerPositionUpdate` messages are sent from the client whenever the player
+moves to a new tile so the server can persist the updated location.
 
 For additional details see [architecture.md](architecture.md).

--- a/server/src/main/java/net/lapidist/colony/server/GameServer.java
+++ b/server/src/main/java/net/lapidist/colony/server/GameServer.java
@@ -18,12 +18,14 @@ import net.lapidist.colony.server.handlers.BuildingRemovalRequestHandler;
 import net.lapidist.colony.server.handlers.ChatMessageHandler;
 import net.lapidist.colony.server.handlers.ResourceGatherRequestHandler;
 import net.lapidist.colony.server.handlers.MapChunkRequestHandler;
+import net.lapidist.colony.server.handlers.PlayerPositionUpdateHandler;
 import net.lapidist.colony.server.commands.CommandBus;
 import net.lapidist.colony.server.commands.CommandHandler;
 import net.lapidist.colony.server.commands.TileSelectionCommandHandler;
 import net.lapidist.colony.server.commands.BuildCommandHandler;
 import net.lapidist.colony.server.commands.GatherCommandHandler;
 import net.lapidist.colony.server.commands.RemoveBuildingCommandHandler;
+import net.lapidist.colony.server.commands.PlayerPositionCommandHandler;
 import net.lapidist.colony.server.services.AutosaveService;
 import net.lapidist.colony.server.services.MapService;
 import net.lapidist.colony.server.services.NetworkService;
@@ -154,7 +156,8 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
                     new TileSelectionCommandHandler(() -> mapState, networkService, stateLock),
                     new BuildCommandHandler(() -> mapState, s -> mapState = s, networkService, stateLock),
                     new GatherCommandHandler(() -> mapState, s -> mapState = s, networkService, stateLock),
-                    new RemoveBuildingCommandHandler(() -> mapState, s -> mapState = s, networkService, stateLock)
+                    new RemoveBuildingCommandHandler(() -> mapState, s -> mapState = s, networkService, stateLock),
+                    new PlayerPositionCommandHandler(() -> mapState, s -> mapState = s, stateLock)
             );
         }
         commandBus.registerHandlers(commandHandlers);
@@ -166,7 +169,8 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
                     new BuildingRemovalRequestHandler(commandBus),
                     new ChatMessageHandler(networkService, commandBus),
                     new ResourceGatherRequestHandler(commandBus),
-                    new MapChunkRequestHandler(() -> mapState, networkService, stateLock)
+                    new MapChunkRequestHandler(() -> mapState, networkService, stateLock),
+                    new PlayerPositionUpdateHandler(commandBus)
             );
         }
         registerHandlers(handlers);

--- a/server/src/main/java/net/lapidist/colony/server/commands/PlayerPositionCommand.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/PlayerPositionCommand.java
@@ -1,0 +1,5 @@
+package net.lapidist.colony.server.commands;
+
+/** Command representing a player position update. */
+public record PlayerPositionCommand(int x, int y) implements ServerCommand {
+}

--- a/server/src/main/java/net/lapidist/colony/server/commands/PlayerPositionCommandHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/PlayerPositionCommandHandler.java
@@ -1,0 +1,41 @@
+package net.lapidist.colony.server.commands;
+
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.PlayerPosition;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.concurrent.locks.ReentrantLock;
+
+/** Applies a {@link PlayerPositionCommand} to the map state. */
+public final class PlayerPositionCommandHandler implements CommandHandler<PlayerPositionCommand> {
+    private final Supplier<MapState> stateSupplier;
+    private final Consumer<MapState> stateConsumer;
+    private final ReentrantLock lock;
+
+    public PlayerPositionCommandHandler(final Supplier<MapState> stateSupplierToUse,
+                                        final Consumer<MapState> stateConsumerToUse,
+                                        final ReentrantLock lockToUse) {
+        this.stateSupplier = stateSupplierToUse;
+        this.stateConsumer = stateConsumerToUse;
+        this.lock = lockToUse;
+    }
+
+    @Override
+    public Class<PlayerPositionCommand> type() {
+        return PlayerPositionCommand.class;
+    }
+
+    @Override
+    public void handle(final PlayerPositionCommand command) {
+        lock.lock();
+        try {
+            MapState state = stateSupplier.get();
+            MapState updated = state.toBuilder()
+                    .playerPos(new PlayerPosition(command.x(), command.y()))
+                    .build();
+            stateConsumer.accept(updated);
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/server/handlers/PlayerPositionUpdateHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/handlers/PlayerPositionUpdateHandler.java
@@ -1,0 +1,21 @@
+package net.lapidist.colony.server.handlers;
+
+import net.lapidist.colony.components.state.PlayerPositionUpdate;
+import net.lapidist.colony.network.AbstractMessageHandler;
+import net.lapidist.colony.server.commands.CommandBus;
+import net.lapidist.colony.server.commands.PlayerPositionCommand;
+
+/** Converts incoming {@link PlayerPositionUpdate} into {@link PlayerPositionCommand}. */
+public final class PlayerPositionUpdateHandler extends AbstractMessageHandler<PlayerPositionUpdate> {
+    private final CommandBus commandBus;
+
+    public PlayerPositionUpdateHandler(final CommandBus bus) {
+        super(PlayerPositionUpdate.class);
+        this.commandBus = bus;
+    }
+
+    @Override
+    public void handle(final PlayerPositionUpdate message) {
+        commandBus.dispatch(new PlayerPositionCommand(message.x(), message.y()));
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/server/services/NetworkService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/NetworkService.java
@@ -88,6 +88,8 @@ public final class NetworkService {
                 state.description(),
                 state.buildings(),
                 state.playerResources(),
+                state.playerPos(),
+                state.cameraPos(),
                 state.width(),
                 state.height(),
                 chunkCount

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationSpawnNetworkTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationSpawnNetworkTest.java
@@ -1,0 +1,93 @@
+package net.lapidist.colony.tests.scenario;
+
+import com.artemis.Aspect;
+import com.artemis.Entity;
+import com.artemis.utils.IntBag;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.utils.viewport.ScreenViewport;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.client.screens.MapWorldBuilder;
+import net.lapidist.colony.client.systems.PlayerCameraSystem;
+import net.lapidist.colony.components.entities.PlayerComponent;
+import net.lapidist.colony.components.state.CameraPosition;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.PlayerPosition;
+import net.lapidist.colony.server.GameServer;
+import net.lapidist.colony.server.GameServerConfig;
+import net.lapidist.colony.server.io.GameStateIO;
+import net.lapidist.colony.io.Paths;
+import net.lapidist.colony.settings.KeyBindings;
+import net.lapidist.colony.settings.Settings;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedConstruction;
+
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
+
+@RunWith(GdxTestRunner.class)
+public class GameSimulationSpawnNetworkTest {
+
+    @Test
+    public void playerAndCameraSpawnFromMetadata() throws Exception {
+        final String save = "spawn-net";
+        final int px = 2;
+        final int py = 3;
+        final float camX = 4f;
+        final float camY = 5f;
+        MapState initial = new MapState().toBuilder()
+                .playerPos(new PlayerPosition(px, py))
+                .cameraPos(new CameraPosition(camX, camY))
+                .build();
+        Path file = Paths.get().getAutosave(save);
+        Paths.get().deleteAutosave(save);
+        GameStateIO.save(initial, file);
+
+        try (GameServer server = new GameServer(GameServerConfig.builder()
+                .saveName(save)
+                .build());
+             GameClient client = new GameClient()) {
+            server.start();
+
+            CountDownLatch latch = new CountDownLatch(1);
+            client.start(state -> latch.countDown());
+            latch.await(1, TimeUnit.SECONDS);
+
+            com.badlogic.gdx.graphics.g2d.Batch batch =
+                    org.mockito.Mockito.mock(com.badlogic.gdx.graphics.g2d.Batch.class);
+            when(batch.getTransformMatrix()).thenReturn(new com.badlogic.gdx.math.Matrix4());
+            when(batch.getProjectionMatrix()).thenReturn(new com.badlogic.gdx.math.Matrix4());
+            Stage stage = new Stage(new ScreenViewport(), batch);
+            Settings settings = new Settings();
+            try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
+                var world = MapWorldBuilder.build(
+                        MapWorldBuilder.builder(client.getMapState(), client, stage, new KeyBindings()),
+                        null,
+                        settings,
+                        client.getMapState().cameraPos()
+                );
+                world.process();
+
+                IntBag players = world.getAspectSubscriptionManager()
+                        .get(Aspect.all(PlayerComponent.class))
+                        .getEntities();
+                Entity player = world.getEntity(players.get(0));
+                var pc = world.getMapper(PlayerComponent.class).get(player);
+                final float epsilon = 0.01f;
+                assertEquals(px * net.lapidist.colony.components.GameConstants.TILE_SIZE, pc.getX(), epsilon);
+                assertEquals(py * net.lapidist.colony.components.GameConstants.TILE_SIZE, pc.getY(), epsilon);
+                PlayerCameraSystem camera = world.getSystem(PlayerCameraSystem.class);
+                assertEquals(camX, camera.getCamera().position.x, epsilon);
+                assertEquals(camY, camera.getCamera().position.y, epsilon);
+                world.dispose();
+            }
+        }
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerPlayerPositionSaveTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerPlayerPositionSaveTest.java
@@ -2,12 +2,9 @@ package net.lapidist.colony.tests.server;
 
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.server.GameServerConfig;
-import net.lapidist.colony.server.io.GameStateIO;
 import net.lapidist.colony.io.Paths;
 import net.lapidist.colony.components.state.PlayerPosition;
 import org.junit.Test;
-
-import java.nio.file.Path;
 
 import static org.junit.Assert.assertEquals;
 
@@ -15,19 +12,25 @@ public class GameServerPlayerPositionSaveTest {
 
     @Test
     public void playerPositionPersistsAcrossSaves() throws Exception {
+        final long waitMs = 200;
+        final long extra = 50;
         GameServerConfig config = GameServerConfig.builder()
                 .saveName("pos-save")
+                .autosaveInterval(waitMs)
                 .build();
         Paths.get().deleteAutosave("pos-save");
         GameServer server = new GameServer(config);
         server.start();
 
-        Path saveFile = Paths.get().getAutosave("pos-save");
+        java.lang.reflect.Method dispatch = net.lapidist.colony.network.AbstractMessageEndpoint.class
+                .getDeclaredMethod("dispatch", Object.class);
+        dispatch.setAccessible(true);
+
         final int x = 3;
         final int y = 4;
-        PlayerPosition pos = new PlayerPosition(x, y);
+        dispatch.invoke(server, new net.lapidist.colony.components.state.PlayerPositionUpdate(x, y));
+        Thread.sleep(waitMs + extra);
         server.stop();
-        GameStateIO.save(server.getMapState().toBuilder().playerPos(pos).build(), saveFile);
 
         GameServer server2 = new GameServer(config);
         server2.start();

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV18Test.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV18Test.java
@@ -1,0 +1,41 @@
+package net.lapidist.colony.tests.server;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Output;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.serialization.KryoRegistry;
+import net.lapidist.colony.save.SaveData;
+import net.lapidist.colony.save.SaveVersion;
+import net.lapidist.colony.serialization.SerializationRegistrar;
+import net.lapidist.colony.server.io.GameStateIO;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+
+public class GameStateIOMigrationV18Test {
+
+    @Test
+    public void migratesV18ToCurrent() throws Exception {
+        Path file = Files.createTempFile("state", ".dat");
+        MapState state = MapState.builder()
+                .version(SaveVersion.V18.number())
+                .build();
+        Kryo kryo = new Kryo();
+        KryoRegistry.register(kryo);
+        try (Output output = new Output(Files.newOutputStream(file))) {
+            SaveData data = new SaveData(
+                    SaveVersion.V18.number(),
+                    SerializationRegistrar.registrationHash(),
+                    state
+            );
+            kryo.writeObject(output, data);
+        }
+
+        MapState loaded = GameStateIO.load(file);
+        Files.deleteIfExists(file);
+        assertEquals(SaveVersion.CURRENT.number(), loaded.version());
+    }
+}


### PR DESCRIPTION
## Summary
- include player and camera positions in MapMetadata
- send player position updates from client to server
- persist new position in MapState via command handler
- expose new save version and migration
- document new networking message
- test saving and loading of player position and spawn

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684d75f241148328984f6e8b384b9fd1