### PR TITLE
feat(server): expose service factory accessors

### DIFF
--- a/server/src/main/java/net/lapidist/colony/server/GameServer.java
+++ b/server/src/main/java/net/lapidist/colony/server/GameServer.java
@@ -212,33 +212,83 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
         return t != null && t.isAlive();
     }
 
-    /** Override the factory for creating {@link MapService} instances. */
+    /**
+     * Override the factory for creating {@link MapService} instances.
+     * Modifications must occur before calling {@link #start()}.
+     */
     public void setMapServiceFactory(final java.util.function.Supplier<MapService> factory) {
         this.mapServiceFactory = factory;
     }
 
-    /** Override the factory for creating {@link NetworkService} instances. */
+    /**
+     * Current factory used to create {@link MapService} instances.
+     */
+    public java.util.function.Supplier<MapService> getMapServiceFactory() {
+        return mapServiceFactory;
+    }
+
+    /**
+     * Override the factory for creating {@link NetworkService} instances.
+     * Modifications must occur before calling {@link #start()}.
+     */
     public void setNetworkServiceFactory(
             final java.util.function.Supplier<NetworkService> factory) {
         this.networkServiceFactory = factory;
     }
 
-    /** Override the factory for creating {@link AutosaveService} instances. */
+    /**
+     * Current factory used to create {@link NetworkService} instances.
+     */
+    public java.util.function.Supplier<NetworkService> getNetworkServiceFactory() {
+        return networkServiceFactory;
+    }
+
+    /**
+     * Override the factory for creating {@link AutosaveService} instances.
+     * Modifications must occur before calling {@link #start()}.
+     */
     public void setAutosaveServiceFactory(
             final java.util.function.Supplier<AutosaveService> factory) {
         this.autosaveServiceFactory = factory;
     }
 
-    /** Override the factory for creating {@link ResourceProductionService} instances. */
+    /**
+     * Current factory used to create {@link AutosaveService} instances.
+     */
+    public java.util.function.Supplier<AutosaveService> getAutosaveServiceFactory() {
+        return autosaveServiceFactory;
+    }
+
+    /**
+     * Override the factory for creating {@link ResourceProductionService} instances.
+     * Modifications must occur before calling {@link #start()}.
+     */
     public void setResourceProductionServiceFactory(
             final java.util.function.Supplier<ResourceProductionService> factory) {
         this.resourceProductionServiceFactory = factory;
     }
 
-    /** Override the factory for creating {@link CommandBus} instances. */
+    /**
+     * Current factory used to create {@link ResourceProductionService} instances.
+     */
+    public java.util.function.Supplier<ResourceProductionService> getResourceProductionServiceFactory() {
+        return resourceProductionServiceFactory;
+    }
+
+    /**
+     * Override the factory for creating {@link CommandBus} instances.
+     * Modifications must occur before calling {@link #start()}.
+     */
     public void setCommandBusFactory(
             final java.util.function.Supplier<CommandBus> factory) {
         this.commandBusFactory = factory;
+    }
+
+    /**
+     * Current factory used to create {@link CommandBus} instances.
+     */
+    public java.util.function.Supplier<CommandBus> getCommandBusFactory() {
+        return commandBusFactory;
     }
 
     /**

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerCoverageTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerCoverageTest.java
@@ -9,9 +9,11 @@ import net.lapidist.colony.network.AbstractMessageHandler;
 import net.lapidist.colony.network.MessageHandler;
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.server.GameServerConfig;
+import net.lapidist.colony.server.commands.CommandBus;
 import net.lapidist.colony.server.services.AutosaveService;
 import net.lapidist.colony.server.services.NetworkService;
 import net.lapidist.colony.server.services.ResourceProductionService;
+import net.lapidist.colony.server.services.MapService;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
@@ -120,5 +122,27 @@ public class GameServerCoverageTest {
         verify((NetworkService) field("networkService").get(server)).stop();
         verify((AutosaveService) field("autosaveService").get(server)).stop();
         verify((ResourceProductionService) field("resourceProductionService").get(server)).stop();
+    }
+
+    @Test
+    public void factoryAccessorsStoreValues() {
+        GameServer server = new GameServer(GameServerConfig.builder().saveName("factories").build());
+        java.util.function.Supplier<MapService> mapFactory = () -> null;
+        java.util.function.Supplier<NetworkService> netFactory = () -> null;
+        java.util.function.Supplier<AutosaveService> autoFactory = () -> null;
+        java.util.function.Supplier<ResourceProductionService> prodFactory = () -> null;
+        java.util.function.Supplier<CommandBus> busFactory = () -> null;
+
+        server.setMapServiceFactory(mapFactory);
+        server.setNetworkServiceFactory(netFactory);
+        server.setAutosaveServiceFactory(autoFactory);
+        server.setResourceProductionServiceFactory(prodFactory);
+        server.setCommandBusFactory(busFactory);
+
+        assertSame(mapFactory, server.getMapServiceFactory());
+        assertSame(netFactory, server.getNetworkServiceFactory());
+        assertSame(autoFactory, server.getAutosaveServiceFactory());
+        assertSame(prodFactory, server.getResourceProductionServiceFactory());
+        assertSame(busFactory, server.getCommandBusFactory());
     }
 }


### PR DESCRIPTION
## Summary
- expose getter methods for server service factories
- document that factory setters must be called before `start`
- verify service factory accessors in server unit tests

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684dad031bc88328959a0e56fc371f2a