### PR TITLE
feat(core): add base definitions mod

### DIFF
--- a/core/src/main/java/net/lapidist/colony/base/BaseDefinitionsMod.java
+++ b/core/src/main/java/net/lapidist/colony/base/BaseDefinitionsMod.java
@@ -1,0 +1,34 @@
+package net.lapidist.colony.base;
+
+import net.lapidist.colony.components.entities.BuildingComponent;
+import net.lapidist.colony.mod.GameMod;
+import net.lapidist.colony.registry.BuildingDefinition;
+import net.lapidist.colony.registry.Registries;
+import net.lapidist.colony.registry.TileDefinition;
+
+/** Built-in mod registering standard tile and building definitions. */
+public final class BaseDefinitionsMod implements GameMod {
+    @Override
+    public void init() {
+        Registries.tiles().register(new TileDefinition("empty", "Empty", "dirt0"));
+        Registries.tiles().register(new TileDefinition("dirt", "Dirt", "dirt0"));
+        Registries.tiles().register(new TileDefinition("grass", "Grass", "grass0"));
+
+        Registries.buildings().register(new BuildingDefinition(
+                "house",
+                BuildingComponent.BuildingType.HOUSE.toString(),
+                "house0"));
+        Registries.buildings().register(new BuildingDefinition(
+                "market",
+                BuildingComponent.BuildingType.MARKET.toString(),
+                "house0"));
+        Registries.buildings().register(new BuildingDefinition(
+                "factory",
+                BuildingComponent.BuildingType.FACTORY.toString(),
+                "house0"));
+        Registries.buildings().register(new BuildingDefinition(
+                "farm",
+                BuildingComponent.BuildingType.FARM.toString(),
+                "house0"));
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/base/package-info.java
+++ b/core/src/main/java/net/lapidist/colony/base/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Built-in mods providing base game definitions.
+ */
+package net.lapidist.colony.base;

--- a/server/src/main/java/net/lapidist/colony/server/GameServer.java
+++ b/server/src/main/java/net/lapidist/colony/server/GameServer.java
@@ -143,6 +143,8 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
         Events.init(new EventSystem());
         mods = new ModLoader(Paths.get()).loadMods();
         mods = new java.util.ArrayList<>(mods);
+        mods.add(new LoadedMod(new net.lapidist.colony.base.BaseDefinitionsMod(),
+                new net.lapidist.colony.mod.ModMetadata("base-definitions", "1.0.0", java.util.List.of())));
         mods.add(new LoadedMod(new net.lapidist.colony.base.BaseServicesMod(),
                 new net.lapidist.colony.mod.ModMetadata("base-services", "1.0.0", java.util.List.of())));
         mods.add(new LoadedMod(new net.lapidist.colony.base.BaseCommandsMod(),

--- a/server/src/main/resources/META-INF/services/net.lapidist.colony.mod.GameMod
+++ b/server/src/main/resources/META-INF/services/net.lapidist.colony.mod.GameMod
@@ -1,2 +1,4 @@
 net.lapidist.colony.base.BaseServicesMod
 net.lapidist.colony.base.BaseCommandsMod
+
+net.lapidist.colony.base.BaseDefinitionsMod

--- a/tests/src/test/java/net/lapidist/colony/tests/core/base/BaseDefinitionsModTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/base/BaseDefinitionsModTest.java
@@ -1,0 +1,21 @@
+package net.lapidist.colony.tests.core.base;
+
+import net.lapidist.colony.base.BaseDefinitionsMod;
+import net.lapidist.colony.registry.Registries;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/** Unit tests for {@link BaseDefinitionsMod}. */
+public class BaseDefinitionsModTest {
+    @Test
+    public void registersDefaultDefinitions() {
+        BaseDefinitionsMod mod = new BaseDefinitionsMod();
+        mod.init();
+
+        assertNotNull(Registries.tiles().get("GRASS"));
+        assertNotNull(Registries.tiles().get("DIRT"));
+        assertNotNull(Registries.buildings().get("HOUSE"));
+        assertNotNull(Registries.buildings().get("FARM"));
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/core/base/package-info.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/base/package-info.java
@@ -1,0 +1,1 @@
+package net.lapidist.colony.tests.core.base;

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerModLoadingTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerModLoadingTest.java
@@ -50,6 +50,7 @@ public class GameServerModLoadingTest {
             List<LoadedMod> loaded = (List<LoadedMod>) f.get(server);
             assertTrue(loaded.stream().anyMatch(m -> "base-services".equals(m.metadata().id())));
             assertTrue(loaded.stream().anyMatch(m -> "base-commands".equals(m.metadata().id())));
+            assertTrue(loaded.stream().anyMatch(m -> "base-definitions".equals(m.metadata().id())));
             assertTrue(loaded.stream().anyMatch(m -> "stub".equals(m.metadata().id())));
             assertTrue(server.isRunning());
             server.stop();


### PR DESCRIPTION
## Summary
- add BaseDefinitionsMod registering standard tiles and buildings
- load BaseDefinitionsMod in GameServer
- list BaseDefinitionsMod in service loader descriptor
- test that BaseDefinitionsMod registers definitions
- expect BaseDefinitionsMod in server mod loading test

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684dc14f6664832881d599e313738db8