### PR TITLE
feat: add base registries and save migration

### DIFF
--- a/core/src/main/java/net/lapidist/colony/base/BaseDefinitionsMod.java
+++ b/core/src/main/java/net/lapidist/colony/base/BaseDefinitionsMod.java
@@ -4,7 +4,6 @@ import net.lapidist.colony.mod.GameMod;
 import net.lapidist.colony.registry.BuildingDefinition;
 import net.lapidist.colony.registry.Registries;
 import net.lapidist.colony.registry.TileDefinition;
-import net.lapidist.colony.registry.ResourceDefinition;
 import net.lapidist.colony.i18n.I18n;
 
 /** Built-in mod registering standard tile and building definitions. */
@@ -15,9 +14,6 @@ public final class BaseDefinitionsMod implements GameMod {
         Registries.tiles().register(new TileDefinition("dirt", "Dirt", "dirt0"));
         Registries.tiles().register(new TileDefinition("grass", "Grass", "grass0"));
 
-        Registries.resources().register(new ResourceDefinition("WOOD", "Wood", "wood0"));
-        Registries.resources().register(new ResourceDefinition("STONE", "Stone", "stone0"));
-        Registries.resources().register(new ResourceDefinition("FOOD", "Food", "food0"));
 
         Registries.buildings().register(new BuildingDefinition(
                 "house",

--- a/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
@@ -42,6 +42,7 @@ public final class SaveMigrator {
         register(new V26ToV27Migration());
         register(new V27ToV28Migration());
         register(new V28ToV29Migration());
+        register(new V29ToV30Migration());
     }
 
     private SaveMigrator() {

--- a/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
@@ -32,9 +32,10 @@ public enum SaveVersion {
     V26(26),
     V27(27),
     V28(28),
-    V29(29);
+    V29(29),
+    V30(30);
 
-    public static final SaveVersion CURRENT = V29;
+    public static final SaveVersion CURRENT = V30;
 
     private final int number;
 

--- a/core/src/main/java/net/lapidist/colony/save/V29ToV30Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V29ToV30Migration.java
@@ -1,0 +1,21 @@
+package net.lapidist.colony.save;
+
+import net.lapidist.colony.components.state.MapState;
+
+/** Identity migration for save version 29 to 30. */
+public final class V29ToV30Migration implements MapStateMigration {
+    @Override
+    public int fromVersion() {
+        return SaveVersion.V29.number();
+    }
+
+    @Override
+    public int toVersion() {
+        return SaveVersion.V30.number();
+    }
+
+    @Override
+    public MapState apply(final MapState state) {
+        return state.toBuilder().version(toVersion()).build();
+    }
+}

--- a/docs/mods.md
+++ b/docs/mods.md
@@ -46,6 +46,9 @@ These are loaded automatically and do not need to be placed inside the `mods/` f
 { "id": "base-autosave", "version": "1.0.0" }
 { "id": "base-resource-production", "version": "1.0.0" }
 { "id": "base-handlers", "version": "1.0.0" }
+{ "id": "base-definitions", "version": "1.0.0" }
+{ "id": "base-resources", "version": "1.0.0" }
+{ "id": "base-items", "version": "1.0.0" }
 ```
 
 ## How mods are discovered
@@ -91,8 +94,15 @@ public final class ExtraMod implements GameMod {
 
 ## Registries
 
-Core data like tile, building, resource and item types are stored in simple string keyed registries. Mods can
-register new entries during the `init()` phase:
+Core game data is looked up from string keyed registries. Four registries are
+provided via the `Registries` helper class:
+
+- `tiles()` – `TileDefinition` entries
+- `buildings()` – `BuildingDefinition` entries
+- `resources()` – `ResourceDefinition` entries
+- `items()` – `ItemDefinition` entries
+
+Mods can register new entries during the `init()` phase:
 
 ```java
 public final class WaterTiles implements GameMod {


### PR DESCRIPTION
## Summary
- register tiles & buildings in BaseDefinitionsMod
- document registry usage in mods guide
- add built-in mod list with new base mods
- bump save version and add V29→V30 migration

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684e76ec2a008328907eef2b90176f01