### PR TITLE
feat: expose new base gameplay mods

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/Colony.java
+++ b/client/src/main/java/net/lapidist/colony/client/Colony.java
@@ -111,7 +111,11 @@ public final class Colony extends Game {
             Paths.get().createGameFoldersIfNotExists();
             settings = Settings.load();
             I18n.setLocale(settings.getLocale());
-            mods = new ModLoader(Paths.get()).loadMods();
+            mods = new java.util.ArrayList<>();
+            for (net.lapidist.colony.mod.GameMod builtin : java.util.ServiceLoader.load(net.lapidist.colony.mod.GameMod.class)) {
+                mods.add(new LoadedMod(builtin, builtinMetadata(builtin.getClass())));
+            }
+            mods.addAll(new ModLoader(Paths.get()).loadMods());
             for (LoadedMod mod : mods) {
                 mod.mod().init();
             }
@@ -139,5 +143,33 @@ public final class Colony extends Game {
             }
         }
         Events.dispose();
+    }
+
+    private static net.lapidist.colony.mod.ModMetadata builtinMetadata(final Class<?> cls) {
+        String id;
+        if (cls.getName().equals("net.lapidist.colony.base.BaseMapServiceMod")) {
+            id = "base-map-service";
+        } else if (cls.getName().equals("net.lapidist.colony.base.BaseNetworkMod")) {
+            id = "base-network";
+        } else if (cls.getName().equals("net.lapidist.colony.base.BaseAutosaveMod")) {
+            id = "base-autosave";
+        } else if (cls.getName().equals("net.lapidist.colony.base.BaseResourceProductionMod")) {
+            id = "base-resource-production";
+        } else if (cls.getName().equals("net.lapidist.colony.base.BaseHandlersMod")) {
+            id = "base-handlers";
+        } else if (cls.getName().equals("net.lapidist.colony.base.BaseDefinitionsMod")) {
+            id = "base-definitions";
+        } else if (cls.getName().equals("net.lapidist.colony.base.BaseResourcesMod")) {
+            id = "base-resources";
+        } else if (cls.getName().equals("net.lapidist.colony.base.BaseCommandBusMod")) {
+            id = "base-command-bus";
+        } else if (cls.getName().equals("net.lapidist.colony.base.BaseMapGenerationMod")) {
+            id = "base-map-generation";
+        } else if (cls.getName().equals("net.lapidist.colony.base.BaseGameplaySystemsMod")) {
+            id = "base-systems";
+        } else {
+            id = cls.getSimpleName();
+        }
+        return new net.lapidist.colony.mod.ModMetadata(id, "1.0.0", java.util.List.of());
     }
 }

--- a/docs/mods.md
+++ b/docs/mods.md
@@ -53,6 +53,8 @@ These are loaded automatically and do not need to be placed inside the `mods/` f
 { "id": "base-definitions", "version": "1.0.0" }
 { "id": "base-resources", "version": "1.0.0" }
 { "id": "base-items", "version": "1.0.0" }
+{ "id": "base-map-generation", "version": "1.0.0" }
+{ "id": "base-systems", "version": "1.0.0" }
 ```
 
 ## How mods are discovered

--- a/server/src/main/java/net/lapidist/colony/base/BaseGameplaySystemsMod.java
+++ b/server/src/main/java/net/lapidist/colony/base/BaseGameplaySystemsMod.java
@@ -1,0 +1,17 @@
+package net.lapidist.colony.base;
+
+import net.lapidist.colony.mod.GameMod;
+import net.lapidist.colony.mod.GameServer;
+import net.lapidist.colony.server.services.ResourceProductionService;
+
+/** Built-in mod registering default gameplay systems. */
+public final class BaseGameplaySystemsMod implements GameMod {
+    @Override
+    public void registerSystems(final GameServer srv) {
+        net.lapidist.colony.server.GameServer s = (net.lapidist.colony.server.GameServer) srv;
+        ResourceProductionService service = s.getResourceProductionService();
+        if (service != null) {
+            srv.registerSystem(service);
+        }
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/base/BaseMapGenerationMod.java
+++ b/server/src/main/java/net/lapidist/colony/base/BaseMapGenerationMod.java
@@ -1,0 +1,20 @@
+package net.lapidist.colony.base;
+
+import net.lapidist.colony.mod.GameMod;
+import net.lapidist.colony.mod.GameServer;
+import net.lapidist.colony.server.services.MapService;
+
+/** Built-in mod providing the default map generator via MapService. */
+public final class BaseMapGenerationMod implements GameMod {
+    @Override
+    public void registerServices(final GameServer srv) {
+        net.lapidist.colony.server.GameServer s = (net.lapidist.colony.server.GameServer) srv;
+        s.setMapServiceFactory(() -> new MapService(
+                s.getMapGenerator(),
+                s.getSaveName(),
+                s.getMapWidth(),
+                s.getMapHeight(),
+                s.getStateLock()
+        ));
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/server/GameServer.java
+++ b/server/src/main/java/net/lapidist/colony/server/GameServer.java
@@ -432,6 +432,10 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
             id = "base-resources";
         } else if (cls.getName().equals("net.lapidist.colony.base.BaseCommandBusMod")) {
             id = "base-command-bus";
+        } else if (cls.getName().equals("net.lapidist.colony.base.BaseMapGenerationMod")) {
+            id = "base-map-generation";
+        } else if (cls.getName().equals("net.lapidist.colony.base.BaseGameplaySystemsMod")) {
+            id = "base-systems";
         } else {
             id = cls.getSimpleName();
         }

--- a/server/src/main/resources/META-INF/services/net.lapidist.colony.mod.GameMod
+++ b/server/src/main/resources/META-INF/services/net.lapidist.colony.mod.GameMod
@@ -9,3 +9,6 @@ net.lapidist.colony.base.BaseDefinitionsMod
 
 net.lapidist.colony.base.BaseResourcesMod
 net.lapidist.colony.base.BaseItemsMod
+
+net.lapidist.colony.base.BaseMapGenerationMod
+net.lapidist.colony.base.BaseGameplaySystemsMod

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerBaseSystemsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerBaseSystemsTest.java
@@ -1,0 +1,34 @@
+package net.lapidist.colony.tests.server;
+
+import net.lapidist.colony.server.GameServer;
+import net.lapidist.colony.server.GameServerConfig;
+import net.lapidist.colony.server.services.ResourceProductionService;
+import net.lapidist.colony.io.Paths;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+/** Ensures built-in mods register default game systems. */
+public class GameServerBaseSystemsTest {
+
+    @SuppressWarnings("unchecked")
+    private static List<Object> systems(final GameServer server) throws Exception {
+        Field f = GameServer.class.getDeclaredField("systems");
+        f.setAccessible(true);
+        return (List<Object>) f.get(server);
+    }
+
+    @Test
+    public void resourceProductionSystemRegistered() throws Exception {
+        String name = "base-systems";
+        Paths.get().deleteAutosave(name);
+        GameServer server = new GameServer(GameServerConfig.builder().saveName(name).build());
+        server.start();
+
+        assertTrue(systems(server).stream().anyMatch(s -> s instanceof ResourceProductionService));
+        server.stop();
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerModLoadingTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerModLoadingTest.java
@@ -56,6 +56,8 @@ public class GameServerModLoadingTest {
             assertTrue(loaded.stream().anyMatch(m -> "base-handlers".equals(m.metadata().id())));
             assertTrue(loaded.stream().anyMatch(m -> "base-resources".equals(m.metadata().id())));
             assertTrue(loaded.stream().anyMatch(m -> "base-definitions".equals(m.metadata().id())));
+            assertTrue(loaded.stream().anyMatch(m -> "base-map-generation".equals(m.metadata().id())));
+            assertTrue(loaded.stream().anyMatch(m -> "base-systems".equals(m.metadata().id())));
             assertTrue(loaded.stream().anyMatch(m -> "stub".equals(m.metadata().id())));
             assertTrue(server.isRunning());
             server.stop();


### PR DESCRIPTION
## Summary
- load built-in mods in the client using ServiceLoader
- add BaseMapGenerationMod and BaseGameplaySystemsMod
- register new mods in services descriptor
- update mod metadata mapping
- document new bundled mods
- test that gameplay systems are loaded
- update mod loading tests

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684e8305f03883288a833b0c76872850