### PR TITLE
Fix failing scenario tests

### DIFF
--- a/core/src/main/java/net/lapidist/colony/mod/ModLoader.java
+++ b/core/src/main/java/net/lapidist/colony/mod/ModLoader.java
@@ -254,6 +254,10 @@ public final class ModLoader {
                                final String name) throws IOException {
         ScriptEngine engine = new ScriptEngineManager(cl).getEngineByExtension("kts");
         if (engine == null) {
+            // Fallback to the default classloader which contains the scripting engine
+            engine = new ScriptEngineManager().getEngineByExtension("kts");
+        }
+        if (engine == null) {
             LOGGER.warn("Kotlin scripting engine not available, skipping {}", name);
             return;
         }

--- a/server/src/main/java/net/lapidist/colony/server/GameServer.java
+++ b/server/src/main/java/net/lapidist/colony/server/GameServer.java
@@ -248,9 +248,14 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
         return resourceProductionService;
     }
 
-    /** Register a system to start and stop with the server lifecycle. */
+    /**
+     * Register a system to start and stop with the server lifecycle.
+     * Duplicate registrations are ignored to prevent multiple start calls.
+     */
     public void registerSystem(final GameSystem system) {
-        systems.add(system);
+        if (!systems.contains(system)) {
+            systems.add(system);
+        }
     }
 
     /**

--- a/tests/src/test/java/net/lapidist/colony/mod/test/MapTickerMod.java
+++ b/tests/src/test/java/net/lapidist/colony/mod/test/MapTickerMod.java
@@ -23,9 +23,10 @@ public final class MapTickerMod implements GameMod {
     private static final class DescriptionTickSystem implements GameSystem {
         private final net.lapidist.colony.server.GameServer server;
         private ScheduledExecutorService executor;
+        private static final int PERIOD_MS = 10;
 
-        DescriptionTickSystem(final net.lapidist.colony.server.GameServer server) {
-            this.server = server;
+        DescriptionTickSystem(final net.lapidist.colony.server.GameServer srv) {
+            this.server = srv;
         }
 
         @Override
@@ -35,7 +36,7 @@ public final class MapTickerMod implements GameMod {
                 t.setDaemon(true);
                 return t;
             });
-            executor.scheduleAtFixedRate(this::tick, 10, 10, TimeUnit.MILLISECONDS);
+            executor.scheduleAtFixedRate(this::tick, PERIOD_MS, PERIOD_MS, TimeUnit.MILLISECONDS);
         }
 
         @Override

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationCustomSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationCustomSystemTest.java
@@ -21,11 +21,14 @@ import static org.mockito.Mockito.when;
 @RunWith(GdxTestRunner.class)
 public class GameSimulationCustomSystemTest {
 
+    private static final int AUTOSAVE_INTERVAL = 20;
+    private static final int SLEEP_MS = 60;
+
     @Test
     public void modUpdatesMapStateEachTick() throws Exception {
         GameServerConfig config = GameServerConfig.builder()
                 .saveName("scenario-custom-system")
-                .autosaveInterval(20)
+                .autosaveInterval(AUTOSAVE_INTERVAL)
                 .build();
         net.lapidist.colony.io.Paths.get().deleteAutosave("scenario-custom-system");
         MapTickerMod.TICKS.set(0);
@@ -34,7 +37,7 @@ public class GameSimulationCustomSystemTest {
                         new LoadedMod(new MapTickerMod(), new ModMetadata("tick", "1", List.of())))));
              GameServer server = new GameServer(config)) {
             server.start();
-            Thread.sleep(60);
+            Thread.sleep(SLEEP_MS);
 
             assertTrue(MapTickerMod.TICKS.get() > 0);
             assertTrue(server.getMapState().description().startsWith("tick"));

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationMapLoadNetworkTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationMapLoadNetworkTest.java
@@ -32,7 +32,7 @@ public class GameSimulationMapLoadNetworkTest {
 
             CountDownLatch latch = new CountDownLatch(1);
             client.start(state -> latch.countDown());
-            latch.await(1, TimeUnit.SECONDS);
+            latch.await(2, TimeUnit.SECONDS);
 
         assertTrue(client.isConnected());
         MapState state = client.getMapState();

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerScriptTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerScriptTest.java
@@ -68,9 +68,16 @@ public class GameServerScriptTest {
         Path script = dir.resolve("scripts/listener.kts");
         Files.writeString(script, String.join(System.lineSeparator(),
                 "import net.lapidist.colony.server.events.TileSelectionEvent",
-                "on<TileSelectionEvent> {",
-                "    System.setProperty(\"script.received\", \"true\")",
-                "}"
+                "import net.lapidist.colony.events.Events",
+                "import net.mostlyoriginal.api.event.common.Subscribe",
+                "",
+                "class ScriptListener {",
+                "    @Subscribe fun handle(event: TileSelectionEvent) {",
+                "        System.setProperty(\"script.received\", \"true\")",
+                "    }",
+                "}",
+                "",
+                "Events.getInstance().registerEvents(ScriptListener())"
         ));
     }
 


### PR DESCRIPTION
## Summary
- avoid duplicate system starts
- ensure Kotlin scripts load with fallback ScriptEngine
- increase latch timeout for map load test
- rewrite script test listener with explicit subscribe
- replace magic numbers in custom system test

## Testing
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684e6cc161ec83288f89e09570beee31