### PR TITLE
Use registries for renderer assets

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
@@ -12,6 +12,8 @@ import net.lapidist.colony.client.systems.CameraProvider;
 import net.lapidist.colony.client.util.CameraUtils;
 import net.lapidist.colony.client.render.data.RenderBuilding;
 import net.lapidist.colony.client.render.MapRenderData;
+import net.lapidist.colony.registry.BuildingDefinition;
+import net.lapidist.colony.registry.Registries;
 
 /**
  * Renders building entities.
@@ -40,11 +42,11 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
         this.cameraSystem = cameraSystemToSet;
         this.resolver = resolverToSet;
 
-        for (String type : new String[]{"HOUSE", "MARKET", "FACTORY", "FARM"}) {
-            String ref = resolver.buildingAsset(type);
+        for (BuildingDefinition def : Registries.buildings().all()) {
+            String ref = resolver.buildingAsset(def.id());
             TextureRegion region = resourceLoader.findRegion(ref);
             if (region != null) {
-                buildingRegions.put(type, region);
+                buildingRegions.put(def.id().toUpperCase(java.util.Locale.ROOT), region);
             }
         }
     }
@@ -66,7 +68,7 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
             }
 
             String type = building.getBuildingType();
-            TextureRegion region = buildingRegions.get(type);
+            TextureRegion region = buildingRegions.get(type.toUpperCase(java.util.Locale.ROOT));
             if (region != null) {
                 spriteBatch.draw(region, worldCoords.x, worldCoords.y);
             }

--- a/client/src/main/java/net/lapidist/colony/client/renderers/DefaultAssetResolver.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/DefaultAssetResolver.java
@@ -1,56 +1,43 @@
 package net.lapidist.colony.client.renderers;
 
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
+
+import net.lapidist.colony.registry.BuildingDefinition;
+import net.lapidist.colony.registry.Registries;
+import net.lapidist.colony.registry.TileDefinition;
 
 /** Default implementation returning built-in asset references. */
 public final class DefaultAssetResolver implements AssetResolver {
 
-    private static final Map<String, String> TILE_ASSETS = new HashMap<>();
-    private static final Map<String, String> BUILDING_ASSETS = new HashMap<>();
-
-    static {
-        TILE_ASSETS.put("EMPTY", "dirt0");
-        TILE_ASSETS.put("DIRT", "dirt0");
-        TILE_ASSETS.put("GRASS", "grass0");
-
-        BUILDING_ASSETS.put("HOUSE", "house0");
-        BUILDING_ASSETS.put("MARKET", "house0");
-        BUILDING_ASSETS.put("FACTORY", "house0");
-        BUILDING_ASSETS.put("FARM", "house0");
-    }
     @Override
     public String tileAsset(final String type) {
-        if (type == null) {
+        TileDefinition def = Registries.tiles().get(type);
+        if (def == null) {
+            def = Registries.tiles().get("empty");
+        }
+        if (def == null || def.asset() == null) {
             return "dirt0";
         }
-        String asset = TILE_ASSETS.get(type.toUpperCase(Locale.ROOT));
-        return asset != null ? asset : "dirt0";
+        return def.asset();
     }
 
     @Override
     public boolean hasTileAsset(final String type) {
-        if (type == null) {
-            return false;
-        }
-        return TILE_ASSETS.containsKey(type.toUpperCase(Locale.ROOT));
+        TileDefinition def = Registries.tiles().get(type);
+        return def != null && def.asset() != null;
     }
 
     @Override
     public String buildingAsset(final String type) {
-        if (type == null) {
+        BuildingDefinition def = Registries.buildings().get(type);
+        if (def == null) {
             return "house0";
         }
-        String asset = BUILDING_ASSETS.get(type.toUpperCase(Locale.ROOT));
-        return asset != null ? asset : "house0";
+        return def.asset() != null ? def.asset() : "house0";
     }
 
     @Override
     public boolean hasBuildingAsset(final String type) {
-        if (type == null) {
-            return false;
-        }
-        return BUILDING_ASSETS.containsKey(type.toUpperCase(Locale.ROOT));
+        BuildingDefinition def = Registries.buildings().get(type);
+        return def != null && def.asset() != null;
     }
 }

--- a/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
@@ -13,6 +13,8 @@ import net.lapidist.colony.client.render.data.RenderTile;
 import net.lapidist.colony.client.render.MapRenderData;
 import net.lapidist.colony.client.TileRotationUtil;
 import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.registry.Registries;
+import net.lapidist.colony.registry.TileDefinition;
 
 /**
  * Renders tile entities.
@@ -48,11 +50,11 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
         this.cameraSystem = cameraSystemToSet;
         this.resolver = resolverToSet;
 
-        for (String type : new String[]{"EMPTY", "DIRT", "GRASS"}) {
-            String ref = resolver.tileAsset(type);
+        for (TileDefinition def : Registries.tiles().all()) {
+            String ref = resolver.tileAsset(def.id());
             TextureRegion region = resourceLoader.findRegion(ref);
             if (region != null) {
-                tileRegions.put(type, region);
+                tileRegions.put(def.id().toUpperCase(java.util.Locale.ROOT), region);
             }
         }
         this.overlayRegion = resourceLoader.findRegion("hoveredTile0");
@@ -97,9 +99,10 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
 
                 if (!overlayOnly) {
                     String type = tile.getTileType();
-                    TextureRegion region = tileRegions.get(type);
+                    TextureRegion region = tileRegions.get(type.toUpperCase(java.util.Locale.ROOT));
                     if (region != null) {
-                        if ("GRASS".equals(type) || "DIRT".equals(type)) {
+                        String upper = type.toUpperCase(java.util.Locale.ROOT);
+                        if ("GRASS".equals(upper) || "DIRT".equals(upper)) {
                             float rotation = TileRotationUtil.rotationFor(tile.getX(), tile.getY());
                             spriteBatch.draw(
                                     region,

--- a/tests/src/test/java/net/lapidist/colony/tests/client/render/data/DefaultAssetResolverTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/render/data/DefaultAssetResolverTest.java
@@ -1,6 +1,7 @@
 package net.lapidist.colony.tests.client.render.data;
 
 import net.lapidist.colony.client.renderers.DefaultAssetResolver;
+import net.lapidist.colony.base.BaseDefinitionsMod;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -8,6 +9,7 @@ import static org.junit.Assert.*;
 public class DefaultAssetResolverTest {
     @Test
     public void returnsSpriteReferences() {
+        new BaseDefinitionsMod().init();
         DefaultAssetResolver resolver = new DefaultAssetResolver();
         assertEquals("grass0", resolver.tileAsset("GRASS"));
         assertEquals("grass0", resolver.tileAsset("grass"));

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/BuildingRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/BuildingRendererTest.java
@@ -10,6 +10,7 @@ import com.badlogic.gdx.utils.viewport.ExtendViewport;
 import net.lapidist.colony.client.renderers.BuildingRenderer;
 import net.lapidist.colony.client.renderers.DefaultAssetResolver;
 import net.lapidist.colony.client.renderers.AssetResolver;
+import net.lapidist.colony.base.BaseDefinitionsMod;
 import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.client.systems.CameraProvider;
 import net.lapidist.colony.client.render.data.RenderBuilding;
@@ -33,6 +34,8 @@ public class BuildingRendererTest {
         ResourceLoader loader = mock(ResourceLoader.class);
         TextureRegion region = mock(TextureRegion.class);
         when(loader.findRegion(anyString())).thenReturn(region);
+
+        new BaseDefinitionsMod().init();
 
         CameraProvider camera = mock(CameraProvider.class);
         OrthographicCamera cam = new OrthographicCamera();
@@ -63,6 +66,8 @@ public class BuildingRendererTest {
         ResourceLoader loader = mock(ResourceLoader.class);
         TextureRegion region = mock(TextureRegion.class);
         when(loader.findRegion(anyString())).thenReturn(region);
+
+        new BaseDefinitionsMod().init();
 
         CameraProvider camera = mock(CameraProvider.class);
         OrthographicCamera cam = new OrthographicCamera();

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/DefaultAssetResolverAssetsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/DefaultAssetResolverAssetsTest.java
@@ -1,6 +1,7 @@
 package net.lapidist.colony.tests.client.renderers;
 
 import net.lapidist.colony.client.renderers.DefaultAssetResolver;
+import net.lapidist.colony.base.BaseDefinitionsMod;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -8,6 +9,7 @@ import static org.junit.Assert.*;
 public class DefaultAssetResolverAssetsTest {
     @Test
     public void returnsSpriteReferences() {
+        new BaseDefinitionsMod().init();
         DefaultAssetResolver resolver = new DefaultAssetResolver();
         assertEquals("grass0", resolver.tileAsset("GRASS"));
         assertEquals("grass0", resolver.tileAsset("grass"));

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/RendererEnumMapTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/RendererEnumMapTest.java
@@ -5,6 +5,8 @@ import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import net.lapidist.colony.client.renderers.BuildingRenderer;
 import net.lapidist.colony.client.renderers.DefaultAssetResolver;
 import net.lapidist.colony.client.renderers.TileRenderer;
+import net.lapidist.colony.base.BaseDefinitionsMod;
+import net.lapidist.colony.registry.Registries;
 import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.client.systems.CameraProvider;
 import net.lapidist.colony.tests.GdxTestRunner;
@@ -24,6 +26,7 @@ public class RendererEnumMapTest {
         SpriteBatch batch = mock(SpriteBatch.class);
         ResourceLoader loader = mock(ResourceLoader.class);
         when(loader.findRegion(anyString())).thenReturn(new TextureRegion());
+        new BaseDefinitionsMod().init();
         TileRenderer renderer = new TileRenderer(
                 batch,
                 loader,
@@ -36,10 +39,10 @@ public class RendererEnumMapTest {
         f.setAccessible(true);
         java.util.Map<?, ?> map = (java.util.Map<?, ?>) f.get(renderer);
 
-        String[] types = {"EMPTY", "DIRT", "GRASS"};
-        assertEquals(types.length, map.size());
-        for (String type : types) {
-            assertNotNull(map.get(type));
+        int expected = Registries.tiles().all().size();
+        assertEquals(expected, map.size());
+        for (var def : Registries.tiles().all()) {
+            assertNotNull(map.get(def.id().toUpperCase(java.util.Locale.ROOT)));
         }
     }
 
@@ -48,6 +51,7 @@ public class RendererEnumMapTest {
         SpriteBatch batch = mock(SpriteBatch.class);
         ResourceLoader loader = mock(ResourceLoader.class);
         when(loader.findRegion(anyString())).thenReturn(new TextureRegion());
+        new BaseDefinitionsMod().init();
         BuildingRenderer renderer = new BuildingRenderer(
                 batch,
                 loader,
@@ -59,10 +63,10 @@ public class RendererEnumMapTest {
         f.setAccessible(true);
         java.util.Map<?, ?> map = (java.util.Map<?, ?>) f.get(renderer);
 
-        String[] buildings = {"HOUSE", "MARKET", "FACTORY", "FARM"};
-        assertEquals(buildings.length, map.size());
-        for (String type : buildings) {
-            assertNotNull(map.get(type));
+        int expected = Registries.buildings().all().size();
+        assertEquals(expected, map.size());
+        for (var def : Registries.buildings().all()) {
+            assertNotNull(map.get(def.id().toUpperCase(java.util.Locale.ROOT)));
         }
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/TileRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/TileRendererTest.java
@@ -8,6 +8,7 @@ import com.badlogic.gdx.utils.Array;
 import net.lapidist.colony.client.renderers.DefaultAssetResolver;
 import net.lapidist.colony.client.renderers.AssetResolver;
 import net.lapidist.colony.client.renderers.TileRenderer;
+import net.lapidist.colony.base.BaseDefinitionsMod;
 import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.client.systems.CameraProvider;
 import net.lapidist.colony.client.render.data.RenderTile;
@@ -35,6 +36,8 @@ public class TileRendererTest {
         TextureRegion overlay = mock(TextureRegion.class);
         when(loader.findRegion(anyString())).thenReturn(region);
         when(loader.findRegion(eq("hoveredTile0"))).thenReturn(overlay);
+
+        new BaseDefinitionsMod().init();
 
         CameraProvider camera = mock(CameraProvider.class);
         com.badlogic.gdx.graphics.OrthographicCamera cam = new com.badlogic.gdx.graphics.OrthographicCamera();
@@ -97,6 +100,8 @@ public class TileRendererTest {
         when(loader.findRegion(anyString())).thenReturn(region);
         when(loader.findRegion(eq("hoveredTile0"))).thenReturn(overlay);
 
+        new BaseDefinitionsMod().init();
+
         CameraProvider camera = mock(CameraProvider.class);
         com.badlogic.gdx.graphics.OrthographicCamera cam = new com.badlogic.gdx.graphics.OrthographicCamera();
         com.badlogic.gdx.utils.viewport.ExtendViewport viewport =
@@ -138,6 +143,8 @@ public class TileRendererTest {
         TextureRegion overlay = mock(TextureRegion.class);
         when(loader.findRegion(anyString())).thenReturn(region);
         when(loader.findRegion(eq("hoveredTile0"))).thenReturn(overlay);
+
+        new BaseDefinitionsMod().init();
 
         CameraProvider camera = mock(CameraProvider.class);
         com.badlogic.gdx.graphics.OrthographicCamera cam = new com.badlogic.gdx.graphics.OrthographicCamera();


### PR DESCRIPTION
## Summary
- pull asset references from `Registries` in `DefaultAssetResolver`
- populate renderer caches using registered definitions
- make renderer caches case-insensitive
- update tests for registry based lookups

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684dda1013d88328b4e966d1be2939a5