### PR TITLE
fix: support registering events before init

### DIFF
--- a/core/src/main/java/net/lapidist/colony/events/Events.java
+++ b/core/src/main/java/net/lapidist/colony/events/Events.java
@@ -21,6 +21,27 @@ public final class Events {
      * threads are spawned.</p>
      */
     private static volatile EventSystem instance;
+    private static final EventSystem PENDING_SYSTEM = new EventSystem() {
+        @Override
+        public void registerEvents(final Object listener) {
+            PENDING.add(listener);
+        }
+
+        @Override
+        public void dispatch(final Event event) {
+            // ignore events until the real system is initialised
+        }
+
+        @Override
+        public <T extends Event> T dispatch(final Class<T> eventType) {
+            return null;
+        }
+
+        @Override
+        protected void processSystem() {
+            // no-op
+        }
+    };
     private static final Logger LOGGER = LoggerFactory.getLogger(Events.class);
     private static final Map<Class<? extends Event>, List<Consumer<? extends Event>>>
             LISTENERS = new ConcurrentHashMap<>();
@@ -45,7 +66,7 @@ public final class Events {
     }
 
     public static EventSystem getInstance() {
-        return instance;
+        return instance != null ? instance : PENDING_SYSTEM;
     }
 
     /**

--- a/tests/src/test/java/net/lapidist/colony/tests/client/ColonyTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/ColonyTest.java
@@ -175,7 +175,7 @@ public class ColonyTest {
 
             verify(client).stop();
             verify(server).stop();
-            assertNull(Events.getInstance());
+            assertNotNull(Events.getInstance());
         }
         java.nio.file.Files.deleteIfExists(autosave);
     }


### PR DESCRIPTION
## Summary
- allow scripts to use `Events.getInstance()` before the system is initialised
- adjust tests for new behaviour

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684ea24e6cf08328b3c7b10b54ec2916