### PR TITLE
feat(server): load built-in core mod

### DIFF
--- a/docs/mods.md
+++ b/docs/mods.md
@@ -35,6 +35,17 @@ A minimal `mod.json` looks like:
 `version` is an arbitrary string.
 `dependencies` lists other mod IDs that must be loaded first.
 
+### Built-in server mod
+
+The dedicated server bundles a mod providing the default services and handlers.
+It is loaded automatically with the following metadata:
+
+```json
+{ "id": "core-server", "version": "1.0.0" }
+```
+
+This mod does not need to be placed inside the `mods/` folder.
+
 ## How mods are discovered
 
 `ModLoader` scans the `mods/` folder and creates a `URLClassLoader` for every

--- a/server/src/main/java/net/lapidist/colony/server/commands/CommandBus.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/CommandBus.java
@@ -6,7 +6,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Simple dispatcher mapping commands to their handlers.
  */
-public final class CommandBus {
+public final class CommandBus implements net.lapidist.colony.mod.CommandBus {
 
     private final Map<Class<?>, CommandHandler<?>> handlers = new ConcurrentHashMap<>();
 

--- a/server/src/main/java/net/lapidist/colony/server/mod/CoreServerMod.java
+++ b/server/src/main/java/net/lapidist/colony/server/mod/CoreServerMod.java
@@ -1,0 +1,35 @@
+package net.lapidist.colony.server.mod;
+
+import net.lapidist.colony.mod.GameMod;
+import net.lapidist.colony.mod.GameServer;
+import net.lapidist.colony.mod.CommandBus;
+
+import java.lang.reflect.Method;
+
+/** Built-in server mod providing default services and handlers. */
+public final class CoreServerMod implements GameMod {
+    private net.lapidist.colony.server.GameServer server;
+
+    @Override
+    public void registerServices(final GameServer srv) {
+        this.server = (net.lapidist.colony.server.GameServer) srv;
+        net.lapidist.colony.server.GameServer s = this.server;
+        // Default factories are already initialised in GameServer's constructor.
+        // Invoking setters ensures mods can override them before services are created.
+        s.setMapServiceFactory(s.getMapServiceFactory());
+        s.setNetworkServiceFactory(s.getNetworkServiceFactory());
+        s.setAutosaveServiceFactory(s.getAutosaveServiceFactory());
+        s.setResourceProductionServiceFactory(s.getResourceProductionServiceFactory());
+    }
+
+    @Override
+    public void registerHandlers(final CommandBus bus) {
+        try {
+            Method m = net.lapidist.colony.server.GameServer.class.getDeclaredMethod("registerDefaultHandlers");
+            m.setAccessible(true);
+            m.invoke(server);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/server/mod/package-info.java
+++ b/server/src/main/java/net/lapidist/colony/server/mod/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Built-in game server mod providing default services and handlers.
+ */
+package net.lapidist.colony.server.mod;

--- a/server/src/main/resources/META-INF/services/net.lapidist.colony.mod.GameMod
+++ b/server/src/main/resources/META-INF/services/net.lapidist.colony.mod.GameMod
@@ -1,0 +1,1 @@
+net.lapidist.colony.server.mod.CoreServerMod

--- a/server/src/main/resources/mod.json
+++ b/server/src/main/resources/mod.json
@@ -1,0 +1,5 @@
+{
+  "id": "core-server",
+  "version": "1.0.0",
+  "dependencies": []
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerModLoadingTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerModLoadingTest.java
@@ -1,0 +1,80 @@
+package net.lapidist.colony.tests.server;
+
+import net.lapidist.colony.io.Paths;
+import net.lapidist.colony.io.TestPathService;
+import net.lapidist.colony.mod.ModLoader.LoadedMod;
+import net.lapidist.colony.mod.test.StubMod;
+import net.lapidist.colony.server.GameServer;
+import net.lapidist.colony.server.GameServerConfig;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import static org.junit.Assert.assertTrue;
+
+/** Verifies the server loads mods and starts correctly. */
+public class GameServerModLoadingTest {
+
+    private static final String META_FILE = "META-INF/services/net.lapidist.colony.mod.GameMod";
+
+    @Test
+    public void loadsModsAndStarts() throws Exception {
+        System.clearProperty("stubmod.init");
+        Path base = Files.createTempDirectory("server-mod-test");
+        Paths paths = new Paths(new TestPathService(base));
+        Path mods = paths.getModsFolder();
+        Files.createDirectories(mods);
+
+        Path jar = mods.resolve("stub.jar");
+        createJarMod(jar);
+
+        try (MockedStatic<Paths> mock = Mockito.mockStatic(Paths.class)) {
+            mock.when(Paths::get).thenReturn(paths);
+
+            GameServerConfig config = GameServerConfig.builder()
+                    .saveName("mod-test")
+                    .build();
+            GameServer server = new GameServer(config);
+            server.start();
+
+            java.lang.reflect.Field f = GameServer.class.getDeclaredField("mods");
+            f.setAccessible(true);
+            List<LoadedMod> loaded = (List<LoadedMod>) f.get(server);
+            assertTrue(loaded.stream().anyMatch(m -> "core-server".equals(m.metadata().id())));
+            assertTrue(loaded.stream().anyMatch(m -> "stub".equals(m.metadata().id())));
+            assertTrue(server.isRunning());
+            server.stop();
+        }
+        assertTrue("true".equals(System.getProperty("stubmod.init")));
+    }
+
+    private void createJarMod(final Path jar) throws IOException {
+        try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jar))) {
+            jos.putNextEntry(new JarEntry("mod.json"));
+            jos.write("{ id: \"stub\", version: \"1\", dependencies: [] }".getBytes(StandardCharsets.UTF_8));
+            jos.closeEntry();
+
+            jos.putNextEntry(new JarEntry(META_FILE));
+            jos.write((StubMod.class.getName() + "\n").getBytes(StandardCharsets.UTF_8));
+            jos.closeEntry();
+
+            Path classFile = classFile();
+            jos.putNextEntry(new JarEntry(StubMod.class.getName().replace('.', '/') + ".class"));
+            jos.write(Files.readAllBytes(classFile));
+            jos.closeEntry();
+        }
+    }
+
+    private Path classFile() throws IOException {
+        return Path.of(StubMod.class.getProtectionDomain().getCodeSource().getLocation().getPath())
+                .resolve(StubMod.class.getName().replace('.', '/') + ".class");
+    }
+}


### PR DESCRIPTION
## Summary
- implement `CoreServerMod` to register default services and handlers
- load this mod from `GameServer.start`
- document the new mod
- ensure `GameServer` and `CommandBus` implement mod APIs
- test that mods load when starting the server

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_684dae7cec588328b758c671d1cd7e6d