### PR TITLE
feat: add base resource mod

### DIFF
--- a/core/src/main/java/net/lapidist/colony/base/BaseResourcesMod.java
+++ b/core/src/main/java/net/lapidist/colony/base/BaseResourcesMod.java
@@ -1,0 +1,15 @@
+package net.lapidist.colony.base;
+
+import net.lapidist.colony.mod.GameMod;
+import net.lapidist.colony.registry.ResourceDefinition;
+import net.lapidist.colony.registry.Registries;
+
+/** Built-in mod registering default resource definitions. */
+public final class BaseResourcesMod implements GameMod {
+    @Override
+    public void init() {
+        Registries.resources().register(new ResourceDefinition("WOOD", "Wood", "wood0"));
+        Registries.resources().register(new ResourceDefinition("STONE", "Stone", "stone0"));
+        Registries.resources().register(new ResourceDefinition("FOOD", "Food", "food0"));
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/server/GameServer.java
+++ b/server/src/main/java/net/lapidist/colony/server/GameServer.java
@@ -145,6 +145,8 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
         mods = new java.util.ArrayList<>(mods);
         mods.add(new LoadedMod(new net.lapidist.colony.base.BaseDefinitionsMod(),
                 new net.lapidist.colony.mod.ModMetadata("base-definitions", "1.0.0", java.util.List.of())));
+        mods.add(new LoadedMod(new net.lapidist.colony.base.BaseResourcesMod(),
+                new net.lapidist.colony.mod.ModMetadata("base-resources", "1.0.0", java.util.List.of())));
         mods.add(new LoadedMod(new net.lapidist.colony.base.BaseMapServiceMod(),
                 new net.lapidist.colony.mod.ModMetadata("base-map-service", "1.0.0", java.util.List.of())));
         mods.add(new LoadedMod(new net.lapidist.colony.base.BaseNetworkMod(),

--- a/server/src/main/resources/META-INF/services/net.lapidist.colony.mod.GameMod
+++ b/server/src/main/resources/META-INF/services/net.lapidist.colony.mod.GameMod
@@ -5,3 +5,5 @@ net.lapidist.colony.base.BaseResourceProductionMod
 net.lapidist.colony.base.BaseHandlersMod
 
 net.lapidist.colony.base.BaseDefinitionsMod
+
+net.lapidist.colony.base.BaseResourcesMod

--- a/tests/src/test/java/net/lapidist/colony/tests/core/base/BaseResourcesModTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/base/BaseResourcesModTest.java
@@ -1,0 +1,20 @@
+package net.lapidist.colony.tests.core.base;
+
+import net.lapidist.colony.base.BaseResourcesMod;
+import net.lapidist.colony.registry.Registries;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/** Unit tests for {@link BaseResourcesMod}. */
+public class BaseResourcesModTest {
+    @Test
+    public void registersDefaultResources() {
+        BaseResourcesMod mod = new BaseResourcesMod();
+        mod.init();
+
+        assertNotNull(Registries.resources().get("WOOD"));
+        assertNotNull(Registries.resources().get("STONE"));
+        assertNotNull(Registries.resources().get("FOOD"));
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerModLoadingTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerModLoadingTest.java
@@ -53,6 +53,7 @@ public class GameServerModLoadingTest {
             assertTrue(loaded.stream().anyMatch(m -> "base-autosave".equals(m.metadata().id())));
             assertTrue(loaded.stream().anyMatch(m -> "base-resource-production".equals(m.metadata().id())));
             assertTrue(loaded.stream().anyMatch(m -> "base-handlers".equals(m.metadata().id())));
+            assertTrue(loaded.stream().anyMatch(m -> "base-resources".equals(m.metadata().id())));
             assertTrue(loaded.stream().anyMatch(m -> "base-definitions".equals(m.metadata().id())));
             assertTrue(loaded.stream().anyMatch(m -> "stub".equals(m.metadata().id())));
             assertTrue(server.isRunning());


### PR DESCRIPTION
## Summary
- implement `BaseResourcesMod` to register wood, stone and food resources
- integrate new mod with service loader and game server start sequence
- add unit tests verifying resource registration and mod loading

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew codeCoverageReport`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684df7f4a1fc83288d48ab11a5b65ec7