### PR TITLE
fix: address checkstyle failure

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/Colony.java
+++ b/client/src/main/java/net/lapidist/colony/client/Colony.java
@@ -20,6 +20,8 @@ import net.lapidist.colony.events.Events;
 import net.lapidist.colony.client.events.GameInitEvent;
 import net.lapidist.colony.mod.ModLoader;
 import net.lapidist.colony.mod.ModLoader.LoadedMod;
+import net.lapidist.colony.mod.GameMod;
+import java.util.ServiceLoader;
 
 import java.io.IOException;
 
@@ -112,7 +114,7 @@ public final class Colony extends Game {
             settings = Settings.load();
             I18n.setLocale(settings.getLocale());
             mods = new java.util.ArrayList<>();
-            for (net.lapidist.colony.mod.GameMod builtin : java.util.ServiceLoader.load(net.lapidist.colony.mod.GameMod.class)) {
+            for (GameMod builtin : ServiceLoader.load(GameMod.class)) {
                 mods.add(new LoadedMod(builtin, builtinMetadata(builtin.getClass())));
             }
             mods.addAll(new ModLoader(Paths.get()).loadMods());


### PR DESCRIPTION
## Summary
- shorten line in `Colony#create` that exceeded 120 characters

## Testing
- `./gradlew spotlessApply`
- `./gradlew clean test` *(fails: Process 'Gradle Test Executor' finished with non-zero exit value 134)*
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684e8bd966888328874f2c6bf35915bc