### PR TITLE
docs: clarify save migration requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Each module contains its own `AGENTS.md` with extra notes.
     `docs/performance.md` with the new numbers so future runs have an accurate baseline.
 
 ## Save Format and Serialization
-Whenever creating a PR, add a new save version and migration. Every PR must have a new save migration, unless they only change documentation.
+Add a new save version and migration whenever your PR changes something that affects the serialized save format. Documentation-only changes do not require a migration.
 1. Add the next constant in `SaveVersion`.
 2. Implement migration logic in `SaveMigrator`.
 3. Add tests covering the migration.

--- a/docs/save_format.md
+++ b/docs/save_format.md
@@ -10,7 +10,7 @@ Game state is serialized into a `SaveData` record containing the save version, a
 
 `DefaultSaveMigrationStrategy` checks the file version when loading a save. If it is older than `SaveVersion.CURRENT`, it calls `SaveMigrator.migrate`. `SaveMigrator` applies each `MapStateMigration` step in order and returns an updated `MapState` with the target version.
 
-The repository's root `AGENTS.md` outlines the required steps whenever the save format changes:
+The repository's root `AGENTS.md` outlines the required steps whenever the save serialization changes:
 
 1. Add the next constant in `SaveVersion`.
 2. Implement migration logic in `SaveMigrator`.


### PR DESCRIPTION
## Summary
- clarify save migration requirement in root AGENTS guide
- update save_format doc with same wording

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684e946377bc8328acab4a1071224654