### PR TITLE
feat: introduce save version 21

### DIFF
--- a/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
@@ -33,6 +33,7 @@ public final class SaveMigrator {
         register(new V17ToV18Migration());
         register(new V18ToV19Migration());
         register(new V19ToV20Migration());
+        register(new V20ToV21Migration());
     }
 
     private SaveMigrator() {

--- a/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
@@ -23,9 +23,10 @@ public enum SaveVersion {
     V17(17),
     V18(18),
     V19(19),
-    V20(20);
+    V20(20),
+    V21(21);
 
-    public static final SaveVersion CURRENT = V20;
+    public static final SaveVersion CURRENT = V21;
 
     private final int number;
 

--- a/core/src/main/java/net/lapidist/colony/save/V20ToV21Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V20ToV21Migration.java
@@ -1,0 +1,23 @@
+package net.lapidist.colony.save;
+
+import net.lapidist.colony.components.state.MapState;
+
+/** Migration from save version 20 to 21 with no data changes. */
+public final class V20ToV21Migration implements MapStateMigration {
+    @Override
+    public int fromVersion() {
+        return SaveVersion.V20.number();
+    }
+
+    @Override
+    public int toVersion() {
+        return SaveVersion.V21.number();
+    }
+
+    @Override
+    public MapState apply(final MapState state) {
+        return state.toBuilder()
+                .version(toVersion())
+                .build();
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,9 +36,10 @@ public enum SaveVersion {
     // ...
     V18(18),
     V19(19),
-    V20(20);
+    V20(20),
+    V21(21);
 
-    public static final SaveVersion CURRENT = V20;
+    public static final SaveVersion CURRENT = V21;
 }
 ```
 
@@ -50,9 +51,9 @@ When a game is loaded, `SaveMigrator` applies registered `MapStateMigration` ste
 2. Implement a migration class:
 
 ```java
-public final class V19ToV20Migration implements MapStateMigration {
-    @Override public int fromVersion() { return SaveVersion.V19.number(); }
-    @Override public int toVersion() { return SaveVersion.V20.number(); }
+public final class V20ToV21Migration implements MapStateMigration {
+    @Override public int fromVersion() { return SaveVersion.V20.number(); }
+    @Override public int toVersion() { return SaveVersion.V21.number(); }
     @Override public MapState apply(MapState state) {
         // update fields here
         return state.toBuilder().version(toVersion()).build();

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV20Test.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV20Test.java
@@ -1,0 +1,41 @@
+package net.lapidist.colony.tests.server;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Output;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.serialization.KryoRegistry;
+import net.lapidist.colony.save.SaveData;
+import net.lapidist.colony.save.SaveVersion;
+import net.lapidist.colony.serialization.SerializationRegistrar;
+import net.lapidist.colony.server.io.GameStateIO;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+
+public class GameStateIOMigrationV20Test {
+
+    @Test
+    public void migratesV20ToCurrent() throws Exception {
+        Path file = Files.createTempFile("state", ".dat");
+        MapState state = MapState.builder()
+                .version(SaveVersion.V20.number())
+                .build();
+        Kryo kryo = new Kryo();
+        KryoRegistry.register(kryo);
+        try (Output output = new Output(Files.newOutputStream(file))) {
+            SaveData data = new SaveData(
+                    SaveVersion.V20.number(),
+                    SerializationRegistrar.registrationHash(),
+                    state
+            );
+            kryo.writeObject(output, data);
+        }
+
+        MapState loaded = GameStateIO.load(file);
+        Files.deleteIfExists(file);
+        assertEquals(SaveVersion.CURRENT.number(), loaded.version());
+    }
+}


### PR DESCRIPTION
## Summary
- add V21 and set CURRENT
- implement V20 to V21 migration
- register the new migration
- document save version update guidance
- test migration from V20 saves

## Testing
- `./gradlew spotlessApply`
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`

------
https://chatgpt.com/codex/tasks/task_e_684db6c2d3c4832881ba0cbbc921f1c1