### PR TITLE
feat: add shader plugin system

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/graphics/NullShaderPlugin.java
+++ b/client/src/main/java/net/lapidist/colony/client/graphics/NullShaderPlugin.java
@@ -1,0 +1,13 @@
+package net.lapidist.colony.client.graphics;
+
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+
+/**
+ * Default implementation that provides no shader program.
+ */
+public final class NullShaderPlugin implements ShaderPlugin {
+    @Override
+    public ShaderProgram create(final ShaderManager manager) {
+        return null;
+    }
+}

--- a/client/src/main/java/net/lapidist/colony/client/graphics/ShaderPlugin.java
+++ b/client/src/main/java/net/lapidist/colony/client/graphics/ShaderPlugin.java
@@ -1,0 +1,23 @@
+package net.lapidist.colony.client.graphics;
+
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+
+/**
+ * Extension point for providing shader programs.
+ */
+public interface ShaderPlugin {
+
+    /**
+     * Create or load a shader program.
+     *
+     * @param manager shader manager used for compilation
+     * @return created program or {@code null} if not available
+     */
+    ShaderProgram create(ShaderManager manager);
+
+    /**
+     * Dispose any resources used by this plugin.
+     */
+    default void dispose() {
+    }
+}

--- a/client/src/main/java/net/lapidist/colony/client/graphics/ShaderPluginLoader.java
+++ b/client/src/main/java/net/lapidist/colony/client/graphics/ShaderPluginLoader.java
@@ -1,0 +1,24 @@
+package net.lapidist.colony.client.graphics;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+
+/**
+ * Discovers available {@link ShaderPlugin} implementations.
+ */
+public final class ShaderPluginLoader {
+
+    /**
+     * Load all shader plugins using {@link ServiceLoader}.
+     *
+     * @return list of discovered plugins
+     */
+    public List<ShaderPlugin> loadPlugins() {
+        List<ShaderPlugin> plugins = new ArrayList<>();
+        for (ShaderPlugin plugin : ServiceLoader.load(ShaderPlugin.class)) {
+            plugins.add(plugin);
+        }
+        return plugins;
+    }
+}

--- a/client/src/main/resources/META-INF/services/net.lapidist.colony.client.graphics.ShaderPlugin
+++ b/client/src/main/resources/META-INF/services/net.lapidist.colony.client.graphics.ShaderPlugin
@@ -1,0 +1,1 @@
+net.lapidist.colony.client.graphics.NullShaderPlugin

--- a/tests/src/test/java/net/lapidist/colony/tests/graphics/ShaderPluginLoaderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/graphics/ShaderPluginLoaderTest.java
@@ -1,0 +1,25 @@
+package net.lapidist.colony.tests.graphics;
+
+import net.lapidist.colony.client.graphics.ShaderPlugin;
+import net.lapidist.colony.client.graphics.ShaderPluginLoader;
+import net.lapidist.colony.client.graphics.NullShaderPlugin;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@RunWith(GdxTestRunner.class)
+public class ShaderPluginLoaderTest {
+
+    @Test
+    public void loadsDefaultPlugin() {
+        ShaderPluginLoader loader = new ShaderPluginLoader();
+        List<ShaderPlugin> plugins = loader.loadPlugins();
+        assertFalse(plugins.isEmpty());
+        assertTrue(plugins.get(0) instanceof NullShaderPlugin);
+        assertNull(plugins.get(0).create(new net.lapidist.colony.client.graphics.ShaderManager()));
+    }
+}


### PR DESCRIPTION
## Summary
- add new ShaderPlugin interface for optional shaders
- load shader plugins using ShaderPluginLoader
- provide default NullShaderPlugin and service entry
- test ShaderPluginLoader via GdxTestRunner

## Testing
- `./scripts/check.sh`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684e9b515e6883289b45dd8d8a021309