### PR TITLE
feat: update resource messaging

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/network/handlers/ResourceUpdateHandler.java
+++ b/client/src/main/java/net/lapidist/colony/client/network/handlers/ResourceUpdateHandler.java
@@ -41,7 +41,7 @@ public final class ResourceUpdateHandler extends AbstractMessageHandler<Resource
         }
         if (message.x() == -1 && message.y() == -1) {
             MapState updated = state.toBuilder()
-                    .playerResources(new ResourceData(message.wood(), message.stone(), message.food()))
+                    .playerResources(new ResourceData(new java.util.HashMap<>(message.amounts())))
                     .build();
             stateConsumer.accept(updated);
         } else {
@@ -49,7 +49,7 @@ public final class ResourceUpdateHandler extends AbstractMessageHandler<Resource
             TileData tile = state.getTile(pos.x(), pos.y());
             if (tile != null) {
                 TileData newTile = tile.toBuilder()
-                        .resources(new ResourceData(message.wood(), message.stone(), message.food()))
+                        .resources(new ResourceData(new java.util.HashMap<>(message.amounts())))
                         .build();
                 int chunkX = Math.floorDiv(pos.x(), MapChunkData.CHUNK_SIZE);
                 int chunkY = Math.floorDiv(pos.y(), MapChunkData.CHUNK_SIZE);

--- a/client/src/main/java/net/lapidist/colony/client/systems/network/ResourceUpdateSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/network/ResourceUpdateSystem.java
@@ -48,21 +48,21 @@ public final class ResourceUpdateSystem extends BaseSystem {
             if (data.x() == -1 && data.y() == -1) {
                 if (player != null) {
                     var pr = playerMapper.get(player);
-                    pr.setAmount("WOOD", data.wood());
-                    pr.setAmount("STONE", data.stone());
-                    pr.setAmount("FOOD", data.food());
+                    for (var entry : data.amounts().entrySet()) {
+                        pr.setAmount(entry.getKey(), entry.getValue());
+                    }
                 }
                 continue;
             }
             var found = MapUtils.findTile(mapComponent, data.x(), data.y())
                     .map(tile -> {
                         ResourceComponent rc = resourceMapper.get(tile);
-                        int deltaWood = rc.getAmount("WOOD") - data.wood();
-                        int deltaStone = rc.getAmount("STONE") - data.stone();
-                        int deltaFood = rc.getAmount("FOOD") - data.food();
-                        rc.setAmount("WOOD", data.wood());
-                        rc.setAmount("STONE", data.stone());
-                        rc.setAmount("FOOD", data.food());
+                        int deltaWood = rc.getAmount("WOOD") - data.amounts().getOrDefault("WOOD", 0);
+                        int deltaStone = rc.getAmount("STONE") - data.amounts().getOrDefault("STONE", 0);
+                        int deltaFood = rc.getAmount("FOOD") - data.amounts().getOrDefault("FOOD", 0);
+                        for (var entry : data.amounts().entrySet()) {
+                            rc.setAmount(entry.getKey(), entry.getValue());
+                        }
                         rc.setDirty(true);
                         int index = mapComponent.getTiles().indexOf(tile, true);
                         var ds = world.getSystem(net.lapidist.colony.client.systems.MapRenderDataSystem.class);

--- a/core/src/main/java/net/lapidist/colony/components/state/ResourceGatherRequestData.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/ResourceGatherRequestData.java
@@ -7,10 +7,10 @@ import net.lapidist.colony.serialization.KryoType;
  *
  * @param x            tile x coordinate
  * @param y            tile y coordinate
- * @param resourceType type of resource to gather
+ * @param resourceId  identifier of the resource to gather
  */
 @KryoType
-public record ResourceGatherRequestData(int x, int y, String resourceType) {
+public record ResourceGatherRequestData(int x, int y, String resourceId) {
     public ResourceGatherRequestData() {
         this(0, 0, null);
     }

--- a/core/src/main/java/net/lapidist/colony/components/state/ResourceUpdateData.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/ResourceUpdateData.java
@@ -7,9 +7,11 @@ import net.lapidist.colony.serialization.KryoType;
  *
  * @param x     tile x coordinate
  * @param y     tile y coordinate
- * @param wood  wood amount
- * @param stone stone amount
- * @param food  food amount
+ * @param amounts map of resource identifiers to updated amounts
  */
 @KryoType
-public record ResourceUpdateData(int x, int y, int wood, int stone, int food) { }
+public record ResourceUpdateData(int x, int y, java.util.Map<String, Integer> amounts) {
+    public ResourceUpdateData() {
+        this(0, 0, new java.util.HashMap<>());
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/map/ChunkedMapGenerator.java
+++ b/core/src/main/java/net/lapidist/colony/map/ChunkedMapGenerator.java
@@ -51,11 +51,11 @@ public final class ChunkedMapGenerator implements MapGenerator {
             for (int y = 0; y < height; y++) {
                 TileData td = state.getTile(x, y);
                 TileData updated = td.toBuilder()
-                        .resources(new ResourceData(Map.of(
+                        .resources(new ResourceData(new java.util.HashMap<>(Map.of(
                                 "WOOD", DEFAULT_WOOD,
                                 "STONE", DEFAULT_STONE,
                                 "FOOD", DEFAULT_FOOD
-                        )))
+                        ))))
                         .build();
                 int chunkX = Math.floorDiv(x, MapChunkData.CHUNK_SIZE);
                 int chunkY = Math.floorDiv(y, MapChunkData.CHUNK_SIZE);

--- a/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
@@ -39,6 +39,7 @@ public final class SaveMigrator {
         register(new V23ToV24Migration());
         register(new V24ToV25Migration());
         register(new V25ToV26Migration());
+        register(new V26ToV27Migration());
     }
 
     private SaveMigrator() {

--- a/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
@@ -29,9 +29,10 @@ public enum SaveVersion {
     V23(23),
     V24(24),
     V25(25),
-    V26(26);
+    V26(26),
+    V27(27);
 
-    public static final SaveVersion CURRENT = V26;
+    public static final SaveVersion CURRENT = V27;
 
     private final int number;
 

--- a/core/src/main/java/net/lapidist/colony/save/V26ToV27Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V26ToV27Migration.java
@@ -1,0 +1,21 @@
+package net.lapidist.colony.save;
+
+import net.lapidist.colony.components.state.MapState;
+
+/** Identity migration for save version 26 to 27. */
+public final class V26ToV27Migration implements MapStateMigration {
+    @Override
+    public int fromVersion() {
+        return SaveVersion.V26.number();
+    }
+
+    @Override
+    public int toVersion() {
+        return SaveVersion.V27.number();
+    }
+
+    @Override
+    public MapState apply(final MapState state) {
+        return state.toBuilder().version(toVersion()).build();
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/save/V3ToV4Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V3ToV4Migration.java
@@ -31,11 +31,11 @@ public final class V3ToV4Migration implements MapStateMigration {
                 TileData tile = chunk.getTiles().get(pos);
                 if (tile.resources() == null) {
                     TileData updated = tile.toBuilder()
-                            .resources(new ResourceData(Map.of(
+                            .resources(new ResourceData(new java.util.HashMap<>(Map.of(
                                     "WOOD", DEFAULT_WOOD,
                                     "STONE", DEFAULT_STONE,
                                     "FOOD", DEFAULT_FOOD
-                            )))
+                            ))))
                             .build();
                     chunk.getTiles().put(pos, updated);
                 }

--- a/core/src/main/java/net/lapidist/colony/serialization/SerializationRegistrar.java
+++ b/core/src/main/java/net/lapidist/colony/serialization/SerializationRegistrar.java
@@ -43,6 +43,7 @@ public final class SerializationRegistrar {
         kryo.register(java.util.ArrayList.class);
         kryo.register(java.util.List.class);
         kryo.register(java.util.HashMap.class);
+        com.esotericsoftware.kryo.serializers.ImmutableCollectionsSerializers.registerSerializers(kryo);
         kryo.register(java.util.Map.class);
         kryo.register(byte[].class);
     }

--- a/server/src/main/java/net/lapidist/colony/server/commands/BuildCommandHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/BuildCommandHandler.java
@@ -84,7 +84,7 @@ public final class BuildCommandHandler implements CommandHandler<BuildCommand> {
             Events.dispatch(new BuildingPlacedEvent(command.x(), command.y(), type));
             networkService.broadcast(building);
             networkService.broadcast(new ResourceUpdateData(-1, -1,
-                    newResources.wood(), newResources.stone(), newResources.food()));
+                    new java.util.HashMap<>(newResources.amounts())));
         } finally {
             lock.unlock();
         }

--- a/server/src/main/java/net/lapidist/colony/server/commands/GatherCommandHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/GatherCommandHandler.java
@@ -70,9 +70,7 @@ public final class GatherCommandHandler implements CommandHandler<GatherCommand>
             networkService.broadcast(new ResourceUpdateData(
                     pos.x(),
                     pos.y(),
-                    updated.wood(),
-                    updated.stone(),
-                    updated.food()
+                    new java.util.HashMap<>(updated.amounts())
             ));
         } finally {
             lock.unlock();

--- a/server/src/main/java/net/lapidist/colony/server/handlers/ResourceGatherRequestHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/handlers/ResourceGatherRequestHandler.java
@@ -16,6 +16,6 @@ public final class ResourceGatherRequestHandler extends AbstractMessageHandler<R
 
     @Override
     public void handle(final ResourceGatherRequestData data) {
-        commandBus.dispatch(new GatherCommand(data.x(), data.y(), data.resourceType()));
+        commandBus.dispatch(new GatherCommand(data.x(), data.y(), data.resourceId()));
     }
 }

--- a/server/src/main/java/net/lapidist/colony/server/services/ResourceProductionService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/ResourceProductionService.java
@@ -80,9 +80,7 @@ public final class ResourceProductionService {
             networkService.broadcast(new ResourceUpdateData(
                     -1,
                     -1,
-                    updated.wood(),
-                    updated.stone(),
-                    updated.food()
+                    new java.util.HashMap<>(updated.amounts())
             ));
         } finally {
             lock.unlock();

--- a/tests/src/test/java/net/lapidist/colony/tests/network/GameServerBuildBroadcastTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/network/GameServerBuildBroadcastTest.java
@@ -56,7 +56,7 @@ public class GameServerBuildBroadcastTest {
         assertEquals(data.y(), update.y());
         ResourceUpdateData res = clientB.poll(ResourceUpdateData.class);
         assertNotNull(res);
-        assertEquals(0, res.wood());
+        assertEquals(0, res.amounts().getOrDefault("WOOD", 0).intValue());
 
         }
         Thread.sleep(WAIT_MS);
@@ -96,7 +96,7 @@ public class GameServerBuildBroadcastTest {
         assertEquals(data.y(), update.y());
         ResourceUpdateData res = clientB.poll(ResourceUpdateData.class);
         assertNotNull(res);
-        assertEquals(0, res.wood());
+        assertEquals(0, res.amounts().getOrDefault("WOOD", 0).intValue());
 
         }
         Thread.sleep(WAIT_MS);

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV26Test.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV26Test.java
@@ -1,0 +1,41 @@
+package net.lapidist.colony.tests.server;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Output;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.serialization.KryoRegistry;
+import net.lapidist.colony.save.SaveData;
+import net.lapidist.colony.save.SaveVersion;
+import net.lapidist.colony.serialization.SerializationRegistrar;
+import net.lapidist.colony.server.io.GameStateIO;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+
+public class GameStateIOMigrationV26Test {
+
+    @Test
+    public void migratesV26ToCurrent() throws Exception {
+        Path file = Files.createTempFile("state", ".dat");
+        MapState state = MapState.builder()
+                .version(SaveVersion.V26.number())
+                .build();
+        Kryo kryo = new Kryo();
+        KryoRegistry.register(kryo);
+        try (Output output = new Output(Files.newOutputStream(file))) {
+            SaveData data = new SaveData(
+                    SaveVersion.V26.number(),
+                    SerializationRegistrar.registrationHash(),
+                    state
+            );
+            kryo.writeObject(output, data);
+        }
+
+        MapState loaded = GameStateIO.load(file);
+        Files.deleteIfExists(file);
+        assertEquals(SaveVersion.CURRENT.number(), loaded.version());
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/InputSystemResourceTypeTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/InputSystemResourceTypeTest.java
@@ -60,7 +60,7 @@ public class InputSystemResourceTypeTest {
         ArgumentCaptor<ResourceGatherRequestData> captor =
                 ArgumentCaptor.forClass(ResourceGatherRequestData.class);
         verify(client).sendGatherRequest(captor.capture());
-        assertEquals(Registries.resources().get("STONE").id(), captor.getValue().resourceType());
+        assertEquals(Registries.resources().get("STONE").id(), captor.getValue().resourceId());
     }
 
     @Test
@@ -99,6 +99,6 @@ public class InputSystemResourceTypeTest {
         ArgumentCaptor<ResourceGatherRequestData> captor =
                 ArgumentCaptor.forClass(ResourceGatherRequestData.class);
         verify(client).sendGatherRequest(captor.capture());
-        assertEquals(Registries.resources().get("WOOD").id(), captor.getValue().resourceType());
+        assertEquals(Registries.resources().get("WOOD").id(), captor.getValue().resourceId());
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/ResourceUpdateSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/ResourceUpdateSystemTest.java
@@ -49,7 +49,11 @@ public class ResourceUpdateSystemTest {
                 .build());
         world.process();
 
-        client.injectResourceUpdate(new ResourceUpdateData(0, 0, UPDATED_WOOD, 0, 0));
+        client.injectResourceUpdate(new ResourceUpdateData(0, 0, java.util.Map.of(
+                "WOOD", UPDATED_WOOD,
+                "STONE", 0,
+                "FOOD", 0
+        )));
         world.process();
         world.process();
 


### PR DESCRIPTION
## Summary
- add resourceId to ResourceGatherRequestData
- change ResourceUpdateData to hold a map of resources
- register immutable map serializers
- bump save version to V27 with migration
- update handlers and tests for new structures

## Testing
- `./gradlew clean test` *(fails: 1 tests)*

------
https://chatgpt.com/codex/tasks/task_e_684e07cf31008328b1709622535317a7