### PR TITLE
feat(server): modularize default services

### DIFF
--- a/server/src/main/java/net/lapidist/colony/base/BaseAutosaveMod.java
+++ b/server/src/main/java/net/lapidist/colony/base/BaseAutosaveMod.java
@@ -2,12 +2,18 @@ package net.lapidist.colony.base;
 
 import net.lapidist.colony.mod.GameMod;
 import net.lapidist.colony.mod.GameServer;
+import net.lapidist.colony.server.services.AutosaveService;
 
 /** Built-in mod providing the default AutosaveService factory. */
 public final class BaseAutosaveMod implements GameMod {
     @Override
     public void registerServices(final GameServer srv) {
         net.lapidist.colony.server.GameServer s = (net.lapidist.colony.server.GameServer) srv;
-        s.setAutosaveServiceFactory(s.getAutosaveServiceFactory());
+        s.setAutosaveServiceFactory(() -> new AutosaveService(
+                s.getAutosaveInterval(),
+                s.getSaveName(),
+                s::getMapState,
+                s.getStateLock()
+        ));
     }
 }

--- a/server/src/main/java/net/lapidist/colony/base/BaseCommandBusMod.java
+++ b/server/src/main/java/net/lapidist/colony/base/BaseCommandBusMod.java
@@ -2,12 +2,13 @@ package net.lapidist.colony.base;
 
 import net.lapidist.colony.mod.GameMod;
 import net.lapidist.colony.mod.GameServer;
+import net.lapidist.colony.server.commands.CommandBus;
 
 /** Built-in mod providing the default CommandBus factory. */
 public final class BaseCommandBusMod implements GameMod {
     @Override
     public void registerServices(final GameServer srv) {
         net.lapidist.colony.server.GameServer s = (net.lapidist.colony.server.GameServer) srv;
-        s.setCommandBusFactory(s.getCommandBusFactory());
+        s.setCommandBusFactory(CommandBus::new);
     }
 }

--- a/server/src/main/java/net/lapidist/colony/base/BaseMapServiceMod.java
+++ b/server/src/main/java/net/lapidist/colony/base/BaseMapServiceMod.java
@@ -2,12 +2,19 @@ package net.lapidist.colony.base;
 
 import net.lapidist.colony.mod.GameMod;
 import net.lapidist.colony.mod.GameServer;
+import net.lapidist.colony.server.services.MapService;
 
 /** Built-in mod providing the default MapService factory. */
 public final class BaseMapServiceMod implements GameMod {
     @Override
     public void registerServices(final GameServer srv) {
         net.lapidist.colony.server.GameServer s = (net.lapidist.colony.server.GameServer) srv;
-        s.setMapServiceFactory(s.getMapServiceFactory());
+        s.setMapServiceFactory(() -> new MapService(
+                s.getMapGenerator(),
+                s.getSaveName(),
+                s.getMapWidth(),
+                s.getMapHeight(),
+                s.getStateLock()
+        ));
     }
 }

--- a/server/src/main/java/net/lapidist/colony/base/BaseNetworkMod.java
+++ b/server/src/main/java/net/lapidist/colony/base/BaseNetworkMod.java
@@ -2,12 +2,18 @@ package net.lapidist.colony.base;
 
 import net.lapidist.colony.mod.GameMod;
 import net.lapidist.colony.mod.GameServer;
+import net.lapidist.colony.config.NetworkConfig;
+import net.lapidist.colony.server.services.NetworkService;
 
 /** Built-in mod providing the default NetworkService factory. */
 public final class BaseNetworkMod implements GameMod {
     @Override
     public void registerServices(final GameServer srv) {
         net.lapidist.colony.server.GameServer s = (net.lapidist.colony.server.GameServer) srv;
-        s.setNetworkServiceFactory(s.getNetworkServiceFactory());
+        s.setNetworkServiceFactory(() -> new NetworkService(
+                s.getServer(),
+                NetworkConfig.getTcpPort(),
+                NetworkConfig.getUdpPort()
+        ));
     }
 }

--- a/server/src/main/java/net/lapidist/colony/base/BaseResourceProductionMod.java
+++ b/server/src/main/java/net/lapidist/colony/base/BaseResourceProductionMod.java
@@ -2,13 +2,20 @@ package net.lapidist.colony.base;
 
 import net.lapidist.colony.mod.GameMod;
 import net.lapidist.colony.mod.GameServer;
+import net.lapidist.colony.server.services.ResourceProductionService;
 
 /** Built-in mod providing the default ResourceProductionService factory. */
 public final class BaseResourceProductionMod implements GameMod {
     @Override
     public void registerServices(final GameServer srv) {
         net.lapidist.colony.server.GameServer s = (net.lapidist.colony.server.GameServer) srv;
-        s.setResourceProductionServiceFactory(s.getResourceProductionServiceFactory());
+        s.setResourceProductionServiceFactory(() -> new ResourceProductionService(
+                s.getAutosaveInterval(),
+                s::getMapState,
+                s::setMapState,
+                s.getNetworkService(),
+                s.getStateLock()
+        ));
     }
 
     @Override

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerBaseModsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerBaseModsTest.java
@@ -1,0 +1,53 @@
+package net.lapidist.colony.tests.server;
+
+import net.lapidist.colony.components.state.TileSelectionData;
+import net.lapidist.colony.network.AbstractMessageEndpoint;
+import net.lapidist.colony.server.GameServer;
+import net.lapidist.colony.server.GameServerConfig;
+import net.lapidist.colony.server.commands.CommandBus;
+import net.lapidist.colony.server.commands.TileSelectionCommand;
+import net.lapidist.colony.io.Paths;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/** Tests that built-in mods register services and handlers automatically. */
+public class GameServerBaseModsTest {
+
+    private static <T> T field(final Object obj, final String name) throws Exception {
+        Field f = GameServer.class.getDeclaredField(name);
+        f.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        T value = (T) f.get(obj);
+        return value;
+    }
+
+    @Test
+    public void servicesAndHandlersRegistered() throws Exception {
+        String name = "base-mods";
+        Paths.get().deleteAutosave(name);
+        GameServer server = new GameServer(GameServerConfig.builder().saveName(name).build());
+        server.start();
+
+        assertNotNull(field(server, "mapService"));
+        assertNotNull(field(server, "networkService"));
+        assertNotNull(field(server, "autosaveService"));
+        assertNotNull(field(server, "resourceProductionService"));
+        CommandBus bus = field(server, "commandBus");
+        assertNotNull(bus);
+
+        Method dispatch = AbstractMessageEndpoint.class.getDeclaredMethod("dispatch", Object.class);
+        dispatch.setAccessible(true);
+        dispatch.invoke(server, new TileSelectionData(0, 0, true));
+        assertTrue(server.getMapState().getTile(0, 0).selected());
+
+        bus.dispatch(new TileSelectionCommand(1, 1, true));
+        assertTrue(server.getMapState().getTile(1, 1).selected());
+
+        server.stop();
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerCoverageTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerCoverageTest.java
@@ -87,6 +87,7 @@ public class GameServerCoverageTest {
         field("mapState").set(server, new MapState());
         NetworkService network = mock(NetworkService.class);
         field("networkService").set(server, network);
+        field("commandBus").set(server, new CommandBus());
 
         server.registerDefaultHandlers();
         dispatch().invoke(server, new MapChunkRequest(0, 0));


### PR DESCRIPTION
## Summary
- move built-in server services and handlers into modular GameMod classes
- expose server configuration details via getters
- load builtin mods before external ones and call lifecycle hooks in order
- verify builtin mods start correctly and register handlers
- update helper tests for new initialization

## Testing
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684e723f1cf483288059227467c2b851