### PR TITLE
test: add registry coverage

### DIFF
--- a/tests/src/test/java/net/lapidist/colony/tests/client/render/data/RenderBuildingTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/render/data/RenderBuildingTest.java
@@ -1,6 +1,8 @@
 package net.lapidist.colony.tests.client.render.data;
 
 import net.lapidist.colony.client.render.data.RenderBuilding;
+import net.lapidist.colony.base.BaseDefinitionsMod;
+import net.lapidist.colony.registry.Registries;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -11,14 +13,16 @@ public class RenderBuildingTest {
 
     @Test
     public void builderSetsFields() {
+        new BaseDefinitionsMod().init();
+        String id = Registries.buildings().get("house").id();
         RenderBuilding building = RenderBuilding.builder()
                 .x(X)
                 .y(Y)
-                .buildingType("house")
+                .buildingType(id)
                 .build();
 
         assertEquals(X, building.getX());
         assertEquals(Y, building.getY());
-        assertEquals("house", building.getBuildingType());
+        assertEquals(id, building.getBuildingType());
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/render/data/RenderTileTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/render/data/RenderTileTest.java
@@ -1,6 +1,8 @@
 package net.lapidist.colony.tests.client.render.data;
 
 import net.lapidist.colony.client.render.data.RenderTile;
+import net.lapidist.colony.base.BaseDefinitionsMod;
+import net.lapidist.colony.registry.Registries;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -14,10 +16,12 @@ public class RenderTileTest {
 
     @Test
     public void builderSetsAllFields() {
+        new BaseDefinitionsMod().init();
+        String id = Registries.tiles().get("grass").id();
         RenderTile tile = RenderTile.builder()
                 .x(X)
                 .y(Y)
-                .tileType("GRASS")
+                .tileType(id)
                 .selected(true)
                 .wood(WOOD)
                 .stone(STONE)
@@ -26,7 +30,7 @@ public class RenderTileTest {
 
         assertEquals(X, tile.getX());
         assertEquals(Y, tile.getY());
-        assertEquals("GRASS", tile.getTileType());
+        assertEquals(id, tile.getTileType());
         assertTrue(tile.isSelected());
         assertEquals(WOOD, tile.getWood());
         assertEquals(STONE, tile.getStone());

--- a/tests/src/test/java/net/lapidist/colony/tests/core/registry/BuildingRegistryTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/registry/BuildingRegistryTest.java
@@ -1,0 +1,41 @@
+package net.lapidist.colony.tests.core.registry;
+
+import net.lapidist.colony.registry.BuildingDefinition;
+import net.lapidist.colony.registry.BuildingRegistry;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class BuildingRegistryTest {
+    @Test
+    public void getIsCaseInsensitive() {
+        BuildingRegistry registry = new BuildingRegistry();
+        BuildingDefinition def = new BuildingDefinition("house", "House", "house0");
+        registry.register(def);
+
+        assertSame(def, registry.get("house"));
+        assertSame(def, registry.get("HOUSE"));
+        assertSame(def, registry.get("HoUsE"));
+    }
+
+    @Test
+    public void registerIgnoresNulls() {
+        BuildingRegistry registry = new BuildingRegistry();
+        registry.register(null);
+        registry.register(new BuildingDefinition(null, null, null));
+        assertTrue(registry.all().isEmpty());
+    }
+
+    @Test
+    public void allReturnsRegisteredDefinitions() {
+        BuildingRegistry registry = new BuildingRegistry();
+        BuildingDefinition house = new BuildingDefinition("house", "House", "house0");
+        BuildingDefinition farm = new BuildingDefinition("farm", "Farm", "farm0");
+        registry.register(house);
+        registry.register(farm);
+
+        assertEquals(2, registry.all().size());
+        assertTrue(registry.all().contains(house));
+        assertTrue(registry.all().contains(farm));
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/core/registry/TileRegistryTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/registry/TileRegistryTest.java
@@ -1,0 +1,41 @@
+package net.lapidist.colony.tests.core.registry;
+
+import net.lapidist.colony.registry.TileDefinition;
+import net.lapidist.colony.registry.TileRegistry;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class TileRegistryTest {
+    @Test
+    public void getIsCaseInsensitive() {
+        TileRegistry registry = new TileRegistry();
+        TileDefinition def = new TileDefinition("grass", "Grass", "grass0");
+        registry.register(def);
+
+        assertSame(def, registry.get("GRASS"));
+        assertSame(def, registry.get("grass"));
+        assertSame(def, registry.get("GrAsS"));
+    }
+
+    @Test
+    public void registerIgnoresNulls() {
+        TileRegistry registry = new TileRegistry();
+        registry.register(null);
+        registry.register(new TileDefinition(null, null, null));
+        assertTrue(registry.all().isEmpty());
+    }
+
+    @Test
+    public void allReturnsRegisteredDefinitions() {
+        TileRegistry registry = new TileRegistry();
+        TileDefinition a = new TileDefinition("grass", "Grass", "grass0");
+        TileDefinition b = new TileDefinition("dirt", "Dirt", "dirt0");
+        registry.register(a);
+        registry.register(b);
+
+        assertEquals(2, registry.all().size());
+        assertTrue(registry.all().contains(a));
+        assertTrue(registry.all().contains(b));
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for TileRegistry and BuildingRegistry
- update render data tests to fetch registry IDs

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test check`
- `./gradlew codeCoverageReport`

------
https://chatgpt.com/codex/tasks/task_e_684ddfa1d13c8328aaa730d6d27bcca4