### PR TITLE
Add shader plugin documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Configuration details are in [docs/configuration.md](docs/configuration.md).
 Performance benchmark numbers are tracked in [docs/performance.md](docs/performance.md).
 Translation instructions are in [docs/i18n.md](docs/i18n.md).
 Scenario test utilities are covered in [docs/tests.md](docs/tests.md).
+Shader plugins are described in [docs/shaders.md](docs/shaders.md).
 
 ## License
 This project is licensed under the [MIT License](LICENSE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,3 +22,4 @@ This directory contains all guides for the Colony project. References are groupe
 - [Performance Notes](performance.md) – benchmarking of data structures and renderer performance.
   Update the numbers whenever benchmarks change and strive to keep them from increasing.
 - [Scenario Test Harness](tests.md) – explains `GameSimulation` and the headless test setup.
+- [Shader Plugin Guide](shaders.md) – how to register custom GLSL programs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,6 +93,8 @@ Rendering code is decoupled from map creation through the `MapRendererFactory`
 interface. `MapWorldBuilder` accepts a factory instance when building the world
 and defaults to a sprite batch based implementation. The active factory can be
 configured via the `graphics.renderer` setting.
+Optional GLSL effects can be added through shader plugins as explained in
+[shaders.md](shaders.md).
 
 `MapRenderData` acts as a lightweight view of the map state for renderers. A
 `MapRenderDataSystem` converts the ECS `MapComponent` into immutable

--- a/docs/shaders.md
+++ b/docs/shaders.md
@@ -1,0 +1,59 @@
+# Shader Plugins
+
+Colony supports pluggable GLSL programs so experiments can be developed
+outside the main repository. Plugins implement the small
+`ShaderPlugin` interface from the client module:
+
+```java
+public interface ShaderPlugin {
+    ShaderProgram create(ShaderManager manager);
+    default void dispose() { }
+}
+```
+
+`create` receives a `ShaderManager` which helps compile a vertex and
+fragment shader. The method may return `null` when the program cannot be
+loaded, for example if the required sources are missing.
+
+## External shader folder
+
+Plugins normally load GLSL sources from the `shaders/` directory inside
+the game's external data folder (typically `~/.colony`). Place your
+`*.vert` and `*.frag` files in this directory so they can be read with
+`FileLocation.EXTERNAL`.
+
+## Service registration
+
+Implementations are discovered through Java's `ServiceLoader`. Each
+plugin must be listed in
+`META-INF/services/net.lapidist.colony.client.graphics.ShaderPlugin` as
+a single fully qualified class name. The default build already contains
+an entry for `NullShaderPlugin`.
+
+## Selecting a plugin
+
+The chosen shader is stored in the `graphics.shaderPlugin` setting. It
+holds the class name from the service file. This value can be edited in
+`settings.properties` or selected through the graphics settings screen.
+
+## Example
+
+A minimal grayscale plugin loading `gray.vert` and `gray.frag` from the
+external shader folder could look like:
+
+```java
+public final class GrayShaderPlugin implements ShaderPlugin {
+    @Override
+    public ShaderProgram create(ShaderManager manager) {
+        try {
+            return manager.load(FileLocation.EXTERNAL,
+                    "shaders/gray.vert", "shaders/gray.frag");
+        } catch (IOException e) {
+            return null;
+        }
+    }
+}
+```
+
+Add `GrayShaderPlugin` to the service descriptor and set
+`graphics.shaderPlugin` to `com.example.GrayShaderPlugin` to enable it.


### PR DESCRIPTION
## Summary
- document shader plugin API and usage
- link shader docs from README and architecture guide
- reference shader guide in documentation index

## Testing
- `./scripts/check.sh`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684eae5f6e188328844fae47a780e9a7