### PR TITLE
feat: consolidate resource data

### DIFF
--- a/core/src/main/java/net/lapidist/colony/components/state/ResourceData.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/ResourceData.java
@@ -2,16 +2,68 @@ package net.lapidist.colony.components.state;
 
 import net.lapidist.colony.serialization.KryoType;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Immutable resource amounts attached to a tile.
- *
- * @param wood  wood amount
- * @param stone stone amount
- * @param food  food amount
  */
 @KryoType
-public record ResourceData(int wood, int stone, int food) {
+public record ResourceData(Map<String, Integer> amounts) {
+
     public ResourceData() {
-        this(0, 0, 0);
+        this(Map.of());
+    }
+
+    public ResourceData(final int wood, final int stone, final int food) {
+        this(Map.of(
+                "WOOD", wood,
+                "STONE", stone,
+                "FOOD", food
+        ));
+    }
+
+    /**
+     * Amount of the specified resource id.
+     *
+     * @param id resource identifier
+     * @return stored amount or {@code 0}
+     */
+    public int amount(final String id) {
+        return amounts.getOrDefault(id, 0);
+    }
+
+    /**
+     * Return a copy of this data with the given amount replaced.
+     *
+     * @param id  resource identifier
+     * @param amt new amount
+     * @return updated immutable instance
+     */
+    public ResourceData with(final String id, final int amt) {
+        Map<String, Integer> map = new HashMap<>(amounts);
+        map.put(id, amt);
+        return new ResourceData(Map.copyOf(map));
+    }
+
+    /**
+     * Convenience accessor for wood.
+     */
+    public int wood() {
+        return amount("WOOD");
+    }
+
+    /**
+     * Convenience accessor for stone.
+     */
+    public int stone() {
+        return amount("STONE");
+    }
+
+    /**
+     * Convenience accessor for food.
+     */
+    public int food() {
+        return amount("FOOD");
     }
 }

--- a/core/src/main/java/net/lapidist/colony/map/ChunkedMapGenerator.java
+++ b/core/src/main/java/net/lapidist/colony/map/ChunkedMapGenerator.java
@@ -8,6 +8,7 @@ import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.components.state.ChunkPos;
 import net.lapidist.colony.i18n.I18n;
 
+import java.util.Map;
 import java.util.Random;
 
 /**
@@ -50,7 +51,11 @@ public final class ChunkedMapGenerator implements MapGenerator {
             for (int y = 0; y < height; y++) {
                 TileData td = state.getTile(x, y);
                 TileData updated = td.toBuilder()
-                        .resources(new ResourceData(DEFAULT_WOOD, DEFAULT_STONE, DEFAULT_FOOD))
+                        .resources(new ResourceData(Map.of(
+                                "WOOD", DEFAULT_WOOD,
+                                "STONE", DEFAULT_STONE,
+                                "FOOD", DEFAULT_FOOD
+                        )))
                         .build();
                 int chunkX = Math.floorDiv(x, MapChunkData.CHUNK_SIZE);
                 int chunkY = Math.floorDiv(y, MapChunkData.CHUNK_SIZE);

--- a/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
@@ -38,6 +38,7 @@ public final class SaveMigrator {
         register(new V22ToV23Migration());
         register(new V23ToV24Migration());
         register(new V24ToV25Migration());
+        register(new V25ToV26Migration());
     }
 
     private SaveMigrator() {

--- a/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
@@ -28,9 +28,10 @@ public enum SaveVersion {
     V22(22),
     V23(23),
     V24(24),
-    V25(25);
+    V25(25),
+    V26(26);
 
-    public static final SaveVersion CURRENT = V25;
+    public static final SaveVersion CURRENT = V26;
 
     private final int number;
 

--- a/core/src/main/java/net/lapidist/colony/save/V25ToV26Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V25ToV26Migration.java
@@ -1,0 +1,21 @@
+package net.lapidist.colony.save;
+
+import net.lapidist.colony.components.state.MapState;
+
+/** Identity migration for save version 25 to 26. */
+public final class V25ToV26Migration implements MapStateMigration {
+    @Override
+    public int fromVersion() {
+        return SaveVersion.V25.number();
+    }
+
+    @Override
+    public int toVersion() {
+        return SaveVersion.V26.number();
+    }
+
+    @Override
+    public MapState apply(final MapState state) {
+        return state.toBuilder().version(toVersion()).build();
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/save/V3ToV4Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V3ToV4Migration.java
@@ -6,6 +6,8 @@ import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.map.MapChunkData;
 
+import java.util.Map;
+
 /** Migration from save version 3 to version 4 adding resource data. */
 public final class V3ToV4Migration implements MapStateMigration {
     private static final int DEFAULT_WOOD = 10;
@@ -29,7 +31,11 @@ public final class V3ToV4Migration implements MapStateMigration {
                 TileData tile = chunk.getTiles().get(pos);
                 if (tile.resources() == null) {
                     TileData updated = tile.toBuilder()
-                            .resources(new ResourceData(DEFAULT_WOOD, DEFAULT_STONE, DEFAULT_FOOD))
+                            .resources(new ResourceData(Map.of(
+                                    "WOOD", DEFAULT_WOOD,
+                                    "STONE", DEFAULT_STONE,
+                                    "FOOD", DEFAULT_FOOD
+                            )))
                             .build();
                     chunk.getTiles().put(pos, updated);
                 }


### PR DESCRIPTION
## Summary
- replace wood, stone, food record fields with map-backed amounts
- add helper accessors to query and update resources
- convert map generator and migrations to build maps
- bump save version and register new migration

## Testing
- `./gradlew spotlessApply`
- `./scripts/check.sh` *(fails: 56 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_684dfe02cb588328b39774b81142be17