### PR TITLE
feat: validate entity type ids during map creation

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/entities/factories/BuildingFactory.java
+++ b/client/src/main/java/net/lapidist/colony/client/entities/factories/BuildingFactory.java
@@ -4,6 +4,7 @@ import com.artemis.Entity;
 import com.artemis.World;
 import com.badlogic.gdx.math.Vector2;
 import net.lapidist.colony.components.entities.BuildingComponent;
+import java.util.Locale;
 
 import static net.lapidist.colony.client.entities.factories.SpriteFactoryUtil.createEntity;
 
@@ -29,7 +30,8 @@ public final class BuildingFactory {
             final Vector2 coords
     ) {
         BuildingComponent buildingComponent = new BuildingComponent();
-        buildingComponent.setBuildingType(buildingType);
+        String id = buildingType == null ? null : buildingType.toLowerCase(Locale.ROOT);
+        buildingComponent.setBuildingType(id);
         return createEntity(world, buildingComponent, coords);
     }
 }

--- a/client/src/main/java/net/lapidist/colony/client/entities/factories/TileFactory.java
+++ b/client/src/main/java/net/lapidist/colony/client/entities/factories/TileFactory.java
@@ -6,6 +6,7 @@ import com.badlogic.gdx.math.Vector2;
 import net.lapidist.colony.components.maps.TileComponent;
 import net.lapidist.colony.components.resources.ResourceComponent;
 import net.lapidist.colony.components.state.ResourceData;
+import java.util.Locale;
 
 import static net.lapidist.colony.client.entities.factories.SpriteFactoryUtil.createEntity;
 
@@ -23,7 +24,8 @@ public final class TileFactory {
             final ResourceData resources
     ) {
         TileComponent tileComponent = new TileComponent();
-        tileComponent.setTileType(tileType);
+        String id = tileType == null ? null : tileType.toLowerCase(Locale.ROOT);
+        tileComponent.setTileType(id);
         tileComponent.setPassable(passable);
         tileComponent.setSelected(selected);
 

--- a/core/src/main/java/net/lapidist/colony/map/MapFactory.java
+++ b/core/src/main/java/net/lapidist/colony/map/MapFactory.java
@@ -12,6 +12,7 @@ import net.lapidist.colony.components.state.BuildingData;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.TilePos;
+import net.lapidist.colony.registry.Registries;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -42,7 +43,11 @@ public final class MapFactory {
                 TileData td = state.getTile(x, y);
                 Entity tile = world.createEntity();
                 TileComponent tileComponent = new TileComponent();
-                tileComponent.setTileType(td.tileType());
+                String tileType = td.tileType();
+                if (Registries.tiles().get(tileType) == null) {
+                    tileType = "empty";
+                }
+                tileComponent.setTileType(tileType);
                 tileComponent.setPassable(td.passable());
                 tileComponent.setSelected(td.selected());
                 tileComponent.setHeight(GameConstants.TILE_SIZE);
@@ -66,9 +71,13 @@ public final class MapFactory {
         }
 
         for (BuildingData bd : state.buildings()) {
+            String buildingType = bd.buildingType();
+            if (Registries.buildings().get(buildingType) == null) {
+                continue;
+            }
             Entity building = world.createEntity();
             BuildingComponent component = new BuildingComponent();
-            component.setBuildingType(bd.buildingType());
+            component.setBuildingType(buildingType);
             component.setHeight(GameConstants.TILE_SIZE);
             component.setWidth(GameConstants.TILE_SIZE);
             component.setX(bd.x());

--- a/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
@@ -34,6 +34,7 @@ public final class SaveMigrator {
         register(new V18ToV19Migration());
         register(new V19ToV20Migration());
         register(new V20ToV21Migration());
+        register(new V21ToV22Migration());
     }
 
     private SaveMigrator() {

--- a/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
@@ -24,9 +24,10 @@ public enum SaveVersion {
     V18(18),
     V19(19),
     V20(20),
-    V21(21);
+    V21(21),
+    V22(22);
 
-    public static final SaveVersion CURRENT = V21;
+    public static final SaveVersion CURRENT = V22;
 
     private final int number;
 

--- a/core/src/main/java/net/lapidist/colony/save/V21ToV22Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V21ToV22Migration.java
@@ -1,0 +1,23 @@
+package net.lapidist.colony.save;
+
+import net.lapidist.colony.components.state.MapState;
+
+/** Migration from save version 21 to 22 with no data changes. */
+public final class V21ToV22Migration implements MapStateMigration {
+    @Override
+    public int fromVersion() {
+        return SaveVersion.V21.number();
+    }
+
+    @Override
+    public int toVersion() {
+        return SaveVersion.V22.number();
+    }
+
+    @Override
+    public MapState apply(final MapState state) {
+        return state.toBuilder()
+                .version(toVersion())
+                .build();
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/server/services/ResourceProductionService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/ResourceProductionService.java
@@ -62,7 +62,7 @@ public final class ResourceProductionService {
             state = supplier.get();
             long farms = state.buildings().stream()
                     .map(BuildingData::buildingType)
-                    .filter(t -> "FARM".equals(t))
+                    .filter(t -> "farm".equalsIgnoreCase(t))
                     .count();
             if (farms == 0) {
                 return;

--- a/tests/src/test/java/net/lapidist/colony/client/renderers/MapTileCacheTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/renderers/MapTileCacheTest.java
@@ -41,6 +41,7 @@ public class MapTileCacheTest {
     private static final int EXPECTED_CACHE_COUNT_AFTER_UPDATE = 2;
 
     private MapRenderData createData() {
+        new net.lapidist.colony.base.BaseDefinitionsMod().init();
         MapState state = new MapState();
         state.putTile(TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true)
@@ -53,6 +54,7 @@ public class MapTileCacheTest {
     }
 
     private MapRenderData createLargeData() {
+        new net.lapidist.colony.base.BaseDefinitionsMod().init();
         MapState state = new MapState();
         int total = LARGE_TILE_COUNT;
         for (int i = 0; i < total; i++) {

--- a/tests/src/test/java/net/lapidist/colony/client/ui/MinimapCacheTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/ui/MinimapCacheTest.java
@@ -30,6 +30,7 @@ public class MinimapCacheTest {
     private static final float DRAW_Y = 6f;
 
     private World createWorld() {
+        new net.lapidist.colony.base.BaseDefinitionsMod().init();
         MapState state = new MapState();
         state.putTile(TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true)

--- a/tests/src/test/java/net/lapidist/colony/tests/client/entities/factories/BuildingFactoryTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/entities/factories/BuildingFactoryTest.java
@@ -19,7 +19,7 @@ public class BuildingFactoryTest {
         var entity = BuildingFactory.create(world, "HOUSE", new Vector2(X, Y));
         BuildingComponent comp = entity.getComponent(BuildingComponent.class);
 
-        assertEquals("HOUSE", comp.getBuildingType());
+        assertEquals("house", comp.getBuildingType());
         assertEquals(X, comp.getX());
         assertEquals(Y, comp.getY());
         world.dispose();

--- a/tests/src/test/java/net/lapidist/colony/tests/client/entities/factories/TileFactoryTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/entities/factories/TileFactoryTest.java
@@ -31,7 +31,7 @@ public class TileFactoryTest {
         );
         TileComponent tc = entity.getComponent(TileComponent.class);
 
-        assertEquals("GRASS", tc.getTileType());
+        assertEquals("grass", tc.getTileType());
         assertTrue(tc.isPassable());
         assertFalse(tc.isSelected());
         assertEquals(X, tc.getX());

--- a/tests/src/test/java/net/lapidist/colony/tests/client/render/data/MapRenderDataBuilderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/render/data/MapRenderDataBuilderTest.java
@@ -25,6 +25,7 @@ public class MapRenderDataBuilderTest {
 
     @Test
     public void convertsMapToRenderObjects() {
+        new net.lapidist.colony.base.BaseDefinitionsMod().init();
         MapState state = new MapState();
         state.putTile(TileData.builder()
                 .x(TILE_X).y(TILE_Y).tileType("GRASS").passable(true)
@@ -51,6 +52,7 @@ public class MapRenderDataBuilderTest {
 
     @Test
     public void updatesExistingRenderData() {
+        new net.lapidist.colony.base.BaseDefinitionsMod().init();
         MapState state = new MapState();
         state.putTile(TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true)

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV21Test.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV21Test.java
@@ -1,0 +1,41 @@
+package net.lapidist.colony.tests.server;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Output;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.serialization.KryoRegistry;
+import net.lapidist.colony.save.SaveData;
+import net.lapidist.colony.save.SaveVersion;
+import net.lapidist.colony.serialization.SerializationRegistrar;
+import net.lapidist.colony.server.io.GameStateIO;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+
+public class GameStateIOMigrationV21Test {
+
+    @Test
+    public void migratesV21ToCurrent() throws Exception {
+        Path file = Files.createTempFile("state", ".dat");
+        MapState state = MapState.builder()
+                .version(SaveVersion.V21.number())
+                .build();
+        Kryo kryo = new Kryo();
+        KryoRegistry.register(kryo);
+        try (Output output = new Output(Files.newOutputStream(file))) {
+            SaveData data = new SaveData(
+                    SaveVersion.V21.number(),
+                    SerializationRegistrar.registrationHash(),
+                    state
+            );
+            kryo.writeObject(output, data);
+        }
+
+        MapState loaded = GameStateIO.load(file);
+        Files.deleteIfExists(file);
+        assertEquals(SaveVersion.CURRENT.number(), loaded.version());
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/MapInitSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/MapInitSystemTest.java
@@ -66,6 +66,7 @@ public class MapInitSystemTest {
 
     @Test
     public void mapFactoryCreatesLogicalComponents() {
+        new net.lapidist.colony.base.BaseDefinitionsMod().init();
         MapState state = new MapState();
         state.putTile(TileData.builder()
                 .x(0)


### PR DESCRIPTION
## Summary
- ensure MapFactory checks tile and building IDs using Registries
- lower-case IDs when creating tiles and buildings
- add save version 22 with migration
- validate building types on server
- check farms case-insensitively for production
- update tests for new IDs and initialize definitions

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test check codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684dd160e6e883289d366af7f78730e2