### PR TITLE
feat: allow optional shader for SpriteBatchMapRenderer

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRenderer.java
@@ -81,14 +81,15 @@ public final class LoadingSpriteMapRenderer implements MapRenderer, Disposable {
                     cameraSystem,
                     world.getSystem(MapRenderDataSystem.class)
             );
+            MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer);
             delegate = new SpriteBatchMapRenderer(
                     spriteBatch,
                     resourceLoader,
                     tileRenderer,
                     buildingRenderer,
-                    resourceRenderer,
-                    playerRenderer,
-                    cacheEnabled
+                    renderers,
+                    cacheEnabled,
+                    null
             );
             if (progressCallback != null) {
                 progressCallback.accept(1f);

--- a/client/src/main/java/net/lapidist/colony/client/renderers/MapEntityRenderers.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/MapEntityRenderers.java
@@ -1,0 +1,8 @@
+package net.lapidist.colony.client.renderers;
+
+/** Holds auxiliary entity renderers used by the map renderer. */
+public record MapEntityRenderers(
+        ResourceRenderer resourceRenderer,
+        PlayerRenderer playerRenderer
+) {
+}

--- a/tests/src/jmh/java/net/lapidist/colony/tests/benchmarks/SpriteBatchRendererBenchmark.java
+++ b/tests/src/jmh/java/net/lapidist/colony/tests/benchmarks/SpriteBatchRendererBenchmark.java
@@ -22,6 +22,7 @@ import net.lapidist.colony.client.renderers.ResourceRenderer;
 import net.lapidist.colony.client.renderers.SpriteBatchMapRenderer;
 import net.lapidist.colony.client.renderers.TileRenderer;
 import net.lapidist.colony.client.renderers.PlayerRenderer;
+import net.lapidist.colony.client.renderers.MapEntityRenderers;
 import net.lapidist.colony.client.systems.CameraProvider;
 import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.components.maps.MapComponent;
@@ -65,10 +66,11 @@ public class SpriteBatchRendererBenchmark {
         BuildingRenderer buildingRenderer = new BuildingRenderer(batch, loader, camera, resolver);
         ResourceRenderer resourceRenderer = mock(ResourceRenderer.class);
         PlayerRenderer playerRenderer = mock(PlayerRenderer.class);
+        MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer);
         cachedRenderer = new SpriteBatchMapRenderer(
-                batch, loader, tileRenderer, buildingRenderer, resourceRenderer, playerRenderer, true);
+                batch, loader, tileRenderer, buildingRenderer, renderers, true, null);
         plainRenderer = new SpriteBatchMapRenderer(
-                batch, loader, tileRenderer, buildingRenderer, resourceRenderer, playerRenderer, false);
+                batch, loader, tileRenderer, buildingRenderer, renderers, false, null);
         data = createData(MAP_SIZE, MAP_SIZE);
         construction = mockConstruction(SpriteCache.class, (mock, ctx) -> {
             when(mock.getProjectionMatrix()).thenReturn(new Matrix4());

--- a/tests/src/test/java/net/lapidist/colony/client/renderers/SpriteBatchMapRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/renderers/SpriteBatchMapRendererTest.java
@@ -1,11 +1,17 @@
 package net.lapidist.colony.client.renderers;
 
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import org.mockito.InOrder;
 import net.lapidist.colony.client.core.io.ResourceLoader;
+import net.lapidist.colony.client.systems.CameraProvider;
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.utils.viewport.ExtendViewport;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import net.lapidist.colony.tests.GdxTestRunner;
 import com.badlogic.gdx.utils.IntArray;
+import net.lapidist.colony.client.render.MapRenderData;
 
 import java.lang.reflect.Field;
 
@@ -22,9 +28,10 @@ public class SpriteBatchMapRendererTest {
         BuildingRenderer buildingRenderer = mock(BuildingRenderer.class);
         ResourceRenderer resourceRenderer = mock(ResourceRenderer.class);
         PlayerRenderer playerRenderer = mock(PlayerRenderer.class);
+        MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer);
 
         SpriteBatchMapRenderer renderer = new SpriteBatchMapRenderer(
-                batch, loader, tileRenderer, buildingRenderer, resourceRenderer, playerRenderer, true);
+                batch, loader, tileRenderer, buildingRenderer, renderers, true, null);
 
         Field cacheField = SpriteBatchMapRenderer.class.getDeclaredField("tileCache");
         cacheField.setAccessible(true);
@@ -45,9 +52,10 @@ public class SpriteBatchMapRendererTest {
         BuildingRenderer buildingRenderer = mock(BuildingRenderer.class);
         ResourceRenderer resourceRenderer = mock(ResourceRenderer.class);
         PlayerRenderer playerRenderer = mock(PlayerRenderer.class);
+        MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer);
 
         SpriteBatchMapRenderer renderer = new SpriteBatchMapRenderer(
-                batch, loader, tileRenderer, buildingRenderer, resourceRenderer, playerRenderer, false);
+                batch, loader, tileRenderer, buildingRenderer, renderers, false, null);
 
         Field cacheField = SpriteBatchMapRenderer.class.getDeclaredField("tileCache");
         cacheField.setAccessible(true);
@@ -57,5 +65,90 @@ public class SpriteBatchMapRendererTest {
         renderer.invalidateTiles(new IntArray(new int[] {2}));
 
         verify(cache, never()).invalidateTiles(any(IntArray.class));
+    }
+
+    @Test
+    public void appliesAndResetsShaderProgram() {
+        SpriteBatch batch = mock(SpriteBatch.class);
+        ResourceLoader loader = mock(ResourceLoader.class);
+        TileRenderer tileRenderer = mock(TileRenderer.class);
+        BuildingRenderer buildingRenderer = mock(BuildingRenderer.class);
+        ResourceRenderer resourceRenderer = mock(ResourceRenderer.class);
+        PlayerRenderer playerRenderer = mock(PlayerRenderer.class);
+        ShaderProgram shader = mock(ShaderProgram.class);
+        MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer);
+
+        SpriteBatchMapRenderer renderer = new SpriteBatchMapRenderer(
+                batch, loader, tileRenderer, buildingRenderer, renderers, false, shader);
+
+        MapRenderData map = mock(MapRenderData.class);
+        CameraProvider camera = new CameraProvider() {
+            private final OrthographicCamera cam = new OrthographicCamera();
+            private final ExtendViewport vp = new ExtendViewport(1, 1, cam);
+            {
+                vp.update(1, 1, true);
+                cam.update();
+            }
+
+            @Override
+            public com.badlogic.gdx.graphics.Camera getCamera() {
+                return cam;
+            }
+
+            @Override
+            public com.badlogic.gdx.utils.viewport.Viewport getViewport() {
+                return vp;
+            }
+        };
+
+        InOrder order = inOrder(batch);
+        renderer.render(map, camera);
+        order.verify(batch).setProjectionMatrix(any());
+        order.verify(batch).setShader(shader);
+        order.verify(batch).begin();
+        order.verify(batch).end();
+        order.verify(batch).setShader(null);
+
+        renderer.dispose();
+        verify(shader).dispose();
+    }
+
+    @Test
+    public void skipsShaderWhenNull() {
+        SpriteBatch batch = mock(SpriteBatch.class);
+        ResourceLoader loader = mock(ResourceLoader.class);
+        TileRenderer tileRenderer = mock(TileRenderer.class);
+        BuildingRenderer buildingRenderer = mock(BuildingRenderer.class);
+        ResourceRenderer resourceRenderer = mock(ResourceRenderer.class);
+        PlayerRenderer playerRenderer = mock(PlayerRenderer.class);
+        MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer);
+
+        SpriteBatchMapRenderer renderer = new SpriteBatchMapRenderer(
+                batch, loader, tileRenderer, buildingRenderer, renderers, false, null);
+
+        MapRenderData map = mock(MapRenderData.class);
+        CameraProvider camera = new CameraProvider() {
+            private final OrthographicCamera cam = new OrthographicCamera();
+            private final ExtendViewport vp = new ExtendViewport(1, 1, cam);
+            {
+                vp.update(1, 1, true);
+                cam.update();
+            }
+
+            @Override
+            public com.badlogic.gdx.graphics.Camera getCamera() {
+                return cam;
+            }
+
+            @Override
+            public com.badlogic.gdx.utils.viewport.Viewport getViewport() {
+                return vp;
+            }
+        };
+
+        renderer.render(map, camera);
+        verify(batch, never()).setShader(any());
+
+        renderer.dispose();
     }
 }


### PR DESCRIPTION
## Summary
- add `MapEntityRenderers` record for auxiliary renderers
- accept shader program in `SpriteBatchMapRenderer` and apply if provided
- update loading factory and benchmark
- test shader usage

## Testing
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684ea3b45e2883288c053882d0c2aa1d