### PR TITLE
feat: store tile resources in map

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/entities/factories/TileFactory.java
+++ b/client/src/main/java/net/lapidist/colony/client/entities/factories/TileFactory.java
@@ -36,9 +36,9 @@ public final class TileFactory {
 
         ResourceComponent rc = new ResourceComponent();
         if (resources != null) {
-            rc.setWood(resources.wood());
-            rc.setStone(resources.stone());
-            rc.setFood(resources.food());
+            rc.setAmount("WOOD", resources.wood());
+            rc.setAmount("STONE", resources.stone());
+            rc.setAmount("FOOD", resources.food());
         }
 
         return createEntity(world, tileComponent, rc, coords);

--- a/client/src/main/java/net/lapidist/colony/client/systems/PlayerInitSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/PlayerInitSystem.java
@@ -38,9 +38,9 @@ public final class PlayerInitSystem extends BaseSystem {
         if (!created) {
             Entity player = world.createEntity();
             PlayerResourceComponent pr = new PlayerResourceComponent();
-            pr.setWood(initialResources.wood());
-            pr.setStone(initialResources.stone());
-            pr.setFood(initialResources.food());
+            pr.setAmount("WOOD", initialResources.wood());
+            pr.setAmount("STONE", initialResources.stone());
+            pr.setAmount("FOOD", initialResources.food());
             PlayerComponent pc = new PlayerComponent();
             int width = client != null ? client.getMapWidth()
                     : net.lapidist.colony.components.state.MapState.DEFAULT_WIDTH;

--- a/client/src/main/java/net/lapidist/colony/client/systems/network/ResourceUpdateSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/network/ResourceUpdateSystem.java
@@ -48,21 +48,21 @@ public final class ResourceUpdateSystem extends BaseSystem {
             if (data.x() == -1 && data.y() == -1) {
                 if (player != null) {
                     var pr = playerMapper.get(player);
-                    pr.setWood(data.wood());
-                    pr.setStone(data.stone());
-                    pr.setFood(data.food());
+                    pr.setAmount("WOOD", data.wood());
+                    pr.setAmount("STONE", data.stone());
+                    pr.setAmount("FOOD", data.food());
                 }
                 continue;
             }
             var found = MapUtils.findTile(mapComponent, data.x(), data.y())
                     .map(tile -> {
                         ResourceComponent rc = resourceMapper.get(tile);
-                        int deltaWood = rc.getWood() - data.wood();
-                        int deltaStone = rc.getStone() - data.stone();
-                        int deltaFood = rc.getFood() - data.food();
-                        rc.setWood(data.wood());
-                        rc.setStone(data.stone());
-                        rc.setFood(data.food());
+                        int deltaWood = rc.getAmount("WOOD") - data.wood();
+                        int deltaStone = rc.getAmount("STONE") - data.stone();
+                        int deltaFood = rc.getAmount("FOOD") - data.food();
+                        rc.setAmount("WOOD", data.wood());
+                        rc.setAmount("STONE", data.stone());
+                        rc.setAmount("FOOD", data.food());
                         rc.setDirty(true);
                         int index = mapComponent.getTiles().indexOf(tile, true);
                         var ds = world.getSystem(net.lapidist.colony.client.systems.MapRenderDataSystem.class);
@@ -72,13 +72,13 @@ public final class ResourceUpdateSystem extends BaseSystem {
                         if (player != null) {
                             var pr = playerMapper.get(player);
                             if (deltaWood > 0) {
-                                pr.addWood(deltaWood);
+                                pr.addAmount("WOOD", deltaWood);
                             }
                             if (deltaStone > 0) {
-                                pr.addStone(deltaStone);
+                                pr.addAmount("STONE", deltaStone);
                             }
                             if (deltaFood > 0) {
-                                pr.addFood(deltaFood);
+                                pr.addAmount("FOOD", deltaFood);
                             }
                         }
                         mapComponent.incrementVersion();

--- a/core/src/main/java/net/lapidist/colony/components/resources/PlayerResourceComponent.java
+++ b/core/src/main/java/net/lapidist/colony/components/resources/PlayerResourceComponent.java
@@ -4,43 +4,62 @@ import com.artemis.Component;
 
 /** Stores player resource amounts. */
 public final class PlayerResourceComponent extends Component {
-    private int wood;
-    private int stone;
-    private int food;
+    private final java.util.Map<String, Integer> amounts = new java.util.HashMap<>();
 
     public int getWood() {
-        return wood;
+        return getAmount("WOOD");
     }
 
     public void setWood(final int amount) {
-        this.wood = amount;
+        setAmount("WOOD", amount);
     }
 
     public void addWood(final int amount) {
-        this.wood += amount;
+        addAmount("WOOD", amount);
     }
 
     public int getStone() {
-        return stone;
+        return getAmount("STONE");
     }
 
     public void setStone(final int amount) {
-        this.stone = amount;
+        setAmount("STONE", amount);
     }
 
     public void addStone(final int amount) {
-        this.stone += amount;
+        addAmount("STONE", amount);
     }
 
     public int getFood() {
-        return food;
+        return getAmount("FOOD");
     }
 
     public void setFood(final int amount) {
-        this.food = amount;
+        setAmount("FOOD", amount);
     }
 
     public void addFood(final int amount) {
-        this.food += amount;
+        addAmount("FOOD", amount);
+    }
+
+    public java.util.Map<String, Integer> getAmounts() {
+        return amounts;
+    }
+
+    public void setAmounts(final java.util.Map<String, Integer> newAmounts) {
+        amounts.clear();
+        amounts.putAll(newAmounts);
+    }
+
+    public int getAmount(final String id) {
+        return amounts.getOrDefault(id, 0);
+    }
+
+    public void setAmount(final String id, final int amt) {
+        amounts.put(id, amt);
+    }
+
+    public void addAmount(final String id, final int delta) {
+        amounts.merge(id, delta, Integer::sum);
     }
 }

--- a/core/src/main/java/net/lapidist/colony/components/resources/ResourceComponent.java
+++ b/core/src/main/java/net/lapidist/colony/components/resources/ResourceComponent.java
@@ -6,29 +6,27 @@ import com.artemis.Component;
  * Holds resource amounts available on a tile.
  */
 public final class ResourceComponent extends Component {
-    private int wood;
-    private int stone;
-    private int food;
+    private final java.util.Map<String, Integer> amounts = new java.util.HashMap<>();
     private boolean dirty;
 
     public int getWood() {
-        return wood;
+        return getAmount("WOOD");
     }
 
     public void setWood(final int woodToSet) {
-        this.wood = woodToSet;
+        setAmount("WOOD", woodToSet);
     }
 
     public int getStone() {
-        return stone;
+        return getAmount("STONE");
     }
 
     public void setStone(final int stoneToSet) {
-        this.stone = stoneToSet;
+        setAmount("STONE", stoneToSet);
     }
 
     public int getFood() {
-        return food;
+        return getAmount("FOOD");
     }
 
     public boolean isDirty() {
@@ -40,6 +38,23 @@ public final class ResourceComponent extends Component {
     }
 
     public void setFood(final int foodToSet) {
-        this.food = foodToSet;
+        setAmount("FOOD", foodToSet);
+    }
+
+    public java.util.Map<String, Integer> getAmounts() {
+        return amounts;
+    }
+
+    public void setAmounts(final java.util.Map<String, Integer> newAmounts) {
+        amounts.clear();
+        amounts.putAll(newAmounts);
+    }
+
+    public int getAmount(final String id) {
+        return amounts.getOrDefault(id, 0);
+    }
+
+    public void setAmount(final String id, final int value) {
+        amounts.put(id, value);
     }
 }

--- a/core/src/main/java/net/lapidist/colony/components/state/ResourceData.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/ResourceData.java
@@ -12,15 +12,15 @@ import java.util.Map;
 public record ResourceData(Map<String, Integer> amounts) {
 
     public ResourceData() {
-        this(Map.of());
+        this(new java.util.HashMap<>());
     }
 
     public ResourceData(final int wood, final int stone, final int food) {
-        this(Map.of(
+        this(new java.util.HashMap<>(java.util.Map.of(
                 "WOOD", wood,
                 "STONE", stone,
                 "FOOD", food
-        ));
+        )));
     }
 
     /**
@@ -43,7 +43,7 @@ public record ResourceData(Map<String, Integer> amounts) {
     public ResourceData with(final String id, final int amt) {
         Map<String, Integer> map = new HashMap<>(amounts);
         map.put(id, amt);
-        return new ResourceData(Map.copyOf(map));
+        return new ResourceData(new HashMap<>(map));
     }
 
     /**

--- a/core/src/main/java/net/lapidist/colony/map/MapFactory.java
+++ b/core/src/main/java/net/lapidist/colony/map/MapFactory.java
@@ -62,9 +62,9 @@ public final class MapFactory {
 
                 ResourceComponent rc = new ResourceComponent();
                 if (td.resources() != null) {
-                    rc.setWood(td.resources().wood());
-                    rc.setStone(td.resources().stone());
-                    rc.setFood(td.resources().food());
+                    rc.setAmount("WOOD", td.resources().wood());
+                    rc.setAmount("STONE", td.resources().stone());
+                    rc.setAmount("FOOD", td.resources().food());
                 }
                 tile.edit().add(rc);
 


### PR DESCRIPTION
## Summary
- represent ResourceComponent resources with a map
- update PlayerResourceComponent to use a map of amounts
- adapt tile factory and map factory to write map amounts
- update ResourceUpdateSystem and PlayerInitSystem for the new API
- adjust ResourceData constructors to avoid immutable maps

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test` *(fails: Connected, but timed out during TCP registration)*
- `./gradlew check` *(fails: tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_684e00b274148328aa013230f8d28482