### PR TITLE
feat: add type registries

### DIFF
--- a/core/src/main/java/net/lapidist/colony/registry/BuildingDefinition.java
+++ b/core/src/main/java/net/lapidist/colony/registry/BuildingDefinition.java
@@ -1,0 +1,14 @@
+package net.lapidist.colony.registry;
+
+/**
+ * Metadata describing a building type.
+ *
+ * @param id     unique identifier
+ * @param label  display label
+ * @param asset  rendering asset reference
+ */
+public record BuildingDefinition(String id, String label, String asset) {
+    public BuildingDefinition() {
+        this(null, null, null);
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/registry/BuildingRegistry.java
+++ b/core/src/main/java/net/lapidist/colony/registry/BuildingRegistry.java
@@ -1,0 +1,32 @@
+package net.lapidist.colony.registry;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/** Registry for {@link BuildingDefinition} instances. */
+public final class BuildingRegistry {
+    private final Map<String, BuildingDefinition> definitions = new HashMap<>();
+
+    /** Register a new building definition. */
+    public void register(final BuildingDefinition def) {
+        if (def == null || def.id() == null) {
+            return;
+        }
+        definitions.put(def.id().toUpperCase(Locale.ROOT), def);
+    }
+
+    /** Lookup a building definition by id. */
+    public BuildingDefinition get(final String id) {
+        if (id == null) {
+            return null;
+        }
+        return definitions.get(id.toUpperCase(Locale.ROOT));
+    }
+
+    /** @return all registered definitions. */
+    public Collection<BuildingDefinition> all() {
+        return definitions.values();
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/registry/Registries.java
+++ b/core/src/main/java/net/lapidist/colony/registry/Registries.java
@@ -1,0 +1,19 @@
+package net.lapidist.colony.registry;
+
+/** Global accessors for type registries. */
+public final class Registries {
+    private static final TileRegistry TILE_REGISTRY = new TileRegistry();
+    private static final BuildingRegistry BUILDING_REGISTRY = new BuildingRegistry();
+
+    private Registries() { }
+
+    /** @return tile type registry */
+    public static TileRegistry tiles() {
+        return TILE_REGISTRY;
+    }
+
+    /** @return building type registry */
+    public static BuildingRegistry buildings() {
+        return BUILDING_REGISTRY;
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/registry/TileDefinition.java
+++ b/core/src/main/java/net/lapidist/colony/registry/TileDefinition.java
@@ -1,0 +1,14 @@
+package net.lapidist.colony.registry;
+
+/**
+ * Metadata describing a tile type.
+ *
+ * @param id     unique identifier
+ * @param label  display label
+ * @param asset  rendering asset reference
+ */
+public record TileDefinition(String id, String label, String asset) {
+    public TileDefinition() {
+        this(null, null, null);
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/registry/TileRegistry.java
+++ b/core/src/main/java/net/lapidist/colony/registry/TileRegistry.java
@@ -1,0 +1,32 @@
+package net.lapidist.colony.registry;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/** Registry for {@link TileDefinition} instances. */
+public final class TileRegistry {
+    private final Map<String, TileDefinition> definitions = new HashMap<>();
+
+    /** Register a new tile definition. */
+    public void register(final TileDefinition def) {
+        if (def == null || def.id() == null) {
+            return;
+        }
+        definitions.put(def.id().toUpperCase(Locale.ROOT), def);
+    }
+
+    /** Lookup a tile definition by id. */
+    public TileDefinition get(final String id) {
+        if (id == null) {
+            return null;
+        }
+        return definitions.get(id.toUpperCase(Locale.ROOT));
+    }
+
+    /** @return all registered definitions. */
+    public Collection<TileDefinition> all() {
+        return definitions.values();
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/registry/package-info.java
+++ b/core/src/main/java/net/lapidist/colony/registry/package-info.java
@@ -1,0 +1,1 @@
+package net.lapidist.colony.registry;

--- a/tests/src/test/java/net/lapidist/colony/tests/core/registry/RegistryTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/registry/RegistryTest.java
@@ -1,0 +1,36 @@
+package net.lapidist.colony.tests.core.registry;
+
+import net.lapidist.colony.registry.BuildingDefinition;
+import net.lapidist.colony.registry.BuildingRegistry;
+import net.lapidist.colony.registry.Registries;
+import net.lapidist.colony.registry.TileDefinition;
+import net.lapidist.colony.registry.TileRegistry;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/** Tests for simple registry implementations. */
+public class RegistryTest {
+
+    @Test
+    public void registersAndRetrievesTile() {
+        TileRegistry registry = new TileRegistry();
+        TileDefinition def = new TileDefinition("grass", "Grass", "grass0");
+        registry.register(def);
+        assertEquals(def, registry.get("GRASS"));
+    }
+
+    @Test
+    public void registersAndRetrievesBuilding() {
+        BuildingRegistry registry = new BuildingRegistry();
+        BuildingDefinition def = new BuildingDefinition("house", "House", "house0");
+        registry.register(def);
+        assertEquals(def, registry.get("HOUSE"));
+    }
+
+    @Test
+    public void globalAccessorsReturnSingletons() {
+        assertSame(Registries.tiles(), Registries.tiles());
+        assertSame(Registries.buildings(), Registries.buildings());
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/core/registry/package-info.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/registry/package-info.java
@@ -1,0 +1,1 @@
+package net.lapidist.colony.tests.core.registry;


### PR DESCRIPTION
## Summary
- introduce `TileDefinition` and `BuildingDefinition`
- add registries for tiles and buildings
- expose the registries through a `Registries` utility
- cover new registries in tests

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684dbd1deb0483288935eba8eedba19f