### PR TITLE
feat: version built-in mods from release

### DIFF
--- a/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
@@ -44,6 +44,7 @@ public final class SaveMigrator {
         register(new V28ToV29Migration());
         register(new V29ToV30Migration());
         register(new V30ToV31Migration());
+        register(new V31ToV32Migration());
     }
 
     private SaveMigrator() {

--- a/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
@@ -34,9 +34,10 @@ public enum SaveVersion {
     V28(28),
     V29(29),
     V30(30),
-    V31(31);
+    V31(31),
+    V32(32);
 
-    public static final SaveVersion CURRENT = V31;
+    public static final SaveVersion CURRENT = V32;
 
     private final int number;
 

--- a/core/src/main/java/net/lapidist/colony/save/V31ToV32Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V31ToV32Migration.java
@@ -1,0 +1,21 @@
+package net.lapidist.colony.save;
+
+import net.lapidist.colony.components.state.MapState;
+
+/** Identity migration for save version 31 to 32. */
+public final class V31ToV32Migration implements MapStateMigration {
+    @Override
+    public int fromVersion() {
+        return SaveVersion.V31.number();
+    }
+
+    @Override
+    public int toVersion() {
+        return SaveVersion.V32.number();
+    }
+
+    @Override
+    public MapState apply(final MapState state) {
+        return state.toBuilder().version(toVersion()).build();
+    }
+}

--- a/docs/mods.md
+++ b/docs/mods.md
@@ -42,17 +42,17 @@ A minimal `mod.json` looks like:
 ### Built-in server mods
 
 The dedicated server bundles several mods providing the default functionality.
-These are loaded automatically and do not need to be placed inside the `mods/` folder:
+These use the same version as the running server and are loaded automatically, so they do not need to be placed inside the `mods/` folder:
 
 ```json
-{ "id": "base-map-service", "version": "1.0.0" }
-{ "id": "base-network", "version": "1.0.0" }
-{ "id": "base-autosave", "version": "1.0.0" }
-{ "id": "base-resource-production", "version": "1.0.0" }
-{ "id": "base-handlers", "version": "1.0.0" }
-{ "id": "base-definitions", "version": "1.0.0" }
-{ "id": "base-resources", "version": "1.0.0" }
-{ "id": "base-items", "version": "1.0.0" }
+{ "id": "base-map-service" }
+{ "id": "base-network" }
+{ "id": "base-autosave" }
+{ "id": "base-resource-production" }
+{ "id": "base-handlers" }
+{ "id": "base-definitions" }
+{ "id": "base-resources" }
+{ "id": "base-items" }
 ```
 
 ## How mods are discovered

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -1,4 +1,21 @@
 apply plugin: 'application'
+import org.gradle.api.file.DuplicatesStrategy
+
+def processedResourcesDir = "$buildDir/processedResources"
+
+task processModJson(type: Copy) {
+    from 'src/main/resources/mod.json'
+    into processedResourcesDir
+    filteringCharset = 'UTF-8'
+    filter { line -> line.replace('"1.0.0"', "\"${rootProject.applicationVersion}\"") }
+}
+
+processResources {
+    dependsOn processModJson
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    from(processedResourcesDir) { include 'mod.json' }
+    from('src/main/resources') { exclude 'mod.json' }
+}
 
 dependencies {
     implementation project(":core")

--- a/server/src/main/java/net/lapidist/colony/server/GameServer.java
+++ b/server/src/main/java/net/lapidist/colony/server/GameServer.java
@@ -32,6 +32,7 @@ import net.lapidist.colony.server.services.MapService;
 import net.lapidist.colony.server.services.NetworkService;
 import net.lapidist.colony.server.services.ResourceProductionService;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.Optional;
 import net.mostlyoriginal.api.event.common.EventSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -415,6 +416,8 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
     }
 
     private static ModMetadata builtinMetadata(final Class<?> cls) {
+        String version = Optional.ofNullable(GameServer.class.getPackage().getImplementationVersion())
+                .orElse("dev");
         String id;
         if (cls.getName().equals("net.lapidist.colony.base.BaseMapServiceMod")) {
             id = "base-map-service";
@@ -435,6 +438,6 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
         } else {
             id = cls.getSimpleName();
         }
-        return new ModMetadata(id, "1.0.0", java.util.List.of());
+        return new ModMetadata(id, version, java.util.List.of());
     }
 }


### PR DESCRIPTION
## Summary
- use server runtime version for built-in mod metadata
- process core-server mod.json during the build so its version matches the release
- clarify that built-in mods share the server version
- bump save format to V32

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684e86ee0c1c8328a23ccfc1ef479f4b