### PR TITLE
feat(core): register ModMetadata with Kryo

### DIFF
--- a/core/src/main/java/net/lapidist/colony/mod/ModMetadata.java
+++ b/core/src/main/java/net/lapidist/colony/mod/ModMetadata.java
@@ -1,5 +1,6 @@
 package net.lapidist.colony.mod;
 
+import net.lapidist.colony.serialization.KryoType;
 import java.util.List;
 
 /**
@@ -9,5 +10,6 @@ import java.util.List;
  * @param version      version string
  * @param dependencies list of required mod ids
  */
+@KryoType
 public record ModMetadata(String id, String version, List<String> dependencies) {
 }

--- a/core/src/main/java/net/lapidist/colony/serialization/SerializationRegistrar.java
+++ b/core/src/main/java/net/lapidist/colony/serialization/SerializationRegistrar.java
@@ -20,6 +20,7 @@ import net.lapidist.colony.save.SaveData;
 import net.lapidist.colony.components.state.PlayerPosition;
 import net.lapidist.colony.components.state.CameraPosition;
 import net.lapidist.colony.components.state.PlayerPositionUpdate;
+import net.lapidist.colony.mod.ModMetadata;
 
 /**
  * Registers all serializable classes with a given Kryo instance.
@@ -61,7 +62,7 @@ public final class SerializationRegistrar {
     }
 
     /** Precomputed registration hash for quick access. */
-    public static final int REGISTRATION_HASH = 632693971;
+    public static final int REGISTRATION_HASH = 23376500;
 
     private static final Class<?>[] REGISTERED_TYPES = {
             TileData.class,
@@ -86,6 +87,7 @@ public final class SerializationRegistrar {
             PlayerPosition.class,
             SaveData.class,
             CameraPosition.class,
-            PlayerPositionUpdate.class
+            PlayerPositionUpdate.class,
+            ModMetadata.class
     };
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/serialization/SerializationRegistrarTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/serialization/SerializationRegistrarTest.java
@@ -3,6 +3,7 @@ package net.lapidist.colony.tests.serialization;
 import com.esotericsoftware.kryo.Kryo;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.serialization.SerializationRegistrar;
+import net.lapidist.colony.mod.ModMetadata;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
@@ -13,5 +14,6 @@ public class SerializationRegistrarTest {
         Kryo kryo = new Kryo();
         SerializationRegistrar.register(kryo);
         assertTrue(kryo.getRegistration(MapState.class) != null);
+        assertTrue(kryo.getRegistration(ModMetadata.class) != null);
     }
 }


### PR DESCRIPTION
## Summary
- annotate `ModMetadata` with `@KryoType`
- add `ModMetadata` to `SerializationRegistrar.REGISTERED_TYPES`
- update `SerializationRegistrar.REGISTRATION_HASH`
- test registration of `ModMetadata`

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684ea1af46f48328a4da0c889ad42eb7