### PR TITLE
feat: add building cost definitions

### DIFF
--- a/core/src/main/java/net/lapidist/colony/base/BaseDefinitionsMod.java
+++ b/core/src/main/java/net/lapidist/colony/base/BaseDefinitionsMod.java
@@ -4,10 +4,17 @@ import net.lapidist.colony.mod.GameMod;
 import net.lapidist.colony.registry.BuildingDefinition;
 import net.lapidist.colony.registry.Registries;
 import net.lapidist.colony.registry.TileDefinition;
+import net.lapidist.colony.components.state.ResourceData;
 import net.lapidist.colony.i18n.I18n;
 
 /** Built-in mod registering standard tile and building definitions. */
 public final class BaseDefinitionsMod implements GameMod {
+    private static final int HOUSE_WOOD = 1;
+    private static final int MARKET_WOOD = 5;
+    private static final int MARKET_STONE = 2;
+    private static final int FACTORY_WOOD = 10;
+    private static final int FACTORY_STONE = 5;
+    private static final int FARM_WOOD = 2;
     @Override
     public void init() {
         Registries.tiles().register(new TileDefinition("empty", "Empty", "dirt0"));
@@ -18,18 +25,22 @@ public final class BaseDefinitionsMod implements GameMod {
         Registries.buildings().register(new BuildingDefinition(
                 "house",
                 I18n.get("building.house"),
-                "house0"));
+                "house0",
+                new ResourceData(HOUSE_WOOD, 0, 0)));
         Registries.buildings().register(new BuildingDefinition(
                 "market",
                 I18n.get("building.market"),
-                "house0"));
+                "house0",
+                new ResourceData(MARKET_WOOD, MARKET_STONE, 0)));
         Registries.buildings().register(new BuildingDefinition(
                 "factory",
                 I18n.get("building.factory"),
-                "house0"));
+                "house0",
+                new ResourceData(FACTORY_WOOD, FACTORY_STONE, 0)));
         Registries.buildings().register(new BuildingDefinition(
                 "farm",
                 I18n.get("building.farm"),
-                "house0"));
+                "house0",
+                new ResourceData(FARM_WOOD, 0, 0)));
     }
 }

--- a/core/src/main/java/net/lapidist/colony/registry/BuildingDefinition.java
+++ b/core/src/main/java/net/lapidist/colony/registry/BuildingDefinition.java
@@ -1,14 +1,22 @@
 package net.lapidist.colony.registry;
 
+import net.lapidist.colony.components.state.ResourceData;
+
 /**
  * Metadata describing a building type.
  *
  * @param id     unique identifier
  * @param label  display label
  * @param asset  rendering asset reference
+ * @param cost   resources required to construct the building
  */
-public record BuildingDefinition(String id, String label, String asset) {
+public record BuildingDefinition(String id, String label, String asset, ResourceData cost) {
     public BuildingDefinition() {
-        this(null, null, null);
+        this(null, null, null, new ResourceData());
+    }
+
+    /** Convenience constructor omitting cost (defaults to zero). */
+    public BuildingDefinition(final String idValue, final String labelValue, final String assetValue) {
+        this(idValue, labelValue, assetValue, new ResourceData());
     }
 }

--- a/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
@@ -43,6 +43,7 @@ public final class SaveMigrator {
         register(new V27ToV28Migration());
         register(new V28ToV29Migration());
         register(new V29ToV30Migration());
+        register(new V30ToV31Migration());
     }
 
     private SaveMigrator() {

--- a/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
@@ -33,9 +33,10 @@ public enum SaveVersion {
     V27(27),
     V28(28),
     V29(29),
-    V30(30);
+    V30(30),
+    V31(31);
 
-    public static final SaveVersion CURRENT = V30;
+    public static final SaveVersion CURRENT = V31;
 
     private final int number;
 

--- a/core/src/main/java/net/lapidist/colony/save/V30ToV31Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V30ToV31Migration.java
@@ -1,0 +1,21 @@
+package net.lapidist.colony.save;
+
+import net.lapidist.colony.components.state.MapState;
+
+/** Identity migration for save version 30 to 31. */
+public final class V30ToV31Migration implements MapStateMigration {
+    @Override
+    public int fromVersion() {
+        return SaveVersion.V30.number();
+    }
+
+    @Override
+    public int toVersion() {
+        return SaveVersion.V31.number();
+    }
+
+    @Override
+    public MapState apply(final MapState state) {
+        return state.toBuilder().version(toVersion()).build();
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/server/commands/BuildCommandHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/BuildCommandHandler.java
@@ -10,8 +10,6 @@ import net.lapidist.colony.server.events.BuildingPlacedEvent;
 import net.lapidist.colony.server.services.NetworkService;
 import net.lapidist.colony.registry.Registries;
 import net.lapidist.colony.registry.BuildingDefinition;
-
-import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.concurrent.locks.ReentrantLock;
@@ -20,28 +18,6 @@ import java.util.concurrent.locks.ReentrantLock;
  * Applies a {@link BuildCommand} to the game state and broadcasts the change.
  */
 public final class BuildCommandHandler implements CommandHandler<BuildCommand> {
-    private static final Map<String, ResourceData> COSTS = Map.of(
-            "house", new ResourceData(new java.util.HashMap<>(Map.of(
-                    "WOOD", 1,
-                    "STONE", 0,
-                    "FOOD", 0
-            ))),
-            "market", new ResourceData(new java.util.HashMap<>(Map.of(
-                    "WOOD", 5,
-                    "STONE", 2,
-                    "FOOD", 0
-            ))),
-            "factory", new ResourceData(new java.util.HashMap<>(Map.of(
-                    "WOOD", 10,
-                    "STONE", 5,
-                    "FOOD", 0
-            ))),
-            "farm", new ResourceData(new java.util.HashMap<>(Map.of(
-                    "WOOD", 2,
-                    "STONE", 0,
-                    "FOOD", 0
-            )))
-    );
 
     private final Supplier<MapState> stateSupplier;
     private final Consumer<MapState> stateConsumer;
@@ -79,7 +55,7 @@ public final class BuildCommandHandler implements CommandHandler<BuildCommand> {
                 return;
             }
             String type = def.id();
-            ResourceData cost = COSTS.getOrDefault(type, new ResourceData());
+            ResourceData cost = def.cost() != null ? def.cost() : new ResourceData();
             ResourceData player = state.playerResources();
             java.util.Map<String, Integer> playerAmounts = new java.util.HashMap<>(player.amounts());
             for (var entry : cost.amounts().entrySet()) {

--- a/tests/src/test/java/net/lapidist/colony/mod/test/BuildingCostMod.java
+++ b/tests/src/test/java/net/lapidist/colony/mod/test/BuildingCostMod.java
@@ -1,0 +1,19 @@
+package net.lapidist.colony.mod.test;
+
+import net.lapidist.colony.components.state.ResourceData;
+import net.lapidist.colony.mod.GameMod;
+import net.lapidist.colony.registry.BuildingDefinition;
+import net.lapidist.colony.registry.Registries;
+
+/** Mod registering a custom building with a unique cost. */
+public final class BuildingCostMod implements GameMod {
+    private static final int HUT_WOOD = 3;
+    @Override
+    public void init() {
+        Registries.buildings().register(new BuildingDefinition(
+                "hut",
+                "Hut",
+                "house0",
+                new ResourceData(HUT_WOOD, 0, 0)));
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationCustomBuildingCostTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationCustomBuildingCostTest.java
@@ -1,0 +1,80 @@
+package net.lapidist.colony.tests.scenario;
+
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.components.resources.PlayerResourceComponent;
+import net.lapidist.colony.components.state.BuildingPlacementData;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.ResourceData;
+import net.lapidist.colony.map.ChunkedMapGenerator;
+import net.lapidist.colony.map.MapGenerator;
+import net.lapidist.colony.mod.ModLoader;
+import net.lapidist.colony.mod.ModLoader.LoadedMod;
+import net.lapidist.colony.mod.ModMetadata;
+import net.lapidist.colony.mod.test.BuildingCostMod;
+import net.lapidist.colony.server.GameServer;
+import net.lapidist.colony.server.GameServerConfig;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedConstruction;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
+
+/** Scenario verifying mods can register new buildings with custom costs. */
+@RunWith(GdxTestRunner.class)
+public class GameSimulationCustomBuildingCostTest {
+
+    private static final int WAIT_MS = 200;
+    private static final int INITIAL_WOOD = 3;
+
+    @Test
+    public void customBuildingConsumesResources() throws Exception {
+        MapGenerator gen = (w, h) -> {
+            MapState state = new ChunkedMapGenerator().generate(w, h);
+            return state.toBuilder().playerResources(new ResourceData(INITIAL_WOOD, 0, 0)).build();
+        };
+        GameServerConfig config = GameServerConfig.builder()
+                .saveName("scenario-custom-cost")
+                .mapGenerator(gen)
+                .build();
+        net.lapidist.colony.io.Paths.get().deleteAutosave("scenario-custom-cost");
+        try (MockedConstruction<ModLoader> loader = mockConstruction(ModLoader.class,
+                (m, c) -> when(m.loadMods()).thenReturn(List.of(
+                        new LoadedMod(new BuildingCostMod(), new ModMetadata("cost", "1", List.of())))));
+             GameServer server = new GameServer(config);
+             GameClient sender = new GameClient();
+             GameClient receiver = new GameClient()) {
+            server.start();
+
+            CountDownLatch latchSender = new CountDownLatch(1);
+            sender.start(state -> latchSender.countDown());
+            CountDownLatch latchReceiver = new CountDownLatch(1);
+            receiver.start(state -> latchReceiver.countDown());
+            latchSender.await(1, TimeUnit.SECONDS);
+            latchReceiver.await(1, TimeUnit.SECONDS);
+
+            MapState state = receiver.getMapState();
+            GameSimulation sim = new GameSimulation(state, receiver);
+
+            BuildingPlacementData data = new BuildingPlacementData(0, 0, "hut");
+            sender.sendBuildRequest(data);
+
+            Thread.sleep(WAIT_MS);
+            sim.step();
+
+            var players = sim.getWorld().getAspectSubscriptionManager()
+                    .get(com.artemis.Aspect.all(PlayerResourceComponent.class))
+                    .getEntities();
+            var prc = sim.getWorld().getMapper(PlayerResourceComponent.class)
+                    .get(sim.getWorld().getEntity(players.get(0)));
+            assertEquals(0, prc.getWood());
+        }
+        Thread.sleep(WAIT_MS);
+    }
+}


### PR DESCRIPTION
## Summary
- add cost field to `BuildingDefinition`
- populate default building costs via `BaseDefinitionsMod`
- adjust `BuildCommandHandler` to read cost from registry
- bump save version and add migration
- add scenario test covering custom building costs

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684e7f84dac08328a860ee41450cd9e3