### PR TITLE
feat: add plugin identifiers

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/graphics/NullShaderPlugin.java
+++ b/client/src/main/java/net/lapidist/colony/client/graphics/NullShaderPlugin.java
@@ -10,4 +10,14 @@ public final class NullShaderPlugin implements ShaderPlugin {
     public ShaderProgram create(final ShaderManager manager) {
         return null;
     }
+
+    @Override
+    public String id() {
+        return "none";
+    }
+
+    @Override
+    public String displayName() {
+        return "None";
+    }
 }

--- a/client/src/main/java/net/lapidist/colony/client/graphics/ShaderPlugin.java
+++ b/client/src/main/java/net/lapidist/colony/client/graphics/ShaderPlugin.java
@@ -16,6 +16,20 @@ public interface ShaderPlugin {
     ShaderProgram create(ShaderManager manager);
 
     /**
+     * Unique identifier for this plugin used when persisting user settings.
+     *
+     * @return stable identifier string
+     */
+    String id();
+
+    /**
+     * User visible name describing the plugin.
+     *
+     * @return display name for UI
+     */
+    String displayName();
+
+    /**
      * Dispose any resources used by this plugin.
      */
     default void dispose() {

--- a/client/src/main/java/net/lapidist/colony/client/screens/GraphicsSettingsScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/GraphicsSettingsScreen.java
@@ -25,6 +25,7 @@ public final class GraphicsSettingsScreen extends BaseScreen {
     private final CheckBox mipBox;
     private final CheckBox afBox;
     private final SelectBox<String> shaderBox;
+    private final com.badlogic.gdx.utils.Array<String> pluginIds;
     private final CheckBox cacheBox;
     private final SelectBox<String> rendererBox;
     private static final float PADDING = 10f;
@@ -48,13 +49,19 @@ public final class GraphicsSettingsScreen extends BaseScreen {
         afBox.setChecked(graphics.isAnisotropicFilteringEnabled());
         shaderBox = new SelectBox<>(getSkin());
         var plugins = new ShaderPluginLoader().loadPlugins();
-        com.badlogic.gdx.utils.Array<String> ids = new com.badlogic.gdx.utils.Array<>();
-        ids.add("none");
+        pluginIds = new com.badlogic.gdx.utils.Array<>();
+        com.badlogic.gdx.utils.Array<String> names = new com.badlogic.gdx.utils.Array<>();
+        pluginIds.add("none");
+        names.add("None");
         for (var p : plugins) {
-            ids.add(p.getClass().getName());
+            pluginIds.add(p.id());
+            names.add(p.displayName());
         }
-        shaderBox.setItems(ids);
-        shaderBox.setSelected(graphics.getShaderPlugin());
+        shaderBox.setItems(names);
+        int selected = pluginIds.indexOf(graphics.getShaderPlugin(), false);
+        if (selected >= 0) {
+            shaderBox.setSelectedIndex(selected);
+        }
         cacheBox = new CheckBox(I18n.get("graphics.spritecache"), getSkin());
         cacheBox.setChecked(graphics.isSpriteCacheEnabled());
 
@@ -89,7 +96,8 @@ public final class GraphicsSettingsScreen extends BaseScreen {
                 graphics.setAntialiasingEnabled(aaBox.isChecked());
                 graphics.setMipMapsEnabled(mipBox.isChecked());
                 graphics.setAnisotropicFilteringEnabled(afBox.isChecked());
-                graphics.setShaderPlugin(shaderBox.getSelected());
+                int idx = shaderBox.getSelectedIndex();
+                graphics.setShaderPlugin(pluginIds.get(idx));
                 graphics.setSpriteCacheEnabled(cacheBox.isChecked());
                 graphics.setRenderer(rendererBox.getSelected());
                 save();

--- a/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -192,7 +192,7 @@ public final class MapWorldBuilder {
             String id = settings.getGraphicsSettings().getShaderPlugin();
             if (!"none".equals(id)) {
                 for (ShaderPlugin p : new ShaderPluginLoader().loadPlugins()) {
-                    if (p.getClass().getName().equals(id)) {
+                    if (p.id().equals(id)) {
                         plugin = p;
                         break;
                     }

--- a/tests/src/test/java/net/lapidist/colony/tests/graphics/ShaderPluginLoaderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/graphics/ShaderPluginLoaderTest.java
@@ -19,7 +19,10 @@ public class ShaderPluginLoaderTest {
         ShaderPluginLoader loader = new ShaderPluginLoader();
         List<ShaderPlugin> plugins = loader.loadPlugins();
         assertFalse(plugins.isEmpty());
-        assertTrue(plugins.get(0) instanceof NullShaderPlugin);
-        assertNull(plugins.get(0).create(new net.lapidist.colony.client.graphics.ShaderManager()));
+        ShaderPlugin plugin = plugins.get(0);
+        assertTrue(plugin instanceof NullShaderPlugin);
+        assertEquals("none", plugin.id());
+        assertEquals("None", plugin.displayName());
+        assertNull(plugin.create(new net.lapidist.colony.client.graphics.ShaderManager()));
     }
 }


### PR DESCRIPTION
## Summary
- expand ShaderPlugin API with `id` and `displayName`
- expose identifier metadata from `NullShaderPlugin`
- use plugin names in GraphicsSettingsScreen but save identifiers
- resolve plugins via identifier in MapWorldBuilder
- verify identifier metadata in ShaderPluginLoaderTest

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684eae55269c8328b5e606757da9e1db