### PR TITLE
feat: persist mod metadata in saves

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/Colony.java
+++ b/client/src/main/java/net/lapidist/colony/client/Colony.java
@@ -55,7 +55,12 @@ public final class Colony extends Game {
         try {
             java.nio.file.Path file = Paths.get().getAutosave(saveName);
             if (java.nio.file.Files.exists(file)) {
-                MapState state = GameStateIO.load(file);
+                net.lapidist.colony.save.SaveData data = GameStateIO.loadData(file);
+                java.util.Set<String> ids = data.mods().stream().map(m -> m.id()).collect(java.util.stream.Collectors.toSet());
+                selectedMods = mods.stream()
+                        .filter(m -> ids.contains(m.metadata().id()))
+                        .toList();
+                MapState state = data.mapState();
                 startGame(saveName, state.width(), state.height());
             } else {
                 setScreen(new NewGameScreen(this));

--- a/core/src/main/java/net/lapidist/colony/base/ModMetadataUtil.java
+++ b/core/src/main/java/net/lapidist/colony/base/ModMetadataUtil.java
@@ -35,6 +35,6 @@ public final class ModMetadataUtil {
         String id = IDS.getOrDefault(cls.getName(), cls.getSimpleName());
         String version = Optional.ofNullable(cls.getPackage().getImplementationVersion())
                 .orElse("dev");
-        return new ModMetadata(id, version, List.of());
+        return new ModMetadata(id, version, new java.util.ArrayList<>());
     }
 }

--- a/core/src/main/java/net/lapidist/colony/mod/ModLoader.java
+++ b/core/src/main/java/net/lapidist/colony/mod/ModLoader.java
@@ -217,7 +217,7 @@ public final class ModLoader {
 
     private ModMetadata readMetadata(final BufferedReader reader) {
         Config config = ConfigFactory.parseReader(reader);
-        List<String> deps = config.hasPath("dependencies") ? config.getStringList("dependencies") : List.of();
+        List<String> deps = config.hasPath("dependencies") ? new java.util.ArrayList<>(config.getStringList("dependencies")) : new java.util.ArrayList<>();
         return new ModMetadata(config.getString("id"), config.getString("version"), deps);
     }
 

--- a/core/src/main/java/net/lapidist/colony/save/SaveData.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveData.java
@@ -2,6 +2,8 @@ package net.lapidist.colony.save;
 
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.serialization.KryoType;
+import net.lapidist.colony.mod.ModMetadata;
+import java.util.List;
 
 /**
  * Wrapper object persisted to disk containing save metadata and map state.
@@ -9,7 +11,16 @@ import net.lapidist.colony.serialization.KryoType;
  * @param version  the save format version
  * @param kryoHash hash used to validate serializer configuration
  * @param mapState the game state snapshot
+ * @param mods     list of loaded mod metadata
  */
 @KryoType
-public record SaveData(int version, int kryoHash, MapState mapState) {
+public record SaveData(int version, int kryoHash, MapState mapState, List<ModMetadata> mods) {
+
+    public SaveData {
+        mods = mods == null ? new java.util.ArrayList<>() : new java.util.ArrayList<>(mods);
+    }
+
+    public SaveData(final int version, final int kryoHash, final MapState mapState) {
+        this(version, kryoHash, mapState, new java.util.ArrayList<>());
+    }
 }

--- a/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
@@ -46,6 +46,7 @@ public final class SaveMigrator {
         register(new V30ToV31Migration());
         register(new V31ToV32Migration());
         register(new V32ToV33Migration());
+        register(new V33ToV34Migration());
     }
 
     private SaveMigrator() {

--- a/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
@@ -36,9 +36,10 @@ public enum SaveVersion {
     V30(30),
     V31(31),
     V32(32),
-    V33(33);
+    V33(33),
+    V34(34);
 
-    public static final SaveVersion CURRENT = V33;
+    public static final SaveVersion CURRENT = V34;
 
     private final int number;
 

--- a/core/src/main/java/net/lapidist/colony/save/V33ToV34Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V33ToV34Migration.java
@@ -1,0 +1,21 @@
+package net.lapidist.colony.save;
+
+import net.lapidist.colony.components.state.MapState;
+
+/** Identity migration for save version 33 to 34. */
+public final class V33ToV34Migration implements MapStateMigration {
+    @Override
+    public int fromVersion() {
+        return SaveVersion.V33.number();
+    }
+
+    @Override
+    public int toVersion() {
+        return SaveVersion.V34.number();
+    }
+
+    @Override
+    public MapState apply(final MapState state) {
+        return state.toBuilder().version(toVersion()).build();
+    }
+}

--- a/docs/save_format.md
+++ b/docs/save_format.md
@@ -1,6 +1,8 @@
 # Save Format
 
-Game state is serialized into a `SaveData` record containing the save version, a Kryo registration hash and the `MapState`. Files are written and read via `GameStateIO`.
+Game state is serialized into a `SaveData` record containing the save version, a Kryo registration hash, the `MapState` and the list of loaded mods. Files are written and read via `GameStateIO`.
+
+The `mods` field captures the `id` and `version` of every loaded mod when the save was created. When the game is loaded these mods are automatically restored if present on the system.
 
 ## SaveVersion
 

--- a/server/src/main/java/net/lapidist/colony/base/BaseAutosaveMod.java
+++ b/server/src/main/java/net/lapidist/colony/base/BaseAutosaveMod.java
@@ -13,6 +13,7 @@ public final class BaseAutosaveMod implements GameMod {
                 s.getAutosaveInterval(),
                 s.getSaveName(),
                 s::getMapState,
+                s::getModMetadata,
                 s.getStateLock()
         ));
     }

--- a/server/src/main/java/net/lapidist/colony/server/services/AutosaveService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/AutosaveService.java
@@ -8,6 +8,7 @@ import net.lapidist.colony.server.events.AutosaveStartEvent;
 import net.lapidist.colony.server.events.ShutdownSaveEvent;
 import net.mostlyoriginal.api.event.common.Event;
 import net.lapidist.colony.server.io.GameStateIO;
+import net.lapidist.colony.mod.ModMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,17 +32,20 @@ public final class AutosaveService {
     private final String saveName;
     private final Supplier<MapState> supplier;
     private final ReentrantLock lock;
+    private final Supplier<java.util.List<ModMetadata>> modsSupplier;
     private ScheduledExecutorService executor;
 
     public AutosaveService(
             final long intervalToUse,
             final String saveNameToUse,
             final Supplier<MapState> stateSupplier,
+            final Supplier<java.util.List<ModMetadata>> modsSupplierToUse,
             final ReentrantLock lockToUse
     ) {
         this.interval = intervalToUse;
         this.saveName = saveNameToUse;
         this.supplier = stateSupplier;
+        this.modsSupplier = modsSupplierToUse;
         this.lock = lockToUse;
     }
 
@@ -87,7 +91,7 @@ public final class AutosaveService {
             Path file = Paths.get().getAutosave(saveName);
             Events.dispatch(new AutosaveStartEvent(file));
             Events.update();
-            GameStateIO.save(mapState, file);
+            GameStateIO.save(mapState, modsSupplier.get(), file);
             long size = Files.size(file);
             Events.dispatch(creator.apply(file, size));
             Events.update();

--- a/tests/src/test/java/net/lapidist/colony/tests/server/AutosaveServiceTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/AutosaveServiceTest.java
@@ -39,6 +39,7 @@ public class AutosaveServiceTest {
                     0,
                     "err",
                     MapState::new,
+                    java.util.List::of,
                     new ReentrantLock()
             );
             service.stop();


### PR DESCRIPTION
## Summary
- record mod metadata in SaveData
- include mods when saving and loading with GameStateIO
- autosave service supplies active mods to saves
- load saved mods when starting server or client
- document the mods list in save_format
- bump save version

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test` *(fails: 8 tests)*


------
https://chatgpt.com/codex/tasks/task_e_684eaa1d6f488328a759f0b7cc346ec2