### PR TITLE
feat: add mod scripting support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
         slf4jVersion = '2.0.17'
         logbackVersion = '1.5.18'
         typesafeConfigVersion = '1.4.3'
+        kotlinVersion = '1.9.24'
     }
 
     repositories {
@@ -22,6 +23,7 @@ buildscript {
 plugins {
     id 'jacoco'
     id 'com.diffplug.spotless' version '7.0.4' apply false
+    id 'org.jetbrains.kotlin.jvm' version '1.9.24' apply false
 }
 
 
@@ -77,6 +79,11 @@ allprojects {
             target 'src/**/*.java'
             leadingTabsToSpaces(4)
             trimTrailingWhitespace()
+            endWithNewline()
+        }
+        kotlin {
+            target 'src/**/*.kt'
+            ktlint()
             endWithNewline()
         }
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java-library'
+apply plugin: 'org.jetbrains.kotlin.jvm'
 
 dependencies {
     implementation "com.badlogicgames.gdx:gdx:$gdxVersion"
@@ -6,7 +7,13 @@ dependencies {
     api "com.typesafe:config:$typesafeConfigVersion"
     implementation 'com.esotericsoftware:kryo:5.6.2'
     compileOnly 'com.esotericsoftware:kryonet:2.22.0-RC1'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-scripting-jsr223:$kotlinVersion"
 }
 
 
 eclipse.project.name = "$appName-core"
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    kotlinOptions.jvmTarget = '21'
+}

--- a/core/src/main/kotlin/ScriptDSL.kt
+++ b/core/src/main/kotlin/ScriptDSL.kt
@@ -1,0 +1,14 @@
+import net.lapidist.colony.events.Events
+import net.mostlyoriginal.api.event.common.Event
+import net.mostlyoriginal.api.event.common.Subscribe
+
+inline fun <reified T : Event> on(noinline handler: (T) -> Unit) {
+    Events.getInstance().registerEvents(
+        object {
+            @Subscribe
+            fun handle(event: T) {
+                handler(event)
+            }
+        },
+    )
+}

--- a/docs/mods.md
+++ b/docs/mods.md
@@ -114,8 +114,9 @@ registration hooks run between these stages during server startup.
 
 ## Scripting
 
-Mods may ship Kotlin scripts inside a `scripts/` folder. Each script runs on load and can listen for events
-using a small DSL. The following script prints a message whenever a tile is selected:
+Mods may ship Kotlin scripts inside a `scripts/` folder. When a mod is loaded the loader executes every
+`*.kts` file found and the script may register event listeners using the `on` DSL function. The following
+script prints a message whenever a tile is selected:
 
 ```kotlin
 // scripts/tileSelect.kts

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerScriptTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerScriptTest.java
@@ -1,0 +1,81 @@
+package net.lapidist.colony.tests.server;
+
+import net.lapidist.colony.io.Paths;
+import net.lapidist.colony.io.TestPathService;
+import net.lapidist.colony.mod.test.StubMod;
+import net.lapidist.colony.server.GameServer;
+import net.lapidist.colony.server.GameServerConfig;
+import net.lapidist.colony.server.commands.CommandBus;
+import net.lapidist.colony.server.commands.TileSelectionCommand;
+import net.lapidist.colony.events.Events;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+
+public class GameServerScriptTest {
+
+    private static final String META_FILE = "META-INF/services/net.lapidist.colony.mod.GameMod";
+
+    @Test
+    public void scriptRespondsToEvent() throws Exception {
+        System.clearProperty("script.received");
+        Path base = Files.createTempDirectory("script-mod-test");
+        Paths paths = new Paths(new TestPathService(base));
+        Path mods = paths.getModsFolder();
+        Files.createDirectories(mods);
+        Path dir = mods.resolve("scriptmod");
+        createScriptMod(dir);
+
+        try (MockedStatic<Paths> mock = Mockito.mockStatic(Paths.class)) {
+            mock.when(Paths::get).thenReturn(paths);
+            GameServerConfig config = GameServerConfig.builder()
+                    .saveName("script-mod")
+                    .build();
+            GameServer server = new GameServer(config);
+            server.start();
+
+            java.lang.reflect.Field f = GameServer.class.getDeclaredField("commandBus");
+            f.setAccessible(true);
+            CommandBus bus = (CommandBus) f.get(server);
+            bus.dispatch(new TileSelectionCommand(0, 0, true));
+            Events.update();
+
+            server.stop();
+        }
+        assertEquals("true", System.getProperty("script.received"));
+    }
+
+    private void createScriptMod(final Path dir) throws IOException {
+        Files.createDirectories(dir.resolve("META-INF/services"));
+        Files.createDirectories(dir.resolve("scripts"));
+        Files.writeString(dir.resolve("mod.json"), "{ id: \"scriptmod\", version: \"1\", dependencies: [] }");
+        Path service = dir.resolve(META_FILE);
+        try (BufferedWriter w = Files.newBufferedWriter(service, StandardCharsets.UTF_8)) {
+            w.write(StubMod.class.getName());
+        }
+        Path classFile = classFile();
+        Path dest = dir.resolve(StubMod.class.getName().replace('.', '/') + ".class");
+        Files.createDirectories(dest.getParent());
+        Files.copy(classFile, dest, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        Path script = dir.resolve("scripts/listener.kts");
+        Files.writeString(script, String.join(System.lineSeparator(),
+                "import net.lapidist.colony.server.events.TileSelectionEvent",
+                "on<TileSelectionEvent> {",
+                "    System.setProperty(\"script.received\", \"true\")",
+                "}"
+        ));
+    }
+
+    private Path classFile() throws IOException {
+        return Path.of(StubMod.class.getProtectionDomain().getCodeSource().getLocation().getPath())
+                .resolve(StubMod.class.getName().replace('.', '/') + ".class");
+    }
+}


### PR DESCRIPTION
## Summary
- enable Kotlin scripts in mods
- add DSL for event-based scripts
- test script reacting to TileSelectionEvent
- document scripting support

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test` *(fails: GameServerPlayerResourceSaveTest and others OutOfMemoryError)*
- `./gradlew check -x test` *(fails: checkstyle violations)*

------
https://chatgpt.com/codex/tasks/task_e_684e66d2521883288010b32c85ebac18