### PR TITLE
feat: support dynamic resource handling

### DIFF
--- a/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
@@ -40,6 +40,7 @@ public final class SaveMigrator {
         register(new V24ToV25Migration());
         register(new V25ToV26Migration());
         register(new V26ToV27Migration());
+        register(new V27ToV28Migration());
     }
 
     private SaveMigrator() {

--- a/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
@@ -30,9 +30,10 @@ public enum SaveVersion {
     V24(24),
     V25(25),
     V26(26),
-    V27(27);
+    V27(27),
+    V28(28);
 
-    public static final SaveVersion CURRENT = V27;
+    public static final SaveVersion CURRENT = V28;
 
     private final int number;
 

--- a/core/src/main/java/net/lapidist/colony/save/V27ToV28Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V27ToV28Migration.java
@@ -1,0 +1,21 @@
+package net.lapidist.colony.save;
+
+import net.lapidist.colony.components.state.MapState;
+
+/** Identity migration for save version 27 to 28. */
+public final class V27ToV28Migration implements MapStateMigration {
+    @Override
+    public int fromVersion() {
+        return SaveVersion.V27.number();
+    }
+
+    @Override
+    public int toVersion() {
+        return SaveVersion.V28.number();
+    }
+
+    @Override
+    public MapState apply(final MapState state) {
+        return state.toBuilder().version(toVersion()).build();
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/server/commands/GatherCommand.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/GatherCommand.java
@@ -6,7 +6,7 @@ package net.lapidist.colony.server.commands;
  *
  * @param x            tile x coordinate
  * @param y            tile y coordinate
- * @param resourceType type of resource to gather
+ * @param resourceId  identifier of the resource to gather
  */
-public record GatherCommand(int x, int y, String resourceType) implements ServerCommand {
+public record GatherCommand(int x, int y, String resourceId) implements ServerCommand {
 }

--- a/server/src/main/java/net/lapidist/colony/server/services/ResourceProductionService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/ResourceProductionService.java
@@ -68,11 +68,9 @@ public final class ResourceProductionService {
                 return;
             }
             ResourceData player = state.playerResources();
-            ResourceData updated = new ResourceData(
-                    player.wood(),
-                    player.stone(),
-                    player.food() + (int) farms
-            );
+            java.util.Map<String, Integer> amounts = new java.util.HashMap<>(player.amounts());
+            amounts.merge("FOOD", (int) farms, Integer::sum);
+            ResourceData updated = new ResourceData(new java.util.HashMap<>(amounts));
             MapState newState = state.toBuilder()
                     .playerResources(updated)
                     .build();

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV27Test.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV27Test.java
@@ -1,0 +1,41 @@
+package net.lapidist.colony.tests.server;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Output;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.serialization.KryoRegistry;
+import net.lapidist.colony.save.SaveData;
+import net.lapidist.colony.save.SaveVersion;
+import net.lapidist.colony.serialization.SerializationRegistrar;
+import net.lapidist.colony.server.io.GameStateIO;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+
+public class GameStateIOMigrationV27Test {
+
+    @Test
+    public void migratesV27ToCurrent() throws Exception {
+        Path file = Files.createTempFile("state", ".dat");
+        MapState state = MapState.builder()
+                .version(SaveVersion.V27.number())
+                .build();
+        Kryo kryo = new Kryo();
+        KryoRegistry.register(kryo);
+        try (Output output = new Output(Files.newOutputStream(file))) {
+            SaveData data = new SaveData(
+                    SaveVersion.V27.number(),
+                    SerializationRegistrar.registrationHash(),
+                    state
+            );
+            kryo.writeObject(output, data);
+        }
+
+        MapState loaded = GameStateIO.load(file);
+        Files.deleteIfExists(file);
+        assertEquals(SaveVersion.CURRENT.number(), loaded.version());
+    }
+}


### PR DESCRIPTION
## Summary
- add resourceId field to GatherCommand
- update handlers and production service for map-based resources
- store build costs in ResourceData maps
- bump save version and provide migration
- test migrating from save version 27

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684e0dc548ac83289f40628953750efd