### PR TITLE
feat: add item registry

### DIFF
--- a/core/src/main/java/net/lapidist/colony/registry/ItemDefinition.java
+++ b/core/src/main/java/net/lapidist/colony/registry/ItemDefinition.java
@@ -1,0 +1,14 @@
+package net.lapidist.colony.registry;
+
+/**
+ * Metadata describing an item type.
+ *
+ * @param id     unique identifier
+ * @param label  display label
+ * @param asset  rendering asset reference
+ */
+public record ItemDefinition(String id, String label, String asset) {
+    public ItemDefinition() {
+        this(null, null, null);
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/registry/ItemRegistry.java
+++ b/core/src/main/java/net/lapidist/colony/registry/ItemRegistry.java
@@ -1,0 +1,32 @@
+package net.lapidist.colony.registry;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/** Registry for {@link ItemDefinition} instances. */
+public final class ItemRegistry {
+    private final Map<String, ItemDefinition> definitions = new HashMap<>();
+
+    /** Register a new item definition. */
+    public void register(final ItemDefinition def) {
+        if (def == null || def.id() == null) {
+            return;
+        }
+        definitions.put(def.id().toUpperCase(Locale.ROOT), def);
+    }
+
+    /** Lookup an item definition by id. */
+    public ItemDefinition get(final String id) {
+        if (id == null) {
+            return null;
+        }
+        return definitions.get(id.toUpperCase(Locale.ROOT));
+    }
+
+    /** @return all registered definitions. */
+    public Collection<ItemDefinition> all() {
+        return definitions.values();
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/core/registry/ItemRegistryTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/registry/ItemRegistryTest.java
@@ -1,0 +1,44 @@
+package net.lapidist.colony.tests.core.registry;
+
+import net.lapidist.colony.registry.ItemDefinition;
+import net.lapidist.colony.registry.ItemRegistry;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/** Unit tests for {@link ItemRegistry}. */
+public class ItemRegistryTest {
+    private ItemRegistry registry;
+
+    @Before
+    public void setUp() {
+        registry = new ItemRegistry();
+    }
+
+    @Test
+    public void registerStoresDefinitionById() {
+        ItemDefinition def = new ItemDefinition("stick", "Stick", "stick0");
+        registry.register(def);
+
+        assertSame(def, registry.get("stick"));
+        // Case insensitive
+        assertSame(def, registry.get("STICK"));
+    }
+
+    @Test
+    public void ignoresNullDefinitions() {
+        registry.register(null);
+        registry.register(new ItemDefinition());
+        assertNull(registry.get(null));
+        assertTrue(registry.all().isEmpty());
+    }
+
+    @Test
+    public void allReturnsAllRegisteredDefinitions() {
+        registry.register(new ItemDefinition("stick", "Stick", "stick0"));
+        registry.register(new ItemDefinition("stone", "Stone", "stone0"));
+
+        assertEquals(2, registry.all().size());
+    }
+}


### PR DESCRIPTION
## Summary
- add ItemDefinition record
- add ItemRegistry class for registering item definitions
- test ItemRegistry

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684deabe88cc83289a5c743253e4a405