### PR TITLE
feat: add mod selection screen

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/Colony.java
+++ b/client/src/main/java/net/lapidist/colony/client/Colony.java
@@ -20,6 +20,7 @@ import net.lapidist.colony.events.Events;
 import net.lapidist.colony.client.events.GameInitEvent;
 import net.lapidist.colony.mod.ModLoader;
 import net.lapidist.colony.mod.ModLoader.LoadedMod;
+import java.util.ServiceLoader;
 
 import java.io.IOException;
 
@@ -29,6 +30,7 @@ public final class Colony extends Game {
     private GameServer server;
     private Settings settings;
     private java.util.List<LoadedMod> mods;
+    private java.util.List<LoadedMod> selectedMods;
 
     public void returnToMainMenu() {
         if (client != null) {
@@ -74,6 +76,7 @@ public final class Colony extends Game {
                             .height(height)
                             .build()
             );
+            server.setMods(selectedMods);
             server.start();
             client = new GameClient();
             client.setConnectionErrorCallback(e -> Gdx.app.postRunnable(() -> {
@@ -104,6 +107,14 @@ public final class Colony extends Game {
         return settings;
     }
 
+    public java.util.List<LoadedMod> getMods() {
+        return mods;
+    }
+
+    public void setSelectedMods(final java.util.List<LoadedMod> modsToUse) {
+        this.selectedMods = new java.util.ArrayList<>(modsToUse);
+    }
+
     @Override
     public void create() {
         // Do global initialisation
@@ -112,13 +123,14 @@ public final class Colony extends Game {
             settings = Settings.load();
             I18n.setLocale(settings.getLocale());
             mods = new java.util.ArrayList<>();
-            for (net.lapidist.colony.mod.GameMod builtin : java.util.ServiceLoader.load(net.lapidist.colony.mod.GameMod.class)) {
+            for (net.lapidist.colony.mod.GameMod builtin : ServiceLoader.load(net.lapidist.colony.mod.GameMod.class)) {
                 mods.add(new LoadedMod(builtin, builtinMetadata(builtin.getClass())));
             }
             mods.addAll(new ModLoader(Paths.get()).loadMods());
             for (LoadedMod mod : mods) {
                 mod.mod().init();
             }
+            selectedMods = new java.util.ArrayList<>(mods);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/client/src/main/java/net/lapidist/colony/client/screens/MainMenuScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MainMenuScreen.java
@@ -57,7 +57,7 @@ public final class MainMenuScreen extends BaseScreen {
         newGameButton.addListener(new ChangeListener() {
             @Override
             public void changed(final ChangeEvent event, final Actor actor) {
-                colony.setScreen(new NewGameScreen(colony));
+                colony.setScreen(new ModSelectionScreen(colony));
             }
         });
 

--- a/client/src/main/java/net/lapidist/colony/client/screens/ModSelectionScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/ModSelectionScreen.java
@@ -1,0 +1,93 @@
+package net.lapidist.colony.client.screens;
+
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.scenes.scene2d.InputEvent;
+import com.badlogic.gdx.scenes.scene2d.InputListener;
+import com.badlogic.gdx.scenes.scene2d.ui.CheckBox;
+import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
+import net.lapidist.colony.client.Colony;
+import net.lapidist.colony.i18n.I18n;
+import net.lapidist.colony.mod.ModLoader.LoadedMod;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Screen allowing users to enable or disable loaded mods.
+ */
+public final class ModSelectionScreen extends BaseScreen {
+    private final Colony colony;
+    private final List<LoadedMod> mods;
+    private final Map<LoadedMod, CheckBox> boxes = new HashMap<>();
+    private static final float PADDING = 10f;
+
+    public ModSelectionScreen(final Colony game) {
+        this.colony = game;
+        this.mods = game.getMods();
+        getRoot().add(new com.badlogic.gdx.scenes.scene2d.ui.Label(
+                I18n.get("modSelect.title"), getSkin())).row();
+
+        Table list = new Table();
+        for (LoadedMod mod : mods) {
+            String label = mod.metadata().id();
+            CheckBox box = new CheckBox(label, getSkin());
+            box.setChecked(true);
+            if (label.startsWith("base-")) {
+                box.setDisabled(true);
+            }
+            boxes.put(mod, box);
+            list.add(box).left().row();
+        }
+
+        ScrollPane scroll = new ScrollPane(list, getSkin());
+        scroll.setScrollingDisabled(true, false);
+        getRoot().add(scroll).expand().fill().row();
+
+        TextButton back = new TextButton(I18n.get("modSelect.back"), getSkin());
+        TextButton next = new TextButton(I18n.get("modSelect.next"), getSkin());
+
+        Table buttons = new Table();
+        buttons.add(back).padRight(PADDING);
+        buttons.add(next);
+        getRoot().add(buttons).padBottom(PADDING).bottom();
+
+        next.addListener(new ChangeListener() {
+            @Override
+            public void changed(final ChangeEvent event, final Actor actor) {
+                List<LoadedMod> enabled = new ArrayList<>();
+                for (LoadedMod mod : mods) {
+                    CheckBox box = boxes.get(mod);
+                    if (box.isChecked() || box.isDisabled()) {
+                        enabled.add(mod);
+                    }
+                }
+                colony.setSelectedMods(enabled);
+                colony.setScreen(new NewGameScreen(colony));
+            }
+        });
+
+        back.addListener(new ChangeListener() {
+            @Override
+            public void changed(final ChangeEvent event, final Actor actor) {
+                colony.setScreen(new MainMenuScreen(colony));
+            }
+        });
+
+        getStage().addListener(new InputListener() {
+            @Override
+            public boolean keyDown(final InputEvent event, final int keycode) {
+                if (keycode == Input.Keys.ESCAPE) {
+                    colony.setScreen(new MainMenuScreen(colony));
+                    return true;
+                }
+                return false;
+            }
+        });
+    }
+}

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -62,3 +62,6 @@ graphics.renderer=Renderer
 graphics.spritecache=Sprite Cache
 common.save=Save
 ui.saving=Saving...
+modSelect.title=Mods
+modSelect.next=Next
+modSelect.back=Back

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -61,3 +61,6 @@ graphics.renderer=Renderer
 graphics.spritecache=Sprite-Cache
 common.save=Speichern
 ui.saving=Speichern...
+modSelect.title=Mods
+modSelect.next=Weiter
+modSelect.back=Zurück

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -61,3 +61,6 @@ graphics.renderer=Renderizador
 graphics.spritecache=Cache de Sprites
 common.save=Guardar
 ui.saving=Guardando...
+modSelect.title=Mods
+modSelect.next=Siguiente
+modSelect.back=Atrás

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -61,3 +61,6 @@ graphics.renderer=Moteur de rendu
 graphics.spritecache=Cache de Sprites
 common.save=Sauvegarder
 ui.saving=Sauvegarde...
+modSelect.title=Mods
+modSelect.next=Suivant
+modSelect.back=Retour

--- a/server/src/main/java/net/lapidist/colony/server/GameServer.java
+++ b/server/src/main/java/net/lapidist/colony/server/GameServer.java
@@ -124,12 +124,14 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
     public void start() throws IOException, InterruptedException {
         initKryo();
         Events.init(new EventSystem());
-        mods = new java.util.ArrayList<>();
-        for (GameMod builtin : java.util.ServiceLoader.load(GameMod.class)) {
-            ModMetadata meta = builtinMetadata(builtin.getClass());
-            mods.add(new LoadedMod(builtin, meta));
+        if (mods == null) {
+            mods = new java.util.ArrayList<>();
+            for (GameMod builtin : java.util.ServiceLoader.load(GameMod.class)) {
+                ModMetadata meta = builtinMetadata(builtin.getClass());
+                mods.add(new LoadedMod(builtin, meta));
+            }
+            mods.addAll(new ModLoader(Paths.get()).loadMods());
         }
-        mods.addAll(new ModLoader(Paths.get()).loadMods());
 
         for (LoadedMod mod : mods) {
             mod.mod().init();
@@ -368,6 +370,13 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
      */
     public java.util.function.Supplier<CommandBus> getCommandBusFactory() {
         return commandBusFactory;
+    }
+
+    /**
+     * Specify the list of mods to load. Must be called before {@link #start()}.
+     */
+    public void setMods(final java.util.List<LoadedMod> modsToUse) {
+        this.mods = modsToUse;
     }
 
     /**

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MainMenuScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MainMenuScreenTest.java
@@ -7,7 +7,7 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import net.lapidist.colony.client.Colony;
 import net.lapidist.colony.client.screens.LoadGameScreen;
 import net.lapidist.colony.client.screens.MainMenuScreen;
-import net.lapidist.colony.client.screens.NewGameScreen;
+import net.lapidist.colony.client.screens.ModSelectionScreen;
 import net.lapidist.colony.client.screens.SettingsScreen;
 import org.mockito.MockedConstruction;
 import static org.mockito.Mockito.mockConstruction;
@@ -39,7 +39,7 @@ public class MainMenuScreenTest {
             MainMenuScreen screen = new MainMenuScreen(colony);
             TextButton newGame = (TextButton) getRoot(screen).getChildren().get(NEW_GAME_INDEX);
             newGame.fire(new ChangeListener.ChangeEvent());
-            verify(colony).setScreen(isA(NewGameScreen.class));
+            verify(colony).setScreen(isA(ModSelectionScreen.class));
             screen.dispose();
         }
     }


### PR DESCRIPTION
## Summary
- implement `ModSelectionScreen` for choosing which mods to load
- open `ModSelectionScreen` when starting a new game
- add translations for new screen
- allow `Colony` to pass selected mods to `GameServer`
- update `GameServer` to accept external mod lists
- adjust tests for main menu

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`

------
https://chatgpt.com/codex/tasks/task_e_684e8ac4e0dc832880f912e80ddd7a8e