### PR TITLE
fix: prevent concurrent modification when loading map

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/Colony.java
+++ b/client/src/main/java/net/lapidist/colony/client/Colony.java
@@ -56,10 +56,17 @@ public final class Colony extends Game {
             java.nio.file.Path file = Paths.get().getAutosave(saveName);
             if (java.nio.file.Files.exists(file)) {
                 net.lapidist.colony.save.SaveData data = GameStateIO.loadData(file);
-                java.util.Set<String> ids = data.mods().stream().map(m -> m.id()).collect(java.util.stream.Collectors.toSet());
-                selectedMods = mods.stream()
-                        .filter(m -> ids.contains(m.metadata().id()))
-                        .toList();
+                java.util.Set<String> ids = data.mods()
+                        .stream()
+                        .map(m -> m.id())
+                        .collect(java.util.stream.Collectors.toSet());
+                if (mods != null) {
+                    selectedMods = mods.stream()
+                            .filter(m -> ids.contains(m.metadata().id()))
+                            .toList();
+                } else {
+                    selectedMods = java.util.Collections.emptyList();
+                }
                 MapState state = data.mapState();
                 startGame(saveName, state.width(), state.height());
             } else {

--- a/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
+++ b/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
@@ -276,7 +276,7 @@ public final class GameClient extends AbstractMessageEndpoint implements AutoClo
     }
 
     private static java.util.Map<ChunkPos, MapChunkData> buildChunks(final java.util.Map<TilePos, TileData> tiles) {
-        java.util.Map<ChunkPos, MapChunkData> chunks = new java.util.HashMap<>();
+        java.util.Map<ChunkPos, MapChunkData> chunks = new java.util.concurrent.ConcurrentHashMap<>();
         for (var entry : tiles.entrySet()) {
             TilePos pos = entry.getKey();
             TileData data = entry.getValue();

--- a/core/src/main/java/net/lapidist/colony/base/ModMetadataUtil.java
+++ b/core/src/main/java/net/lapidist/colony/base/ModMetadataUtil.java
@@ -1,6 +1,5 @@
 package net.lapidist.colony.base;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 

--- a/core/src/main/java/net/lapidist/colony/components/state/MapState.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/MapState.java
@@ -6,9 +6,9 @@ import net.lapidist.colony.save.SaveVersion;
 import net.lapidist.colony.map.MapChunkData;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.UUID;
 
 @KryoType
@@ -37,7 +37,7 @@ public record MapState(
                 "save-" + UUID.randomUUID(),
                 null,
                 null,
-                new HashMap<>(),
+                new ConcurrentHashMap<>(),
                 new ArrayList<>(),
                 new ResourceData(),
                 new PlayerPosition(DEFAULT_WIDTH / 2, DEFAULT_HEIGHT / 2),

--- a/core/src/main/java/net/lapidist/colony/map/MapChunkData.java
+++ b/core/src/main/java/net/lapidist/colony/map/MapChunkData.java
@@ -4,8 +4,8 @@ import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.serialization.KryoType;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Random;
 
 /**
@@ -17,7 +17,7 @@ public final class MapChunkData {
     public static final int CHUNK_SIZE = 32;
     private static final double NOISE_SCALE = 0.1;
 
-    private final Map<TilePos, TileData> tiles = new HashMap<>();
+    private final Map<TilePos, TileData> tiles = new ConcurrentHashMap<>();
     private final long seed;
     private transient PerlinNoise noise;
     private final int baseX;

--- a/core/src/main/java/net/lapidist/colony/mod/ModLoader.java
+++ b/core/src/main/java/net/lapidist/colony/mod/ModLoader.java
@@ -217,7 +217,9 @@ public final class ModLoader {
 
     private ModMetadata readMetadata(final BufferedReader reader) {
         Config config = ConfigFactory.parseReader(reader);
-        List<String> deps = config.hasPath("dependencies") ? new java.util.ArrayList<>(config.getStringList("dependencies")) : new java.util.ArrayList<>();
+        List<String> deps = config.hasPath("dependencies")
+                ? new java.util.ArrayList<>(config.getStringList("dependencies"))
+                : new java.util.ArrayList<>();
         return new ModMetadata(config.getString("id"), config.getString("version"), deps);
     }
 

--- a/core/src/main/java/net/lapidist/colony/save/SaveData.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveData.java
@@ -20,7 +20,7 @@ public record SaveData(int version, int kryoHash, MapState mapState, List<ModMet
         mods = mods == null ? new java.util.ArrayList<>() : new java.util.ArrayList<>(mods);
     }
 
-    public SaveData(final int version, final int kryoHash, final MapState mapState) {
-        this(version, kryoHash, mapState, new java.util.ArrayList<>());
+    public SaveData(final int versionValue, final int kryoHashValue, final MapState state) {
+        this(versionValue, kryoHashValue, state, new java.util.ArrayList<>());
     }
 }

--- a/core/src/main/java/net/lapidist/colony/save/V6ToV7Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V6ToV7Migration.java
@@ -6,7 +6,6 @@ import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.components.state.ChunkPos;
 import net.lapidist.colony.map.MapChunkData;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /** Migration from save version 6 to version 7 converting tile maps to chunks. */
@@ -27,7 +26,7 @@ public final class V6ToV7Migration implements MapStateMigration {
         if (!existing.isEmpty() && existing.keySet().iterator().next() instanceof ChunkPos) {
             return state.toBuilder().version(toVersion()).build();
         }
-        Map<ChunkPos, MapChunkData> chunks = new HashMap<>();
+        Map<ChunkPos, MapChunkData> chunks = new java.util.concurrent.ConcurrentHashMap<>();
         for (Map.Entry<?, ?> e : existing.entrySet()) {
             Object key = e.getKey();
             Object value = e.getValue();

--- a/core/src/main/java/net/lapidist/colony/serialization/SerializationRegistrar.java
+++ b/core/src/main/java/net/lapidist/colony/serialization/SerializationRegistrar.java
@@ -44,6 +44,7 @@ public final class SerializationRegistrar {
         kryo.register(java.util.ArrayList.class);
         kryo.register(java.util.List.class);
         kryo.register(java.util.HashMap.class);
+        kryo.register(java.util.concurrent.ConcurrentHashMap.class);
         com.esotericsoftware.kryo.serializers.ImmutableCollectionsSerializers.registerSerializers(kryo);
         kryo.register(java.util.Map.class);
         kryo.register(byte[].class);

--- a/server/src/main/java/net/lapidist/colony/server/GameServer.java
+++ b/server/src/main/java/net/lapidist/colony/server/GameServer.java
@@ -192,15 +192,16 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
             mapState = data.mapState();
             if (mods == null) {
                 mods = new java.util.ArrayList<>();
+                boolean useAll = data.mods().isEmpty();
                 for (GameMod builtin : java.util.ServiceLoader.load(GameMod.class)) {
                     ModMetadata meta = ModMetadataUtil.builtinMetadata(builtin.getClass());
-                    if (data.mods().stream().anyMatch(m -> m.id().equals(meta.id()))) {
+                    if (useAll || data.mods().stream().anyMatch(m -> m.id().equals(meta.id()))) {
                         mods.add(new LoadedMod(builtin, meta));
                     }
                 }
                 java.util.List<LoadedMod> loaded = new ModLoader(Paths.get()).loadMods();
                 for (LoadedMod mod : loaded) {
-                    if (data.mods().stream().anyMatch(m -> m.id().equals(mod.metadata().id()))) {
+                    if (useAll || data.mods().stream().anyMatch(m -> m.id().equals(mod.metadata().id()))) {
                         mods.add(mod);
                     }
                 }

--- a/tests/src/test/java/net/lapidist/colony/tests/components/ConcurrentCollectionsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/components/ConcurrentCollectionsTest.java
@@ -1,0 +1,19 @@
+package net.lapidist.colony.tests.components;
+
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.map.MapChunkData;
+import org.junit.Test;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.Assert.assertTrue;
+
+public class ConcurrentCollectionsTest {
+    @Test
+    public void usesConcurrentMaps() {
+        MapState state = new MapState();
+        assertTrue(state.chunks() instanceof ConcurrentHashMap);
+        MapChunkData chunk = new MapChunkData();
+        assertTrue(chunk.getTiles() instanceof ConcurrentHashMap);
+    }
+}


### PR DESCRIPTION
## Summary
- register `ConcurrentHashMap` with Kryo
- load all mods when autosave lacks mod metadata

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684eb42146f48328af8a4fda7b0caef2