### PR TITLE
fix: prevent map state concurrency errors

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
+++ b/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
@@ -276,7 +276,7 @@ public final class GameClient extends AbstractMessageEndpoint implements AutoClo
     }
 
     private static java.util.Map<ChunkPos, MapChunkData> buildChunks(final java.util.Map<TilePos, TileData> tiles) {
-        java.util.Map<ChunkPos, MapChunkData> chunks = new java.util.HashMap<>();
+        java.util.Map<ChunkPos, MapChunkData> chunks = new java.util.concurrent.ConcurrentHashMap<>();
         for (var entry : tiles.entrySet()) {
             TilePos pos = entry.getKey();
             TileData data = entry.getValue();

--- a/core/src/main/java/net/lapidist/colony/components/state/MapState.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/MapState.java
@@ -6,7 +6,7 @@ import net.lapidist.colony.save.SaveVersion;
 import net.lapidist.colony.map.MapChunkData;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -37,7 +37,7 @@ public record MapState(
                 "save-" + UUID.randomUUID(),
                 null,
                 null,
-                new HashMap<>(),
+                new ConcurrentHashMap<>(),
                 new ArrayList<>(),
                 new ResourceData(),
                 new PlayerPosition(DEFAULT_WIDTH / 2, DEFAULT_HEIGHT / 2),

--- a/core/src/main/java/net/lapidist/colony/map/MapChunkData.java
+++ b/core/src/main/java/net/lapidist/colony/map/MapChunkData.java
@@ -4,7 +4,7 @@ import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.serialization.KryoType;
 
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
 import java.util.Random;
 
@@ -17,7 +17,7 @@ public final class MapChunkData {
     public static final int CHUNK_SIZE = 32;
     private static final double NOISE_SCALE = 0.1;
 
-    private final Map<TilePos, TileData> tiles = new HashMap<>();
+    private final Map<TilePos, TileData> tiles = new ConcurrentHashMap<>();
     private final long seed;
     private transient PerlinNoise noise;
     private final int baseX;

--- a/core/src/main/java/net/lapidist/colony/save/V6ToV7Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V6ToV7Migration.java
@@ -6,7 +6,7 @@ import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.components.state.ChunkPos;
 import net.lapidist.colony.map.MapChunkData;
 
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
 
 /** Migration from save version 6 to version 7 converting tile maps to chunks. */
@@ -27,7 +27,7 @@ public final class V6ToV7Migration implements MapStateMigration {
         if (!existing.isEmpty() && existing.keySet().iterator().next() instanceof ChunkPos) {
             return state.toBuilder().version(toVersion()).build();
         }
-        Map<ChunkPos, MapChunkData> chunks = new HashMap<>();
+        Map<ChunkPos, MapChunkData> chunks = new ConcurrentHashMap<>();
         for (Map.Entry<?, ?> e : existing.entrySet()) {
             Object key = e.getKey();
             Object value = e.getValue();


### PR DESCRIPTION
## Summary
- use thread-safe maps for chunks and tiles
- adjust migrations and network chunk builder

## Testing
- `./gradlew spotlessApply`
- `./gradlew tests:copyAssets`
- `./gradlew clean test` *(fails: Connected, but timed out during TCP registration)*
- `./gradlew check` *(fails: Checkstyle rule violations were found)*
- `./gradlew codeCoverageReport` *(fails: Process 'Gradle Test Executor 7' finished with non-zero exit value 134)*

------
https://chatgpt.com/codex/tasks/task_e_684eb071be188328bcf135308bb7f49e