### PR TITLE
fix: defer event listener registration

### DIFF
--- a/tests/src/test/java/net/lapidist/colony/tests/core/events/EventsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/events/EventsTest.java
@@ -27,7 +27,7 @@ public class EventsTest {
     @Before
     public void setUp() {
         Events.init(new EventSystem());
-        Events.getInstance().registerEvents(this);
+        Events.registerEvents(this);
     }
 
     @Subscribe
@@ -89,5 +89,16 @@ public class EventsTest {
                 String.format("ResizeEvent(width=%d, height=%d)", width, height),
                 event.toString()
         );
+    }
+
+    @Test
+    public void listenerQueuedUntilInit() {
+        Events.dispose();
+        pauseHandled = false;
+        Events.registerEvents(this);
+        Events.init(new EventSystem());
+        Events.dispatch(new PauseEvent());
+        Events.update();
+        assertTrue(pauseHandled);
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerScriptTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerScriptTest.java
@@ -77,7 +77,7 @@ public class GameServerScriptTest {
                 "    }",
                 "}",
                 "",
-                "Events.getInstance().registerEvents(ScriptListener())"
+                "Events.registerEvents(ScriptListener())"
         ));
     }
 


### PR DESCRIPTION
## Summary
- add pending listener queue in `Events` to allow registration before initialization
- update tests to use the new registration method
- ensure script example registers listeners safely

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684e8f36dc588328b01b3704f852adc7