### PR TITLE
feat(core): add item registry and base mod

### DIFF
--- a/core/src/main/java/net/lapidist/colony/base/BaseItemsMod.java
+++ b/core/src/main/java/net/lapidist/colony/base/BaseItemsMod.java
@@ -1,0 +1,14 @@
+package net.lapidist.colony.base;
+
+import net.lapidist.colony.mod.GameMod;
+import net.lapidist.colony.registry.ItemDefinition;
+import net.lapidist.colony.registry.Registries;
+
+/** Built-in mod registering default item definitions. */
+public final class BaseItemsMod implements GameMod {
+    @Override
+    public void init() {
+        Registries.items().register(new ItemDefinition("stick", "Stick", "stick0"));
+        Registries.items().register(new ItemDefinition("stone", "Stone", "stone0"));
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/registry/Registries.java
+++ b/core/src/main/java/net/lapidist/colony/registry/Registries.java
@@ -5,6 +5,7 @@ public final class Registries {
     private static final TileRegistry TILE_REGISTRY = new TileRegistry();
     private static final BuildingRegistry BUILDING_REGISTRY = new BuildingRegistry();
     private static final ResourceRegistry RESOURCE_REGISTRY = new ResourceRegistry();
+    private static final ItemRegistry ITEM_REGISTRY = new ItemRegistry();
 
     private Registries() { }
 
@@ -21,5 +22,10 @@ public final class Registries {
     /** @return resource type registry */
     public static ResourceRegistry resources() {
         return RESOURCE_REGISTRY;
+    }
+
+    /** @return item type registry */
+    public static ItemRegistry items() {
+        return ITEM_REGISTRY;
     }
 }

--- a/docs/mods.md
+++ b/docs/mods.md
@@ -91,14 +91,15 @@ public final class ExtraMod implements GameMod {
 
 ## Registries
 
-Core data like tile, building and resource types are stored in simple string keyed registries. Mods can
+Core data like tile, building, resource and item types are stored in simple string keyed registries. Mods can
 register new entries during the `init()` phase:
 
 ```java
 public final class WaterTiles implements GameMod {
     @Override
     public void init() {
-        Registries.tileTypes().register("WATER");
+        Registries.tiles().register(new TileDefinition("WATER", "Water", "water0"));
+        Registries.items().register(new ItemDefinition("bucket", "Bucket", "bucket0"));
     }
 }
 ```
@@ -136,7 +137,7 @@ registers a `WATER` tile type and prints a message whenever the player selects o
 public final class WaterMod implements GameMod {
     @Override
     public void init() {
-        Registries.tileTypes().register("WATER");
+        Registries.tiles().register(new TileDefinition("WATER", "Water", "water0"));
     }
 }
 ```

--- a/server/src/main/resources/META-INF/services/net.lapidist.colony.mod.GameMod
+++ b/server/src/main/resources/META-INF/services/net.lapidist.colony.mod.GameMod
@@ -7,3 +7,4 @@ net.lapidist.colony.base.BaseHandlersMod
 net.lapidist.colony.base.BaseDefinitionsMod
 
 net.lapidist.colony.base.BaseResourcesMod
+net.lapidist.colony.base.BaseItemsMod

--- a/tests/src/test/java/net/lapidist/colony/tests/core/base/BaseItemsModTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/base/BaseItemsModTest.java
@@ -1,0 +1,19 @@
+package net.lapidist.colony.tests.core.base;
+
+import net.lapidist.colony.base.BaseItemsMod;
+import net.lapidist.colony.registry.Registries;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/** Unit tests for {@link BaseItemsMod}. */
+public class BaseItemsModTest {
+    @Test
+    public void registersDefaultItems() {
+        BaseItemsMod mod = new BaseItemsMod();
+        mod.init();
+
+        assertNotNull(Registries.items().get("stick"));
+        assertNotNull(Registries.items().get("stone"));
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/core/registry/RegistryTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/registry/RegistryTest.java
@@ -32,5 +32,6 @@ public class RegistryTest {
     public void globalAccessorsReturnSingletons() {
         assertSame(Registries.tiles(), Registries.tiles());
         assertSame(Registries.buildings(), Registries.buildings());
+        assertSame(Registries.items(), Registries.items());
     }
 }


### PR DESCRIPTION
## Summary
- expose Registries.items()
- register default items via new BaseItemsMod
- load BaseItemsMod in server
- add BaseItemsMod tests and extend RegistryTest
- document item registry in mods guide

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684e1488bdc88328bdf6dbada5535eda