### PR TITLE
feat: restructure map UI layout

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/MapUiBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapUiBuilder.java
@@ -140,13 +140,22 @@ public final class MapUiBuilder {
             }
         });
 
-        table.add(menuButton).pad(PADDING).left().top();
-        table.add(buildButton).pad(PADDING).left().top();
-        table.add(removeButton).pad(PADDING).left().top();
-        table.add(mapButton).pad(PADDING).left().top();
-        table.add(minimapButton).pad(PADDING).left().top();
-        table.add(resourcesActor).pad(PADDING).expandX().left().top();
-        table.add(minimapActor).pad(PADDING).right().top();
+        Table topRow = new Table();
+        topRow.add(menuButton).pad(PADDING).left().top();
+        topRow.add(resourcesActor).pad(PADDING).expandX().left().top();
+        topRow.add(minimapActor).pad(PADDING).right().top();
+
+        Table leftColumn = new Table();
+        leftColumn.top().left();
+        leftColumn.add(buildButton).pad(PADDING).left().top().row();
+        leftColumn.add(removeButton).pad(PADDING).left().top().row();
+        leftColumn.add(mapButton).pad(PADDING).left().top().row();
+        leftColumn.add(minimapButton).pad(PADDING).left().top();
+
+        table.add(topRow).growX();
+        table.row();
+        table.add(leftColumn).left().top();
+
         table.row();
         chatTable.add(chatBox).pad(PADDING).growX();
 


### PR DESCRIPTION
## Summary
- reorganize map screen UI layout
  - move Menu, Resources and Minimap display to a top row
  - arrange Build/Remove/Map/Minimap buttons vertically on the left

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_684d7f1882cc832886f74e4d768c0bb3