### PR TITLE
feat(server): allow mod systems

### DIFF
--- a/core/src/main/java/net/lapidist/colony/mod/GameMod.java
+++ b/core/src/main/java/net/lapidist/colony/mod/GameMod.java
@@ -38,4 +38,16 @@ public interface GameMod {
      */
     default void registerHandlers(CommandBus bus) {
     }
+
+    /**
+     * Register additional runnable systems with the server.
+     *
+     * <p>Invoked during startup after core services are created but before they
+     * begin execution. Mods may use this hook to schedule periodic tasks or
+     * other background work.</p>
+     *
+     * @param server active server instance
+     */
+    default void registerSystems(GameServer server) {
+    }
 }

--- a/server/src/main/java/net/lapidist/colony/base/BaseResourceProductionMod.java
+++ b/server/src/main/java/net/lapidist/colony/base/BaseResourceProductionMod.java
@@ -10,4 +10,10 @@ public final class BaseResourceProductionMod implements GameMod {
         net.lapidist.colony.server.GameServer s = (net.lapidist.colony.server.GameServer) srv;
         s.setResourceProductionServiceFactory(s.getResourceProductionServiceFactory());
     }
+
+    @Override
+    public void registerSystems(final GameServer srv) {
+        net.lapidist.colony.server.GameServer s = (net.lapidist.colony.server.GameServer) srv;
+        s.registerSystem(s.getResourceProductionService());
+    }
 }

--- a/server/src/main/java/net/lapidist/colony/server/GameSystem.java
+++ b/server/src/main/java/net/lapidist/colony/server/GameSystem.java
@@ -1,0 +1,9 @@
+package net.lapidist.colony.server;
+
+/** Simple lifecycle for server side runnable systems. */
+public interface GameSystem {
+    /** Start the system. */
+    void start();
+    /** Stop the system. */
+    void stop();
+}

--- a/server/src/main/java/net/lapidist/colony/server/services/ResourceProductionService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/ResourceProductionService.java
@@ -15,7 +15,7 @@ import java.util.concurrent.locks.ReentrantLock;
 /**
  * Periodically increases player food based on existing farms.
  */
-public final class ResourceProductionService {
+public final class ResourceProductionService implements net.lapidist.colony.server.GameSystem {
 
     private final long interval;
     private final Supplier<MapState> supplier;

--- a/tests/src/test/java/net/lapidist/colony/mod/test/MapTickerMod.java
+++ b/tests/src/test/java/net/lapidist/colony/mod/test/MapTickerMod.java
@@ -1,0 +1,55 @@
+package net.lapidist.colony.mod.test;
+
+import net.lapidist.colony.mod.GameMod;
+import net.lapidist.colony.mod.GameServer;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.server.GameSystem;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** Mod supplying a system that updates map description each tick. */
+public final class MapTickerMod implements GameMod {
+    public static final AtomicInteger TICKS = new AtomicInteger();
+
+    @Override
+    public void registerSystems(final GameServer srv) {
+        net.lapidist.colony.server.GameServer s = (net.lapidist.colony.server.GameServer) srv;
+        s.registerSystem(new DescriptionTickSystem(s));
+    }
+
+    private static final class DescriptionTickSystem implements GameSystem {
+        private final net.lapidist.colony.server.GameServer server;
+        private ScheduledExecutorService executor;
+
+        DescriptionTickSystem(final net.lapidist.colony.server.GameServer server) {
+            this.server = server;
+        }
+
+        @Override
+        public void start() {
+            executor = Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r);
+                t.setDaemon(true);
+                return t;
+            });
+            executor.scheduleAtFixedRate(this::tick, 10, 10, TimeUnit.MILLISECONDS);
+        }
+
+        @Override
+        public void stop() {
+            if (executor != null) {
+                executor.shutdownNow();
+            }
+        }
+
+        private void tick() {
+            MapState state = server.getMapState();
+            server.setMapState(state.toBuilder()
+                    .description("tick" + TICKS.incrementAndGet())
+                    .build());
+        }
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/mod/test/ResourceStubMod.java
+++ b/tests/src/test/java/net/lapidist/colony/mod/test/ResourceStubMod.java
@@ -27,4 +27,9 @@ public final class ResourceStubMod implements GameMod {
         ((net.lapidist.colony.server.GameServer) server)
                 .setResourceProductionServiceFactory(() -> service);
     }
+
+    @Override
+    public void registerSystems(final GameServer server) {
+        ((net.lapidist.colony.server.GameServer) server).registerSystem(service);
+    }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationCustomSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationCustomSystemTest.java
@@ -1,0 +1,43 @@
+package net.lapidist.colony.tests.scenario;
+
+import net.lapidist.colony.mod.ModLoader;
+import net.lapidist.colony.mod.ModLoader.LoadedMod;
+import net.lapidist.colony.mod.ModMetadata;
+import net.lapidist.colony.mod.test.MapTickerMod;
+import net.lapidist.colony.server.GameServer;
+import net.lapidist.colony.server.GameServerConfig;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedConstruction;
+
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
+
+/** Scenario ensuring a mod can register a custom system. */
+@RunWith(GdxTestRunner.class)
+public class GameSimulationCustomSystemTest {
+
+    @Test
+    public void modUpdatesMapStateEachTick() throws Exception {
+        GameServerConfig config = GameServerConfig.builder()
+                .saveName("scenario-custom-system")
+                .autosaveInterval(20)
+                .build();
+        net.lapidist.colony.io.Paths.get().deleteAutosave("scenario-custom-system");
+        MapTickerMod.TICKS.set(0);
+        try (MockedConstruction<ModLoader> loader = mockConstruction(ModLoader.class,
+                (m, c) -> when(m.loadMods()).thenReturn(List.of(
+                        new LoadedMod(new MapTickerMod(), new ModMetadata("tick", "1", List.of())))));
+             GameServer server = new GameServer(config)) {
+            server.start();
+            Thread.sleep(60);
+
+            assertTrue(MapTickerMod.TICKS.get() > 0);
+            assertTrue(server.getMapState().description().startsWith("tick"));
+        }
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerCoverageTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerCoverageTest.java
@@ -99,7 +99,9 @@ public class GameServerCoverageTest {
         GameServer server = new GameServer(GameServerConfig.builder().saveName("mods").build());
         field("networkService").set(server, mock(NetworkService.class));
         field("autosaveService").set(server, mock(AutosaveService.class));
-        field("resourceProductionService").set(server, mock(ResourceProductionService.class));
+        ResourceProductionService prod = mock(ResourceProductionService.class);
+        field("resourceProductionService").set(server, prod);
+        server.registerSystem(prod);
         class DummyMod implements GameMod {
             private boolean disposed;
 


### PR DESCRIPTION
## Summary
- expose registerSystems hook in `GameMod`
- add `GameSystem` interface for server runnables
- keep a system list in `GameServer`
- run mod systems via `BaseResourceProductionMod`
- update stub and coverage tests
- add scenario test demonstrating custom server system

## Testing
- `./gradlew spotlessApply`
- `./gradlew tests:copyAssets`
- `./gradlew clean test` *(fails: OutOfMemoryError in HeadlessApplication)*
- `./gradlew check` *(terminated due to long output)*

------
https://chatgpt.com/codex/tasks/task_e_684e148c0ea483288a4a88fdf4b89a2b