### PR TITLE
feat: send building ids via network

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/systems/input/BuildingPlacementHandler.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/input/BuildingPlacementHandler.java
@@ -42,7 +42,7 @@ public final class BuildingPlacementHandler {
                     BuildingPlacementData msg = new BuildingPlacementData(
                             tc.getX(),
                             tc.getY(),
-                            "HOUSE"
+                            "house"
                     );
                     client.sendBuildRequest(msg);
                     return true;

--- a/core/src/main/java/net/lapidist/colony/components/state/BuildingPlacementData.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/BuildingPlacementData.java
@@ -7,8 +7,8 @@ import net.lapidist.colony.serialization.KryoType;
  *
  * @param x            tile x coordinate
  * @param y            tile y coordinate
- * @param buildingType building type identifier
+ * @param buildingId building identifier
  */
 @KryoType
-public record BuildingPlacementData(int x, int y, String buildingType) {
+public record BuildingPlacementData(int x, int y, String buildingId) {
 }

--- a/core/src/main/java/net/lapidist/colony/map/ChunkedMapGenerator.java
+++ b/core/src/main/java/net/lapidist/colony/map/ChunkedMapGenerator.java
@@ -42,7 +42,7 @@ public final class ChunkedMapGenerator implements MapGenerator {
         }
 
         // generate a starting building in the middle
-        BuildingData building = new BuildingData(width / 2, height / 2, "HOUSE");
+        BuildingData building = new BuildingData(width / 2, height / 2, "house");
         state.buildings().add(building);
 
         // prepopulate resources when tiles are first accessed

--- a/server/src/main/java/net/lapidist/colony/server/commands/BuildCommand.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/BuildCommand.java
@@ -5,7 +5,7 @@ package net.lapidist.colony.server.commands;
  *
  * @param x    tile x coordinate
  * @param y    tile y coordinate
- * @param type building type
+ * @param buildingId building identifier
  */
-public record BuildCommand(int x, int y, String type) implements ServerCommand {
+public record BuildCommand(int x, int y, String buildingId) implements ServerCommand {
 }

--- a/server/src/main/java/net/lapidist/colony/server/commands/BuildCommandHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/BuildCommandHandler.java
@@ -58,7 +58,7 @@ public final class BuildCommandHandler implements CommandHandler<BuildCommand> {
             if (tile == null || occupied) {
                 return;
             }
-            BuildingDefinition def = Registries.buildings().get(command.type());
+            BuildingDefinition def = Registries.buildings().get(command.buildingId());
             if (def == null) {
                 return;
             }

--- a/server/src/main/java/net/lapidist/colony/server/handlers/BuildingPlacementRequestHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/handlers/BuildingPlacementRequestHandler.java
@@ -21,7 +21,7 @@ public final class BuildingPlacementRequestHandler extends AbstractMessageHandle
         commandBus.dispatch(new BuildCommand(
                 data.x(),
                 data.y(),
-                data.buildingType()
+                data.buildingId()
         ));
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/entities/factories/BuildingFactoryTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/entities/factories/BuildingFactoryTest.java
@@ -16,7 +16,7 @@ public class BuildingFactoryTest {
     @Test
     public void createSetsBuildingType() {
         World world = new World(new WorldConfigurationBuilder().build());
-        var entity = BuildingFactory.create(world, "HOUSE", new Vector2(X, Y));
+        var entity = BuildingFactory.create(world, "house", new Vector2(X, Y));
         BuildingComponent comp = entity.getComponent(BuildingComponent.class);
 
         assertEquals("house", comp.getBuildingType());

--- a/tests/src/test/java/net/lapidist/colony/tests/client/render/data/DefaultAssetResolverTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/render/data/DefaultAssetResolverTest.java
@@ -19,15 +19,15 @@ public class DefaultAssetResolverTest {
         assertEquals("dirt0", resolver.tileAsset("invalid"));
         assertTrue(resolver.hasTileAsset("GRASS"));
         assertFalse(resolver.hasTileAsset("invalid"));
-        assertEquals("house0", resolver.buildingAsset("HOUSE"));
         assertEquals("house0", resolver.buildingAsset("house"));
-        assertEquals("house0", resolver.buildingAsset("MARKET"));
-        assertEquals("house0", resolver.buildingAsset("FACTORY"));
-        assertEquals("house0", resolver.buildingAsset("FARM"));
+        assertEquals("house0", resolver.buildingAsset("house"));
+        assertEquals("house0", resolver.buildingAsset("market"));
+        assertEquals("house0", resolver.buildingAsset("factory"));
+        assertEquals("house0", resolver.buildingAsset("farm"));
         assertEquals("house0", resolver.buildingAsset(null));
         assertEquals("house0", resolver.buildingAsset("invalid"));
-        assertTrue(resolver.hasBuildingAsset("HOUSE"));
-        assertTrue(resolver.hasBuildingAsset("FARM"));
+        assertTrue(resolver.hasBuildingAsset("house"));
+        assertTrue(resolver.hasBuildingAsset("farm"));
         assertFalse(resolver.hasBuildingAsset("invalid"));
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/render/data/MapRenderDataBuilderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/render/data/MapRenderDataBuilderTest.java
@@ -31,7 +31,7 @@ public class MapRenderDataBuilderTest {
                 .x(TILE_X).y(TILE_Y).tileType("GRASS").passable(true)
                 .resources(new net.lapidist.colony.components.state.ResourceData(WOOD, STONE, FOOD))
                 .build());
-        state.buildings().add(new BuildingData(BUILDING_X, BUILDING_Y, "HOUSE"));
+        state.buildings().add(new BuildingData(BUILDING_X, BUILDING_Y, "house"));
 
         World world = new World(new WorldConfigurationBuilder().build());
         MapComponent map = MapFactory.create(world, state).getComponent(MapComponent.class);

--- a/tests/src/test/java/net/lapidist/colony/tests/client/render/data/RenderBuildingTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/render/data/RenderBuildingTest.java
@@ -14,11 +14,11 @@ public class RenderBuildingTest {
         RenderBuilding building = RenderBuilding.builder()
                 .x(X)
                 .y(Y)
-                .buildingType("HOUSE")
+                .buildingType("house")
                 .build();
 
         assertEquals(X, building.getX());
         assertEquals(Y, building.getY());
-        assertEquals("HOUSE", building.getBuildingType());
+        assertEquals("house", building.getBuildingType());
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/BuildingRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/BuildingRendererTest.java
@@ -49,7 +49,7 @@ public class BuildingRendererTest {
         reset(loader);
 
         Array<RenderBuilding> buildings = new Array<>();
-        RenderBuilding building = RenderBuilding.builder().x(0).y(0).buildingType("HOUSE").build();
+        RenderBuilding building = RenderBuilding.builder().x(0).y(0).buildingType("house").build();
         buildings.add(building);
 
         MapRenderData map = new SimpleMapRenderData(new Array<RenderTile>(), buildings,
@@ -81,7 +81,7 @@ public class BuildingRendererTest {
         reset(loader);
 
         Array<RenderBuilding> buildings = new Array<>();
-        RenderBuilding building = RenderBuilding.builder().x(0).y(0).buildingType("HOUSE").build();
+        RenderBuilding building = RenderBuilding.builder().x(0).y(0).buildingType("house").build();
         buildings.add(building);
 
         MapRenderData map = new SimpleMapRenderData(new Array<RenderTile>(), buildings,
@@ -124,7 +124,7 @@ public class BuildingRendererTest {
         layoutField.set(renderer, layout);
 
         Array<RenderBuilding> buildings = new Array<>();
-        RenderBuilding building = RenderBuilding.builder().x(0).y(0).buildingType("HOUSE").build();
+        RenderBuilding building = RenderBuilding.builder().x(0).y(0).buildingType("house").build();
         buildings.add(building);
 
         MapRenderData map = new SimpleMapRenderData(new Array<RenderTile>(), buildings,

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/DefaultAssetResolverAssetsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/DefaultAssetResolverAssetsTest.java
@@ -19,15 +19,15 @@ public class DefaultAssetResolverAssetsTest {
         assertEquals("dirt0", resolver.tileAsset("invalid"));
         assertTrue(resolver.hasTileAsset("GRASS"));
         assertFalse(resolver.hasTileAsset("invalid"));
-        assertEquals("house0", resolver.buildingAsset("HOUSE"));
         assertEquals("house0", resolver.buildingAsset("house"));
-        assertEquals("house0", resolver.buildingAsset("MARKET"));
-        assertEquals("house0", resolver.buildingAsset("FACTORY"));
-        assertEquals("house0", resolver.buildingAsset("FARM"));
+        assertEquals("house0", resolver.buildingAsset("house"));
+        assertEquals("house0", resolver.buildingAsset("market"));
+        assertEquals("house0", resolver.buildingAsset("factory"));
+        assertEquals("house0", resolver.buildingAsset("farm"));
         assertEquals("house0", resolver.buildingAsset(null));
         assertEquals("house0", resolver.buildingAsset("invalid"));
-        assertTrue(resolver.hasBuildingAsset("HOUSE"));
-        assertTrue(resolver.hasBuildingAsset("FARM"));
+        assertTrue(resolver.hasBuildingAsset("house"));
+        assertTrue(resolver.hasBuildingAsset("farm"));
         assertFalse(resolver.hasBuildingAsset("invalid"));
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/core/base/BaseDefinitionsModTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/base/BaseDefinitionsModTest.java
@@ -15,7 +15,7 @@ public class BaseDefinitionsModTest {
 
         assertNotNull(Registries.tiles().get("GRASS"));
         assertNotNull(Registries.tiles().get("DIRT"));
-        assertNotNull(Registries.buildings().get("HOUSE"));
-        assertNotNull(Registries.buildings().get("FARM"));
+        assertNotNull(Registries.buildings().get("house"));
+        assertNotNull(Registries.buildings().get("farm"));
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/core/registry/RegistryTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/registry/RegistryTest.java
@@ -25,7 +25,7 @@ public class RegistryTest {
         BuildingRegistry registry = new BuildingRegistry();
         BuildingDefinition def = new BuildingDefinition("house", "House", "house0");
         registry.register(def);
-        assertEquals(def, registry.get("HOUSE"));
+        assertEquals(def, registry.get("house"));
     }
 
     @Test

--- a/tests/src/test/java/net/lapidist/colony/tests/network/GameServerBuildBroadcastTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/network/GameServerBuildBroadcastTest.java
@@ -45,7 +45,7 @@ public class GameServerBuildBroadcastTest {
             latchA.await(1, TimeUnit.SECONDS);
             latchB.await(1, TimeUnit.SECONDS);
 
-        BuildingPlacementData data = new BuildingPlacementData(0, 0, "HOUSE");
+        BuildingPlacementData data = new BuildingPlacementData(0, 0, "house");
         clientA.sendBuildRequest(data);
 
         Thread.sleep(WAIT_MS);
@@ -85,7 +85,7 @@ public class GameServerBuildBroadcastTest {
             latchA.await(1, TimeUnit.SECONDS);
             latchB.await(1, TimeUnit.SECONDS);
 
-        BuildingPlacementData data = new BuildingPlacementData(0, 0, "FARM");
+        BuildingPlacementData data = new BuildingPlacementData(0, 0, "farm");
         clientA.sendBuildRequest(data);
 
         Thread.sleep(WAIT_MS);

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationBuildingCostTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationBuildingCostTest.java
@@ -49,7 +49,7 @@ public class GameSimulationBuildingCostTest {
         MapState state = receiver.getMapState();
         GameSimulation sim = new GameSimulation(state, receiver);
 
-        BuildingPlacementData data = new BuildingPlacementData(0, 0, "HOUSE");
+        BuildingPlacementData data = new BuildingPlacementData(0, 0, "house");
         sender.sendBuildRequest(data);
 
         Thread.sleep(WAIT_MS);
@@ -92,7 +92,7 @@ public class GameSimulationBuildingCostTest {
         MapState state = receiver.getMapState();
         GameSimulation sim = new GameSimulation(state, receiver);
 
-        BuildingPlacementData data = new BuildingPlacementData(0, 0, "FARM");
+        BuildingPlacementData data = new BuildingPlacementData(0, 0, "farm");
         sender.sendBuildRequest(data);
 
         Thread.sleep(WAIT_MS);

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationBuildingRemovalTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationBuildingRemovalTest.java
@@ -28,7 +28,7 @@ public class GameSimulationBuildingRemovalTest {
         MapGenerator gen = (w, h) -> {
             MapState state = new ChunkedMapGenerator().generate(w, h);
             state.buildings().clear();
-            state.buildings().add(new BuildingData(0, 0, "HOUSE"));
+            state.buildings().add(new BuildingData(0, 0, "house"));
             return state;
         };
         GameServerConfig config = GameServerConfig.builder()

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationBuildingUpdateTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationBuildingUpdateTest.java
@@ -49,7 +49,7 @@ public class GameSimulationBuildingUpdateTest {
         MapState state = receiver.getMapState();
         GameSimulation sim = new GameSimulation(state, receiver);
 
-        BuildingPlacementData data = new BuildingPlacementData(0, 0, "HOUSE");
+        BuildingPlacementData data = new BuildingPlacementData(0, 0, "house");
         sender.sendBuildRequest(data);
 
         Thread.sleep(WAIT_MS);

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationFoodProductionTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationFoodProductionTest.java
@@ -29,7 +29,7 @@ public class GameSimulationFoodProductionTest {
     public void foodIncreasesFromServerProduction() throws Exception {
         MapGenerator gen = (w, h) -> {
             MapState s = new ChunkedMapGenerator().generate(w, h);
-            s.buildings().add(new BuildingData(0, 0, "FARM"));
+            s.buildings().add(new BuildingData(0, 0, "farm"));
             return s.toBuilder().playerResources(new ResourceData()).build();
         };
         GameServerConfig config = GameServerConfig.builder()

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationResourceProductionOverrideTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationResourceProductionOverrideTest.java
@@ -38,7 +38,7 @@ public class GameSimulationResourceProductionOverrideTest {
     public void overriddenServicePreventsFoodProduction() throws Exception {
         MapGenerator gen = (w, h) -> {
             MapState s = new ChunkedMapGenerator().generate(w, h);
-            s.buildings().add(new BuildingData(0, 0, "FARM"));
+            s.buildings().add(new BuildingData(0, 0, "farm"));
             return s.toBuilder().playerResources(new ResourceData()).build();
         };
         GameServerConfig config = GameServerConfig.builder()

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerBuildTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerBuildTest.java
@@ -47,7 +47,7 @@ public class GameServerBuildTest {
             client.start(state -> latch.countDown());
             latch.await(1, TimeUnit.SECONDS);
 
-        BuildingPlacementData data = new BuildingPlacementData(0, 0, "HOUSE");
+        BuildingPlacementData data = new BuildingPlacementData(0, 0, "house");
         client.sendBuildRequest(data);
         Thread.sleep(WAIT_MS);
         Events.update();

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerConcurrencyTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerConcurrencyTest.java
@@ -39,7 +39,7 @@ public class GameServerConcurrencyTest {
             client.start(state -> latch.countDown());
             latch.await(1, TimeUnit.SECONDS);
 
-        client.sendBuildRequest(new BuildingPlacementData(0, 0, "HOUSE"));
+        client.sendBuildRequest(new BuildingPlacementData(0, 0, "house"));
         Thread.sleep(WAIT_MS);
 
         assertTrue(server.getMapState().buildings().stream()

--- a/tests/src/test/java/net/lapidist/colony/tests/server/ResourceProductionServiceTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/ResourceProductionServiceTest.java
@@ -22,7 +22,7 @@ public class ResourceProductionServiceTest {
     @Test
     public void increasesFoodWhenFarmsExist() throws Exception {
         MapState state = new MapState();
-        state.buildings().add(new BuildingData(0, 0, "FARM"));
+        state.buildings().add(new BuildingData(0, 0, "farm"));
         state = state.toBuilder().playerResources(new ResourceData()).build();
         AtomicReference<MapState> ref = new AtomicReference<>(state);
         NetworkService network = mock(NetworkService.class);

--- a/tests/src/test/java/net/lapidist/colony/tests/server/events/ServerEventsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/events/ServerEventsTest.java
@@ -102,9 +102,9 @@ public class ServerEventsTest {
     public void testBuildingPlacedEventToString() {
         final int x = 1;
         final int y = 2;
-        BuildingPlacedEvent event = new BuildingPlacedEvent(x, y, "HOUSE");
+        BuildingPlacedEvent event = new BuildingPlacedEvent(x, y, "house");
         assertEquals(
-                String.format("BuildingPlacedEvent(x=%d, y=%d, buildingType=HOUSE)", x, y),
+                String.format("BuildingPlacedEvent(x=%d, y=%d, buildingType=house)", x, y),
                 event.toString()
         );
     }

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/BuildPlacementSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/BuildPlacementSystemTest.java
@@ -97,7 +97,7 @@ public class BuildPlacementSystemTest {
     @Test
     public void tapRemovesBuildingWhenEnabled() {
         MapState state = new MapState();
-        state.buildings().add(new net.lapidist.colony.components.state.BuildingData(0, 0, "HOUSE"));
+        state.buildings().add(new net.lapidist.colony.components.state.BuildingData(0, 0, "house"));
         state.putTile(TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true)
                 .build());

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/BuildingUpdateSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/BuildingUpdateSystemTest.java
@@ -40,7 +40,7 @@ public class BuildingUpdateSystemTest {
 
         world.process();
 
-        BuildingData data = new BuildingData(0, 0, "HOUSE");
+        BuildingData data = new BuildingData(0, 0, "house");
         client.injectBuildingUpdate(data);
 
         world.process();

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/MapLoadSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/MapLoadSystemTest.java
@@ -28,7 +28,7 @@ public class MapLoadSystemTest {
                 .build();
         state.putTile(tile);
 
-        BuildingData building = new BuildingData(1, 1, "HOUSE");
+        BuildingData building = new BuildingData(1, 1, "house");
         state.buildings().add(building);
 
         World world = new World(new WorldConfigurationBuilder()


### PR DESCRIPTION
## Summary
- send building ids instead of enum names
- look up building definitions with `Registries` when handling build commands
- normalize tests and generation code to use lowercase ids

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684ddd343f5c83288ff5d5dc96955241