### PR TITLE
feat: replace tile and building enums

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/entities/factories/BuildingFactory.java
+++ b/client/src/main/java/net/lapidist/colony/client/entities/factories/BuildingFactory.java
@@ -25,7 +25,7 @@ public final class BuildingFactory {
      */
     public static Entity create(
             final World world,
-            final BuildingComponent.BuildingType buildingType,
+            final String buildingType,
             final Vector2 coords
     ) {
         BuildingComponent buildingComponent = new BuildingComponent();

--- a/client/src/main/java/net/lapidist/colony/client/entities/factories/TileFactory.java
+++ b/client/src/main/java/net/lapidist/colony/client/entities/factories/TileFactory.java
@@ -16,7 +16,7 @@ public final class TileFactory {
 
     public static Entity create(
             final World world,
-            final TileComponent.TileType tileType,
+            final String tileType,
             final Vector2 coords,
             final boolean passable,
             final boolean selected,

--- a/client/src/main/java/net/lapidist/colony/client/render/MapRenderDataBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/render/MapRenderDataBuilder.java
@@ -64,7 +64,7 @@ public final class MapRenderDataBuilder {
         return RenderTile.builder()
                 .x(tc.getX())
                 .y(tc.getY())
-                .tileType(tc.getTileType().name())
+                .tileType(tc.getTileType())
                 .selected(tc.isSelected())
                 .wood(rc.getWood())
                 .stone(rc.getStone())
@@ -76,7 +76,7 @@ public final class MapRenderDataBuilder {
         return RenderBuilding.builder()
                 .x(bc.getX())
                 .y(bc.getY())
-                .buildingType(bc.getBuildingType().name())
+                .buildingType(bc.getBuildingType())
                 .build();
     }
 

--- a/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
@@ -12,7 +12,6 @@ import net.lapidist.colony.client.systems.CameraProvider;
 import net.lapidist.colony.client.util.CameraUtils;
 import net.lapidist.colony.client.render.data.RenderBuilding;
 import net.lapidist.colony.client.render.MapRenderData;
-import net.lapidist.colony.components.entities.BuildingComponent;
 
 /**
  * Renders building entities.
@@ -23,8 +22,7 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
     private final ResourceLoader resourceLoader;
     private final CameraProvider cameraSystem;
     private final AssetResolver resolver;
-    private final java.util.EnumMap<BuildingComponent.BuildingType, TextureRegion> buildingRegions =
-            new java.util.EnumMap<>(BuildingComponent.BuildingType.class);
+    private final java.util.HashMap<String, TextureRegion> buildingRegions = new java.util.HashMap<>();
     private final BitmapFont font = new BitmapFont();
     private final GlyphLayout layout = new GlyphLayout();
     private static final float LABEL_OFFSET_Y = 8f;
@@ -42,8 +40,8 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
         this.cameraSystem = cameraSystemToSet;
         this.resolver = resolverToSet;
 
-        for (BuildingComponent.BuildingType type : BuildingComponent.BuildingType.values()) {
-            String ref = resolver.buildingAsset(type.name());
+        for (String type : new String[]{"HOUSE", "MARKET", "FACTORY", "FARM"}) {
+            String ref = resolver.buildingAsset(type);
             TextureRegion region = resourceLoader.findRegion(ref);
             if (region != null) {
                 buildingRegions.put(type, region);
@@ -67,14 +65,13 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
                 continue;
             }
 
-            BuildingComponent.BuildingType type =
-                    BuildingComponent.BuildingType.valueOf(building.getBuildingType());
+            String type = building.getBuildingType();
             TextureRegion region = buildingRegions.get(type);
             if (region != null) {
                 spriteBatch.draw(region, worldCoords.x, worldCoords.y);
             }
-            if (!resolver.hasBuildingAsset(type.name())) {
-                layout.setText(font, type.name());
+            if (!resolver.hasBuildingAsset(type)) {
+                layout.setText(font, type);
                 font.draw(spriteBatch, layout, worldCoords.x, worldCoords.y + LABEL_OFFSET_Y);
             }
         }

--- a/client/src/main/java/net/lapidist/colony/client/renderers/DefaultAssetResolver.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/DefaultAssetResolver.java
@@ -3,8 +3,6 @@ package net.lapidist.colony.client.renderers;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import net.lapidist.colony.components.entities.BuildingComponent;
-import net.lapidist.colony.components.maps.TileComponent;
 
 /** Default implementation returning built-in asset references. */
 public final class DefaultAssetResolver implements AssetResolver {
@@ -13,14 +11,14 @@ public final class DefaultAssetResolver implements AssetResolver {
     private static final Map<String, String> BUILDING_ASSETS = new HashMap<>();
 
     static {
-        TILE_ASSETS.put(TileComponent.TileType.EMPTY.name(), "dirt0");
-        TILE_ASSETS.put(TileComponent.TileType.DIRT.name(), "dirt0");
-        TILE_ASSETS.put(TileComponent.TileType.GRASS.name(), "grass0");
+        TILE_ASSETS.put("EMPTY", "dirt0");
+        TILE_ASSETS.put("DIRT", "dirt0");
+        TILE_ASSETS.put("GRASS", "grass0");
 
-        BUILDING_ASSETS.put(BuildingComponent.BuildingType.HOUSE.name(), "house0");
-        BUILDING_ASSETS.put(BuildingComponent.BuildingType.MARKET.name(), "house0");
-        BUILDING_ASSETS.put(BuildingComponent.BuildingType.FACTORY.name(), "house0");
-        BUILDING_ASSETS.put(BuildingComponent.BuildingType.FARM.name(), "house0");
+        BUILDING_ASSETS.put("HOUSE", "house0");
+        BUILDING_ASSETS.put("MARKET", "house0");
+        BUILDING_ASSETS.put("FACTORY", "house0");
+        BUILDING_ASSETS.put("FARM", "house0");
     }
     @Override
     public String tileAsset(final String type) {

--- a/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
@@ -13,7 +13,6 @@ import net.lapidist.colony.client.render.data.RenderTile;
 import net.lapidist.colony.client.render.MapRenderData;
 import net.lapidist.colony.client.TileRotationUtil;
 import net.lapidist.colony.components.state.MapState;
-import net.lapidist.colony.components.maps.TileComponent;
 
 /**
  * Renders tile entities.
@@ -25,8 +24,7 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
     private final ResourceLoader resourceLoader;
     private final CameraProvider cameraSystem;
     private final AssetResolver resolver;
-    private final java.util.EnumMap<TileComponent.TileType, TextureRegion> tileRegions =
-            new java.util.EnumMap<>(TileComponent.TileType.class);
+    private final java.util.HashMap<String, TextureRegion> tileRegions = new java.util.HashMap<>();
     private final TextureRegion overlayRegion;
     private final BitmapFont font = new BitmapFont();
     private final GlyphLayout layout = new GlyphLayout();
@@ -50,8 +48,8 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
         this.cameraSystem = cameraSystemToSet;
         this.resolver = resolverToSet;
 
-        for (TileComponent.TileType type : TileComponent.TileType.values()) {
-            String ref = resolver.tileAsset(type.name());
+        for (String type : new String[]{"EMPTY", "DIRT", "GRASS"}) {
+            String ref = resolver.tileAsset(type);
             TextureRegion region = resourceLoader.findRegion(ref);
             if (region != null) {
                 tileRegions.put(type, region);
@@ -98,10 +96,10 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
                 CameraUtils.tileCoordsToWorldCoords(tile.getX(), tile.getY(), worldCoords);
 
                 if (!overlayOnly) {
-                    TileComponent.TileType type = TileComponent.TileType.valueOf(tile.getTileType());
+                    String type = tile.getTileType();
                     TextureRegion region = tileRegions.get(type);
                     if (region != null) {
-                        if (type == TileComponent.TileType.GRASS || type == TileComponent.TileType.DIRT) {
+                        if ("GRASS".equals(type) || "DIRT".equals(type)) {
                             float rotation = TileRotationUtil.rotationFor(tile.getX(), tile.getY());
                             spriteBatch.draw(
                                     region,
@@ -119,8 +117,8 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
                             spriteBatch.draw(region, worldCoords.x, worldCoords.y);
                         }
                     }
-                    if (!resolver.hasTileAsset(type.name())) {
-                        layout.setText(font, type.name());
+                    if (!resolver.hasTileAsset(type)) {
+                        layout.setText(font, type);
                         font.draw(spriteBatch, layout, worldCoords.x, worldCoords.y + LABEL_OFFSET_Y);
                     }
                 }

--- a/client/src/main/java/net/lapidist/colony/client/systems/input/BuildingPlacementHandler.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/input/BuildingPlacementHandler.java
@@ -6,7 +6,6 @@ import net.lapidist.colony.map.MapUtils;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
 import net.lapidist.colony.client.util.CameraUtils;
-import net.lapidist.colony.components.entities.BuildingComponent;
 import net.lapidist.colony.components.maps.MapComponent;
 import net.lapidist.colony.components.maps.TileComponent;
 import net.lapidist.colony.components.state.BuildingPlacementData;
@@ -43,7 +42,7 @@ public final class BuildingPlacementHandler {
                     BuildingPlacementData msg = new BuildingPlacementData(
                             tc.getX(),
                             tc.getY(),
-                            BuildingComponent.BuildingType.HOUSE.name()
+                            "HOUSE"
                     );
                     client.sendBuildRequest(msg);
                     return true;

--- a/client/src/main/java/net/lapidist/colony/client/systems/network/BuildingUpdateSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/network/BuildingUpdateSystem.java
@@ -37,7 +37,7 @@ public final class BuildingUpdateSystem extends BaseSystem {
             world.createEntity();
             var entity = BuildingFactory.create(
                     world,
-                    BuildingComponent.BuildingType.valueOf(update.buildingType()),
+                    update.buildingType(),
                     new Vector2(update.x(), update.y())
             );
             buildingMapper.get(entity).setDirty(true);

--- a/client/src/main/java/net/lapidist/colony/client/ui/MinimapCache.java
+++ b/client/src/main/java/net/lapidist/colony/client/ui/MinimapCache.java
@@ -70,9 +70,10 @@ final class MinimapCache implements Disposable {
         for (int i = 0; i < tiles.size; i++) {
             TileComponent tc = tileMapper.get(tiles.get(i));
             Color c = switch (tc.getTileType()) {
-                case GRASS -> GRASS_COLOR;
-                case DIRT -> DIRT_COLOR;
-                case EMPTY -> Color.CLEAR;
+                case "GRASS" -> GRASS_COLOR;
+                case "DIRT" -> DIRT_COLOR;
+                case "EMPTY" -> Color.CLEAR;
+                default -> Color.CLEAR;
             };
             this.pixmap.setColor(c);
             this.pixmap.drawPixel(tc.getX(), mapHeight - 1 - tc.getY());

--- a/core/src/main/java/net/lapidist/colony/base/BaseDefinitionsMod.java
+++ b/core/src/main/java/net/lapidist/colony/base/BaseDefinitionsMod.java
@@ -1,10 +1,10 @@
 package net.lapidist.colony.base;
 
-import net.lapidist.colony.components.entities.BuildingComponent;
 import net.lapidist.colony.mod.GameMod;
 import net.lapidist.colony.registry.BuildingDefinition;
 import net.lapidist.colony.registry.Registries;
 import net.lapidist.colony.registry.TileDefinition;
+import net.lapidist.colony.i18n.I18n;
 
 /** Built-in mod registering standard tile and building definitions. */
 public final class BaseDefinitionsMod implements GameMod {
@@ -16,19 +16,19 @@ public final class BaseDefinitionsMod implements GameMod {
 
         Registries.buildings().register(new BuildingDefinition(
                 "house",
-                BuildingComponent.BuildingType.HOUSE.toString(),
+                I18n.get("building.house"),
                 "house0"));
         Registries.buildings().register(new BuildingDefinition(
                 "market",
-                BuildingComponent.BuildingType.MARKET.toString(),
+                I18n.get("building.market"),
                 "house0"));
         Registries.buildings().register(new BuildingDefinition(
                 "factory",
-                BuildingComponent.BuildingType.FACTORY.toString(),
+                I18n.get("building.factory"),
                 "house0"));
         Registries.buildings().register(new BuildingDefinition(
                 "farm",
-                BuildingComponent.BuildingType.FARM.toString(),
+                I18n.get("building.farm"),
                 "house0"));
     }
 }

--- a/core/src/main/java/net/lapidist/colony/components/entities/BuildingComponent.java
+++ b/core/src/main/java/net/lapidist/colony/components/entities/BuildingComponent.java
@@ -1,32 +1,13 @@
 package net.lapidist.colony.components.entities;
 
 import net.lapidist.colony.components.AbstractBoundedComponent;
-import net.lapidist.colony.i18n.I18n;
 
 public final class BuildingComponent extends AbstractBoundedComponent {
-
-    public enum BuildingType {
-        HOUSE("building.house"),
-        MARKET("building.market"),
-        FACTORY("building.factory"),
-        FARM("building.farm");
-
-        private final String key;
-
-        BuildingType(final String keyToSet) {
-            this.key = keyToSet;
-        }
-
-        @Override
-        public String toString() {
-            return I18n.get(key);
-        }
-    }
-    private BuildingType buildingType;
+    private String buildingTypeId;
     private boolean dirty;
 
-    public BuildingType getBuildingType() {
-        return buildingType;
+    public String getBuildingType() {
+        return buildingTypeId;
     }
 
     public boolean isDirty() {
@@ -37,7 +18,7 @@ public final class BuildingComponent extends AbstractBoundedComponent {
         this.dirty = dirtyToSet;
     }
 
-    public void setBuildingType(final BuildingType buildingTypeToSet) {
-        this.buildingType = buildingTypeToSet;
+    public void setBuildingType(final String buildingTypeToSet) {
+        this.buildingTypeId = buildingTypeToSet;
     }
 }

--- a/core/src/main/java/net/lapidist/colony/components/maps/TileComponent.java
+++ b/core/src/main/java/net/lapidist/colony/components/maps/TileComponent.java
@@ -4,30 +4,13 @@ import net.lapidist.colony.components.AbstractBoundedComponent;
 
 public final class TileComponent extends AbstractBoundedComponent {
 
-    public enum TileType {
-        EMPTY("empty"),
-        DIRT("dirt"),
-        GRASS("grass");
-
-        private final String type;
-
-        TileType(final String typeToSet) {
-            this.type = typeToSet;
-        }
-
-        @Override
-        public String toString() {
-            return type;
-        }
-    }
-
     private boolean passable;
 
     private boolean selected;
 
     private boolean dirty;
 
-    private TileType tileType;
+    private String tileTypeId;
 
     public boolean isPassable() {
         return passable;
@@ -37,8 +20,8 @@ public final class TileComponent extends AbstractBoundedComponent {
         return selected;
     }
 
-    public TileType getTileType() {
-        return tileType;
+    public String getTileType() {
+        return tileTypeId;
     }
 
     public boolean isDirty() {
@@ -57,7 +40,7 @@ public final class TileComponent extends AbstractBoundedComponent {
         this.selected = selectedToSet;
     }
 
-    public void setTileType(final TileType tileTypeToSet) {
-        this.tileType = tileTypeToSet;
+    public void setTileType(final String tileTypeToSet) {
+        this.tileTypeId = tileTypeToSet;
     }
 }

--- a/core/src/main/java/net/lapidist/colony/map/MapFactory.java
+++ b/core/src/main/java/net/lapidist/colony/map/MapFactory.java
@@ -42,7 +42,7 @@ public final class MapFactory {
                 TileData td = state.getTile(x, y);
                 Entity tile = world.createEntity();
                 TileComponent tileComponent = new TileComponent();
-                tileComponent.setTileType(TileComponent.TileType.valueOf(td.tileType()));
+                tileComponent.setTileType(td.tileType());
                 tileComponent.setPassable(td.passable());
                 tileComponent.setSelected(td.selected());
                 tileComponent.setHeight(GameConstants.TILE_SIZE);
@@ -68,7 +68,7 @@ public final class MapFactory {
         for (BuildingData bd : state.buildings()) {
             Entity building = world.createEntity();
             BuildingComponent component = new BuildingComponent();
-            component.setBuildingType(BuildingComponent.BuildingType.valueOf(bd.buildingType()));
+            component.setBuildingType(bd.buildingType());
             component.setHeight(GameConstants.TILE_SIZE);
             component.setWidth(GameConstants.TILE_SIZE);
             component.setX(bd.x());

--- a/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
@@ -33,6 +33,7 @@ public final class SaveMigrator {
         register(new V17ToV18Migration());
         register(new V18ToV19Migration());
         register(new V19ToV20Migration());
+        register(new V20ToV21Migration());
     }
 
     private SaveMigrator() {

--- a/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
@@ -23,9 +23,10 @@ public enum SaveVersion {
     V17(17),
     V18(18),
     V19(19),
-    V20(20);
+    V20(20),
+    V21(21);
 
-    public static final SaveVersion CURRENT = V20;
+    public static final SaveVersion CURRENT = V21;
 
     private final int number;
 

--- a/core/src/main/java/net/lapidist/colony/save/V20ToV21Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V20ToV21Migration.java
@@ -1,0 +1,23 @@
+package net.lapidist.colony.save;
+
+import net.lapidist.colony.components.state.MapState;
+
+/** Migration from save version 20 to 21 with no data changes. */
+public final class V20ToV21Migration implements MapStateMigration {
+    @Override
+    public int fromVersion() {
+        return SaveVersion.V20.number();
+    }
+
+    @Override
+    public int toVersion() {
+        return SaveVersion.V21.number();
+    }
+
+    @Override
+    public MapState apply(final MapState state) {
+        return state.toBuilder()
+                .version(toVersion())
+                .build();
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/server/commands/BuildCommand.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/BuildCommand.java
@@ -1,7 +1,5 @@
 package net.lapidist.colony.server.commands;
 
-import net.lapidist.colony.components.entities.BuildingComponent;
-
 /**
  * Command representing a building placement request.
  *
@@ -9,5 +7,5 @@ import net.lapidist.colony.components.entities.BuildingComponent;
  * @param y    tile y coordinate
  * @param type building type
  */
-public record BuildCommand(int x, int y, BuildingComponent.BuildingType type) implements ServerCommand {
+public record BuildCommand(int x, int y, String type) implements ServerCommand {
 }

--- a/server/src/main/java/net/lapidist/colony/server/commands/BuildCommandHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/BuildCommandHandler.java
@@ -5,7 +5,6 @@ import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.ResourceData;
 import net.lapidist.colony.components.state.ResourceUpdateData;
 import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.entities.BuildingComponent.BuildingType;
 import net.lapidist.colony.events.Events;
 import net.lapidist.colony.server.events.BuildingPlacedEvent;
 import net.lapidist.colony.server.services.NetworkService;
@@ -19,11 +18,11 @@ import java.util.concurrent.locks.ReentrantLock;
  * Applies a {@link BuildCommand} to the game state and broadcasts the change.
  */
 public final class BuildCommandHandler implements CommandHandler<BuildCommand> {
-    private static final Map<BuildingType, ResourceData> COSTS = Map.of(
-            BuildingType.HOUSE, new ResourceData(1, 0, 0),
-            BuildingType.MARKET, new ResourceData(5, 2, 0),
-            BuildingType.FACTORY, new ResourceData(10, 5, 0),
-            BuildingType.FARM, new ResourceData(2, 0, 0)
+    private static final Map<String, ResourceData> COSTS = Map.of(
+            "HOUSE", new ResourceData(1, 0, 0),
+            "MARKET", new ResourceData(5, 2, 0),
+            "FACTORY", new ResourceData(10, 5, 0),
+            "FARM", new ResourceData(2, 0, 0)
     );
 
     private final Supplier<MapState> stateSupplier;
@@ -64,7 +63,7 @@ public final class BuildCommandHandler implements CommandHandler<BuildCommand> {
                     || player.food() < cost.food()) {
                 return;
             }
-            BuildingData building = new BuildingData(command.x(), command.y(), command.type().name());
+            BuildingData building = new BuildingData(command.x(), command.y(), command.type());
             state.buildings().add(building);
             ResourceData newResources = new ResourceData(
                     player.wood() - cost.wood(),
@@ -75,7 +74,7 @@ public final class BuildCommandHandler implements CommandHandler<BuildCommand> {
                     .playerResources(newResources)
                     .build();
             stateConsumer.accept(updated);
-            Events.dispatch(new BuildingPlacedEvent(command.x(), command.y(), command.type().name()));
+            Events.dispatch(new BuildingPlacedEvent(command.x(), command.y(), command.type()));
             networkService.broadcast(building);
             networkService.broadcast(new ResourceUpdateData(-1, -1,
                     newResources.wood(), newResources.stone(), newResources.food()));

--- a/server/src/main/java/net/lapidist/colony/server/handlers/BuildingPlacementRequestHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/handlers/BuildingPlacementRequestHandler.java
@@ -1,6 +1,5 @@
 package net.lapidist.colony.server.handlers;
 
-import net.lapidist.colony.components.entities.BuildingComponent;
 import net.lapidist.colony.components.state.BuildingPlacementData;
 import net.lapidist.colony.server.commands.BuildCommand;
 import net.lapidist.colony.server.commands.CommandBus;
@@ -22,7 +21,7 @@ public final class BuildingPlacementRequestHandler extends AbstractMessageHandle
         commandBus.dispatch(new BuildCommand(
                 data.x(),
                 data.y(),
-                BuildingComponent.BuildingType.valueOf(data.buildingType())
+                data.buildingType()
         ));
     }
 }

--- a/server/src/main/java/net/lapidist/colony/server/services/ResourceProductionService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/ResourceProductionService.java
@@ -1,6 +1,5 @@
 package net.lapidist.colony.server.services;
 
-import net.lapidist.colony.components.entities.BuildingComponent.BuildingType;
 import net.lapidist.colony.components.state.BuildingData;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.ResourceData;
@@ -63,7 +62,7 @@ public final class ResourceProductionService {
             state = supplier.get();
             long farms = state.buildings().stream()
                     .map(BuildingData::buildingType)
-                    .filter(t -> BuildingType.FARM.name().equals(t))
+                    .filter(t -> "FARM".equals(t))
                     .count();
             if (farms == 0) {
                 return;

--- a/tests/src/test/java/net/lapidist/colony/tests/client/entities/factories/BuildingFactoryTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/entities/factories/BuildingFactoryTest.java
@@ -16,10 +16,10 @@ public class BuildingFactoryTest {
     @Test
     public void createSetsBuildingType() {
         World world = new World(new WorldConfigurationBuilder().build());
-        var entity = BuildingFactory.create(world, BuildingComponent.BuildingType.HOUSE, new Vector2(X, Y));
+        var entity = BuildingFactory.create(world, "HOUSE", new Vector2(X, Y));
         BuildingComponent comp = entity.getComponent(BuildingComponent.class);
 
-        assertEquals(BuildingComponent.BuildingType.HOUSE, comp.getBuildingType());
+        assertEquals("HOUSE", comp.getBuildingType());
         assertEquals(X, comp.getX());
         assertEquals(Y, comp.getY());
         world.dispose();

--- a/tests/src/test/java/net/lapidist/colony/tests/client/entities/factories/TileFactoryTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/entities/factories/TileFactoryTest.java
@@ -23,7 +23,7 @@ public class TileFactoryTest {
         World world = new World(new WorldConfigurationBuilder().build());
         var entity = TileFactory.create(
                 world,
-                TileComponent.TileType.GRASS,
+                "GRASS",
                 new Vector2(X, Y),
                 true,
                 false,
@@ -31,7 +31,7 @@ public class TileFactoryTest {
         );
         TileComponent tc = entity.getComponent(TileComponent.class);
 
-        assertEquals(TileComponent.TileType.GRASS, tc.getTileType());
+        assertEquals("GRASS", tc.getTileType());
         assertTrue(tc.isPassable());
         assertFalse(tc.isSelected());
         assertEquals(X, tc.getX());
@@ -45,7 +45,7 @@ public class TileFactoryTest {
         ResourceData data = new ResourceData(WOOD, STONE, FOOD);
         var entity = TileFactory.create(
                 world,
-                TileComponent.TileType.GRASS,
+                "GRASS",
                 new Vector2(X, Y),
                 true,
                 false,

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/RendererEnumMapTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/RendererEnumMapTest.java
@@ -7,8 +7,6 @@ import net.lapidist.colony.client.renderers.DefaultAssetResolver;
 import net.lapidist.colony.client.renderers.TileRenderer;
 import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.client.systems.CameraProvider;
-import net.lapidist.colony.components.entities.BuildingComponent;
-import net.lapidist.colony.components.maps.TileComponent;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,8 +36,9 @@ public class RendererEnumMapTest {
         f.setAccessible(true);
         java.util.Map<?, ?> map = (java.util.Map<?, ?>) f.get(renderer);
 
-        assertEquals(TileComponent.TileType.values().length, map.size());
-        for (TileComponent.TileType type : TileComponent.TileType.values()) {
+        String[] types = {"EMPTY", "DIRT", "GRASS"};
+        assertEquals(types.length, map.size());
+        for (String type : types) {
             assertNotNull(map.get(type));
         }
     }
@@ -60,8 +59,9 @@ public class RendererEnumMapTest {
         f.setAccessible(true);
         java.util.Map<?, ?> map = (java.util.Map<?, ?>) f.get(renderer);
 
-        assertEquals(BuildingComponent.BuildingType.values().length, map.size());
-        for (BuildingComponent.BuildingType type : BuildingComponent.BuildingType.values()) {
+        String[] buildings = {"HOUSE", "MARKET", "FACTORY", "FARM"};
+        assertEquals(buildings.length, map.size());
+        for (String type : buildings) {
             assertNotNull(map.get(type));
         }
     }

--- a/tests/src/test/java/net/lapidist/colony/tests/components/BuildingTypeTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/components/BuildingTypeTest.java
@@ -1,6 +1,5 @@
 package net.lapidist.colony.tests.components;
 
-import net.lapidist.colony.components.entities.BuildingComponent;
 import net.lapidist.colony.i18n.I18n;
 import org.junit.Test;
 
@@ -12,16 +11,8 @@ public class BuildingTypeTest {
     @Test
     public void returnsLocalizedString() {
         I18n.setLocale(Locale.ENGLISH);
-        assertEquals("House", BuildingComponent.BuildingType.HOUSE.toString());
+        assertEquals("House", I18n.get("building.house"));
         I18n.setLocale(Locale.FRENCH);
-        assertEquals("Maison", BuildingComponent.BuildingType.HOUSE.toString());
-    }
-
-    @Test
-    public void enumContainsFarm() {
-        assertEquals(
-                BuildingComponent.BuildingType.FARM,
-                BuildingComponent.BuildingType.valueOf("FARM")
-        );
+        assertEquals("Maison", I18n.get("building.house"));
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationFoodProductionTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationFoodProductionTest.java
@@ -1,7 +1,6 @@
 package net.lapidist.colony.tests.scenario;
 
 import net.lapidist.colony.client.network.GameClient;
-import net.lapidist.colony.components.entities.BuildingComponent.BuildingType;
 import net.lapidist.colony.components.resources.PlayerResourceComponent;
 import net.lapidist.colony.components.state.BuildingData;
 import net.lapidist.colony.components.state.MapState;
@@ -30,7 +29,7 @@ public class GameSimulationFoodProductionTest {
     public void foodIncreasesFromServerProduction() throws Exception {
         MapGenerator gen = (w, h) -> {
             MapState s = new ChunkedMapGenerator().generate(w, h);
-            s.buildings().add(new BuildingData(0, 0, BuildingType.FARM.name()));
+            s.buildings().add(new BuildingData(0, 0, "FARM"));
             return s.toBuilder().playerResources(new ResourceData()).build();
         };
         GameServerConfig config = GameServerConfig.builder()

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationResourceProductionOverrideTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationResourceProductionOverrideTest.java
@@ -2,7 +2,6 @@ package net.lapidist.colony.tests.scenario;
 
 import com.artemis.Aspect;
 import net.lapidist.colony.client.network.GameClient;
-import net.lapidist.colony.components.entities.BuildingComponent.BuildingType;
 import net.lapidist.colony.components.resources.PlayerResourceComponent;
 import net.lapidist.colony.components.state.BuildingData;
 import net.lapidist.colony.components.state.MapState;
@@ -39,7 +38,7 @@ public class GameSimulationResourceProductionOverrideTest {
     public void overriddenServicePreventsFoodProduction() throws Exception {
         MapGenerator gen = (w, h) -> {
             MapState s = new ChunkedMapGenerator().generate(w, h);
-            s.buildings().add(new BuildingData(0, 0, BuildingType.FARM.name()));
+            s.buildings().add(new BuildingData(0, 0, "FARM"));
             return s.toBuilder().playerResources(new ResourceData()).build();
         };
         GameServerConfig config = GameServerConfig.builder()

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV20Test.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV20Test.java
@@ -1,0 +1,41 @@
+package net.lapidist.colony.tests.server;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Output;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.serialization.KryoRegistry;
+import net.lapidist.colony.save.SaveData;
+import net.lapidist.colony.save.SaveVersion;
+import net.lapidist.colony.serialization.SerializationRegistrar;
+import net.lapidist.colony.server.io.GameStateIO;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+
+public class GameStateIOMigrationV20Test {
+
+    @Test
+    public void migratesV20ToCurrent() throws Exception {
+        Path file = Files.createTempFile("state", ".dat");
+        MapState state = MapState.builder()
+                .version(SaveVersion.V20.number())
+                .build();
+        Kryo kryo = new Kryo();
+        KryoRegistry.register(kryo);
+        try (Output output = new Output(Files.newOutputStream(file))) {
+            SaveData data = new SaveData(
+                    SaveVersion.V20.number(),
+                    SerializationRegistrar.registrationHash(),
+                    state
+            );
+            kryo.writeObject(output, data);
+        }
+
+        MapState loaded = GameStateIO.load(file);
+        Files.deleteIfExists(file);
+        assertEquals(SaveVersion.CURRENT.number(), loaded.version());
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/MapInitSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/MapInitSystemTest.java
@@ -82,7 +82,7 @@ public class MapInitSystemTest {
         TileComponent tc = world.getMapper(TileComponent.class).get(tile);
         ResourceComponent rc = world.getMapper(ResourceComponent.class).get(tile);
 
-        assertEquals(TileComponent.TileType.GRASS, tc.getTileType());
+        assertEquals("GRASS", tc.getTileType());
         assertEquals(WOOD, rc.getWood());
         assertEquals(STONE, rc.getStone());
         assertEquals(FOOD, rc.getFood());


### PR DESCRIPTION
## Summary
- swap `TileComponent.TileType` and `BuildingComponent.BuildingType` enums for string ids
- update factories, renderers and systems for new string fields
- add save version 21 with migration
- adjust tests for new identifiers

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684dc71949548328acbf5e5d5ffe4e30