### PR TITLE
feat: integrate shader plugin into map renderer

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRenderer.java
@@ -22,6 +22,7 @@ public final class LoadingSpriteMapRenderer implements MapRenderer, Disposable {
     private final CameraProvider cameraSystem;
     private final boolean cacheEnabled;
     private final Consumer<Float> progressCallback;
+    private final com.badlogic.gdx.graphics.glutils.ShaderProgram shader;
 
     private MapRenderer delegate;
 
@@ -31,7 +32,8 @@ public final class LoadingSpriteMapRenderer implements MapRenderer, Disposable {
             final ResourceLoader loaderToUse,
             final CameraProvider camera,
             final boolean cache,
-            final Consumer<Float> callback
+            final Consumer<Float> callback,
+            final com.badlogic.gdx.graphics.glutils.ShaderProgram shaderProgram
     ) {
         this.world = worldContext;
         this.spriteBatch = batchToUse;
@@ -39,6 +41,7 @@ public final class LoadingSpriteMapRenderer implements MapRenderer, Disposable {
         this.cameraSystem = camera;
         this.cacheEnabled = cache;
         this.progressCallback = callback;
+        this.shader = shaderProgram;
         // ensure mapper initialization for render systems
         worldContext.getMapper(MapComponent.class);
     }
@@ -89,7 +92,7 @@ public final class LoadingSpriteMapRenderer implements MapRenderer, Disposable {
                     buildingRenderer,
                     renderers,
                     cacheEnabled,
-                    null
+                    shader
             );
             if (progressCallback != null) {
                 progressCallback.accept(1f);

--- a/client/src/main/java/net/lapidist/colony/client/renderers/MapRendererFactory.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/MapRendererFactory.java
@@ -12,5 +12,5 @@ public interface MapRendererFactory {
      * @param world game world context
      * @return configured map renderer
      */
-    MapRenderer create(World world);
+    MapRenderer create(World world, net.lapidist.colony.client.graphics.ShaderPlugin plugin);
 }

--- a/client/src/main/java/net/lapidist/colony/client/renderers/SpriteMapRendererFactory.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/SpriteMapRendererFactory.java
@@ -7,6 +7,9 @@ import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.client.core.io.TextureAtlasResourceLoader;
 import net.lapidist.colony.client.systems.CameraProvider;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
+import net.lapidist.colony.client.graphics.ShaderManager;
+import net.lapidist.colony.client.graphics.ShaderPlugin;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import net.lapidist.colony.settings.GraphicsSettings;
 import net.lapidist.colony.settings.Settings;
 import org.slf4j.Logger;
@@ -51,7 +54,7 @@ public final class SpriteMapRendererFactory implements MapRendererFactory {
     }
 
     @Override
-    public MapRenderer create(final World world) {
+    public MapRenderer create(final World world, final ShaderPlugin plugin) {
         GraphicsSettings graphics;
         try {
             graphics = Settings.load().getGraphicsSettings();
@@ -65,13 +68,23 @@ public final class SpriteMapRendererFactory implements MapRendererFactory {
 
         CameraProvider cameraSystem = world.getSystem(PlayerCameraSystem.class);
 
+        ShaderProgram shader = null;
+        if (plugin != null && graphics.isShadersEnabled()) {
+            try {
+                shader = plugin.create(new ShaderManager());
+            } catch (Exception ex) {
+                LOGGER.warn("Shader plugin {} failed", plugin.getClass().getSimpleName(), ex);
+            }
+        }
+
         return new LoadingSpriteMapRenderer(
                 world,
                 batch,
                 resourceLoader,
                 cameraSystem,
                 graphics.isSpriteCacheEnabled(),
-                progressCallback
+                progressCallback,
+                shader
         );
     }
 }

--- a/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -9,6 +9,8 @@ import net.lapidist.colony.client.renderers.MapRendererFactory;
 import net.lapidist.colony.client.renderers.MapRenderer;
 import net.lapidist.colony.client.renderers.SpriteMapRendererFactory;
 import net.lapidist.colony.settings.Settings;
+import net.lapidist.colony.client.graphics.ShaderPluginLoader;
+import net.lapidist.colony.client.graphics.ShaderPlugin;
 import net.lapidist.colony.client.systems.ClearScreenSystem;
 import net.lapidist.colony.client.systems.CameraInputSystem;
 import net.lapidist.colony.client.systems.SelectionSystem;
@@ -185,10 +187,18 @@ public final class MapWorldBuilder {
         }
         builder.with(new PlayerCameraSystem());
 
+        ShaderPlugin plugin = null;
+        if (settings != null && settings.getGraphicsSettings().isShadersEnabled()) {
+            var plugins = new ShaderPluginLoader().loadPlugins();
+            if (!plugins.isEmpty()) {
+                plugin = plugins.get(0);
+            }
+        }
+
         World world = new World(builder.build());
         MapRenderSystem renderSystem = world.getSystem(MapRenderSystem.class);
         if (renderSystem != null) {
-            MapRenderer renderer = actualFactory.create(world);
+            MapRenderer renderer = actualFactory.create(world, plugin);
             renderSystem.setMapRenderer(renderer);
             renderSystem.setCameraProvider(world.getSystem(PlayerCameraSystem.class));
         }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/MapRendererFactoryTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/MapRendererFactoryTest.java
@@ -94,7 +94,7 @@ public class MapRendererFactoryTest {
                     "textures/textures.atlas",
                     p -> progressCalls.incrementAndGet()
             );
-            MapRenderer renderer = factory.create(world);
+            MapRenderer renderer = factory.create(world, null);
 
             assertNotNull(renderer);
             assertFalse(loader.updated);
@@ -119,7 +119,7 @@ public class MapRendererFactoryTest {
                     FileLocation.INTERNAL,
                     "textures/textures.atlas"
             );
-            MapRenderer renderer = factory.create(world);
+            MapRenderer renderer = factory.create(world, null);
 
             assertNotNull(renderer);
             assertFalse(loader.updated);
@@ -203,7 +203,7 @@ public class MapRendererFactoryTest {
                     "textures/textures.atlas",
                     progress::set
             );
-            MapRenderer renderer = factory.create(world);
+            MapRenderer renderer = factory.create(world, null);
 
             assertNotNull(renderer);
             renderer.render(null, null);
@@ -236,7 +236,7 @@ public class MapRendererFactoryTest {
                     FileLocation.INTERNAL,
                     "textures/missing.atlas"
             );
-            MapRenderer renderer = factory.create(world);
+            MapRenderer renderer = factory.create(world, null);
 
             assertNotNull(renderer);
         }


### PR DESCRIPTION
## Summary
- extend `MapRendererFactory` with shader plugin parameter
- compile shader in `SpriteMapRendererFactory` when provided
- pass shader program to `SpriteBatchMapRenderer` via `LoadingSpriteMapRenderer`
- select shader plugin in `MapWorldBuilder` and pass it to the factory
- adapt renderer factory tests

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684ea8a0d618832898833e6928ea138e