### PR TITLE
Remove unused serialization package from client module

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/core/io/serialization/package-info.java
+++ b/client/src/main/java/net/lapidist/colony/client/core/io/serialization/package-info.java
@@ -1,1 +1,0 @@
-package net.lapidist.colony.client.core.io.serialization;


### PR DESCRIPTION
## Summary
- delete empty `client.core.io.serialization` package

## Testing
- `./scripts/check.sh`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684e92d3368c8328ab20c2275acc24b3