### PR TITLE
feat(server): split built-in mods

### DIFF
--- a/docs/mods.md
+++ b/docs/mods.md
@@ -37,12 +37,15 @@ A minimal `mod.json` looks like:
 
 ### Built-in server mods
 
-The dedicated server bundles two mods providing the default functionality. These
-are loaded automatically and do not need to be placed inside the `mods/` folder:
+The dedicated server bundles several mods providing the default functionality.
+These are loaded automatically and do not need to be placed inside the `mods/` folder:
 
 ```json
-{ "id": "base-services", "version": "1.0.0" }
-{ "id": "base-commands", "version": "1.0.0" }
+{ "id": "base-map-service", "version": "1.0.0" }
+{ "id": "base-network", "version": "1.0.0" }
+{ "id": "base-autosave", "version": "1.0.0" }
+{ "id": "base-resource-production", "version": "1.0.0" }
+{ "id": "base-handlers", "version": "1.0.0" }
 ```
 
 ## How mods are discovered

--- a/server/src/main/java/net/lapidist/colony/base/BaseAutosaveMod.java
+++ b/server/src/main/java/net/lapidist/colony/base/BaseAutosaveMod.java
@@ -1,0 +1,13 @@
+package net.lapidist.colony.base;
+
+import net.lapidist.colony.mod.GameMod;
+import net.lapidist.colony.mod.GameServer;
+
+/** Built-in mod providing the default AutosaveService factory. */
+public final class BaseAutosaveMod implements GameMod {
+    @Override
+    public void registerServices(final GameServer srv) {
+        net.lapidist.colony.server.GameServer s = (net.lapidist.colony.server.GameServer) srv;
+        s.setAutosaveServiceFactory(s.getAutosaveServiceFactory());
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/base/BaseHandlersMod.java
+++ b/server/src/main/java/net/lapidist/colony/base/BaseHandlersMod.java
@@ -5,7 +5,7 @@ import net.lapidist.colony.mod.GameServer;
 import net.lapidist.colony.mod.CommandBus;
 
 /** Built-in mod registering default command and message handlers. */
-public final class BaseCommandsMod implements GameMod {
+public final class BaseHandlersMod implements GameMod {
     private net.lapidist.colony.server.GameServer server;
 
     @Override

--- a/server/src/main/java/net/lapidist/colony/base/BaseMapServiceMod.java
+++ b/server/src/main/java/net/lapidist/colony/base/BaseMapServiceMod.java
@@ -1,0 +1,13 @@
+package net.lapidist.colony.base;
+
+import net.lapidist.colony.mod.GameMod;
+import net.lapidist.colony.mod.GameServer;
+
+/** Built-in mod providing the default MapService factory. */
+public final class BaseMapServiceMod implements GameMod {
+    @Override
+    public void registerServices(final GameServer srv) {
+        net.lapidist.colony.server.GameServer s = (net.lapidist.colony.server.GameServer) srv;
+        s.setMapServiceFactory(s.getMapServiceFactory());
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/base/BaseNetworkMod.java
+++ b/server/src/main/java/net/lapidist/colony/base/BaseNetworkMod.java
@@ -1,0 +1,13 @@
+package net.lapidist.colony.base;
+
+import net.lapidist.colony.mod.GameMod;
+import net.lapidist.colony.mod.GameServer;
+
+/** Built-in mod providing the default NetworkService factory. */
+public final class BaseNetworkMod implements GameMod {
+    @Override
+    public void registerServices(final GameServer srv) {
+        net.lapidist.colony.server.GameServer s = (net.lapidist.colony.server.GameServer) srv;
+        s.setNetworkServiceFactory(s.getNetworkServiceFactory());
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/base/BaseResourceProductionMod.java
+++ b/server/src/main/java/net/lapidist/colony/base/BaseResourceProductionMod.java
@@ -3,15 +3,11 @@ package net.lapidist.colony.base;
 import net.lapidist.colony.mod.GameMod;
 import net.lapidist.colony.mod.GameServer;
 
-/** Built-in mod providing default service factories. */
-public final class BaseServicesMod implements GameMod {
+/** Built-in mod providing the default ResourceProductionService factory. */
+public final class BaseResourceProductionMod implements GameMod {
     @Override
     public void registerServices(final GameServer srv) {
         net.lapidist.colony.server.GameServer s = (net.lapidist.colony.server.GameServer) srv;
-        s.setMapServiceFactory(s.getMapServiceFactory());
-        s.setNetworkServiceFactory(s.getNetworkServiceFactory());
-        s.setAutosaveServiceFactory(s.getAutosaveServiceFactory());
         s.setResourceProductionServiceFactory(s.getResourceProductionServiceFactory());
-        s.setCommandBusFactory(s.getCommandBusFactory());
     }
 }

--- a/server/src/main/java/net/lapidist/colony/server/GameServer.java
+++ b/server/src/main/java/net/lapidist/colony/server/GameServer.java
@@ -145,10 +145,16 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
         mods = new java.util.ArrayList<>(mods);
         mods.add(new LoadedMod(new net.lapidist.colony.base.BaseDefinitionsMod(),
                 new net.lapidist.colony.mod.ModMetadata("base-definitions", "1.0.0", java.util.List.of())));
-        mods.add(new LoadedMod(new net.lapidist.colony.base.BaseServicesMod(),
-                new net.lapidist.colony.mod.ModMetadata("base-services", "1.0.0", java.util.List.of())));
-        mods.add(new LoadedMod(new net.lapidist.colony.base.BaseCommandsMod(),
-                new net.lapidist.colony.mod.ModMetadata("base-commands", "1.0.0", java.util.List.of())));
+        mods.add(new LoadedMod(new net.lapidist.colony.base.BaseMapServiceMod(),
+                new net.lapidist.colony.mod.ModMetadata("base-map-service", "1.0.0", java.util.List.of())));
+        mods.add(new LoadedMod(new net.lapidist.colony.base.BaseNetworkMod(),
+                new net.lapidist.colony.mod.ModMetadata("base-network", "1.0.0", java.util.List.of())));
+        mods.add(new LoadedMod(new net.lapidist.colony.base.BaseAutosaveMod(),
+                new net.lapidist.colony.mod.ModMetadata("base-autosave", "1.0.0", java.util.List.of())));
+        mods.add(new LoadedMod(new net.lapidist.colony.base.BaseResourceProductionMod(),
+                new net.lapidist.colony.mod.ModMetadata("base-resource-production", "1.0.0", java.util.List.of())));
+        mods.add(new LoadedMod(new net.lapidist.colony.base.BaseHandlersMod(),
+                new net.lapidist.colony.mod.ModMetadata("base-handlers", "1.0.0", java.util.List.of())));
 
         for (LoadedMod mod : mods) {
             mod.mod().init();

--- a/server/src/main/resources/META-INF/services/net.lapidist.colony.mod.GameMod
+++ b/server/src/main/resources/META-INF/services/net.lapidist.colony.mod.GameMod
@@ -1,4 +1,7 @@
-net.lapidist.colony.base.BaseServicesMod
-net.lapidist.colony.base.BaseCommandsMod
+net.lapidist.colony.base.BaseMapServiceMod
+net.lapidist.colony.base.BaseNetworkMod
+net.lapidist.colony.base.BaseAutosaveMod
+net.lapidist.colony.base.BaseResourceProductionMod
+net.lapidist.colony.base.BaseHandlersMod
 
 net.lapidist.colony.base.BaseDefinitionsMod

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerModLoadingTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerModLoadingTest.java
@@ -48,8 +48,11 @@ public class GameServerModLoadingTest {
             java.lang.reflect.Field f = GameServer.class.getDeclaredField("mods");
             f.setAccessible(true);
             List<LoadedMod> loaded = (List<LoadedMod>) f.get(server);
-            assertTrue(loaded.stream().anyMatch(m -> "base-services".equals(m.metadata().id())));
-            assertTrue(loaded.stream().anyMatch(m -> "base-commands".equals(m.metadata().id())));
+            assertTrue(loaded.stream().anyMatch(m -> "base-map-service".equals(m.metadata().id())));
+            assertTrue(loaded.stream().anyMatch(m -> "base-network".equals(m.metadata().id())));
+            assertTrue(loaded.stream().anyMatch(m -> "base-autosave".equals(m.metadata().id())));
+            assertTrue(loaded.stream().anyMatch(m -> "base-resource-production".equals(m.metadata().id())));
+            assertTrue(loaded.stream().anyMatch(m -> "base-handlers".equals(m.metadata().id())));
             assertTrue(loaded.stream().anyMatch(m -> "base-definitions".equals(m.metadata().id())));
             assertTrue(loaded.stream().anyMatch(m -> "stub".equals(m.metadata().id())));
             assertTrue(server.isRunning());


### PR DESCRIPTION
## Summary
- split built-in server mods into individual modules
- register default handlers from `BaseHandlersMod`
- load new base mods when the server starts
- document new mod identifiers
- update mod-loading test for new IDs

## Testing
- `./gradlew spotlessApply`
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684de329d7c88328bab7307501029b4c