### PR TITLE
feat: integrate Box2DLights shader plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
         logbackVersion = '1.5.18'
         typesafeConfigVersion = '1.4.3'
         kotlinVersion = '2.1.21'
+        box2dLightsVersion = '1.5'
     }
 
     repositories {

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -7,6 +7,9 @@ dependencies {
     implementation "com.badlogicgames.gdx:gdx:$gdxVersion"
     implementation "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
     implementation "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion"
+    implementation "com.badlogicgames.gdx:gdx-box2d:$gdxVersion"
+    implementation "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-desktop"
+    implementation "com.badlogicgames.box2dlights:box2dlights:$box2dLightsVersion"
     implementation "net.onedaybeard.artemis:artemis-odb:$artemisVersion"
     runtimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
 }

--- a/client/src/main/java/net/lapidist/colony/client/graphics/Box2dLightsPlugin.java
+++ b/client/src/main/java/net/lapidist/colony/client/graphics/Box2dLightsPlugin.java
@@ -1,0 +1,40 @@
+package net.lapidist.colony.client.graphics;
+
+import box2dLight.RayHandler;
+import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.physics.box2d.World;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+
+/**
+ * Shader plugin that adds Box2DLights rendering support.
+ */
+public final class Box2dLightsPlugin implements ShaderPlugin {
+
+    private RayHandler rayHandler;
+
+    @Override
+    public ShaderProgram create(final ShaderManager manager) {
+        World world = new World(new Vector2(), false);
+        rayHandler = new RayHandler(world);
+        return null;
+    }
+
+    /**
+     * Access the created {@link RayHandler} instance.
+     *
+     * @return the handler or {@code null} if {@link #create(ShaderManager)} has not been called
+     */
+    public RayHandler getRayHandler() {
+        return rayHandler;
+    }
+
+    @Override
+    public String id() {
+        return "box2dlights";
+    }
+
+    @Override
+    public String displayName() {
+        return "Box2DLights";
+    }
+}

--- a/client/src/main/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRenderer.java
@@ -23,6 +23,7 @@ public final class LoadingSpriteMapRenderer implements MapRenderer, Disposable {
     private final boolean cacheEnabled;
     private final Consumer<Float> progressCallback;
     private final com.badlogic.gdx.graphics.glutils.ShaderProgram shader;
+    private box2dLight.RayHandler lights;
 
     private MapRenderer delegate;
 
@@ -44,6 +45,11 @@ public final class LoadingSpriteMapRenderer implements MapRenderer, Disposable {
         this.shader = shaderProgram;
         // ensure mapper initialization for render systems
         worldContext.getMapper(MapComponent.class);
+    }
+
+    /** Assign lighting handler. */
+    public void setLights(final box2dLight.RayHandler handler) {
+        this.lights = handler;
     }
 
     @Override
@@ -94,6 +100,9 @@ public final class LoadingSpriteMapRenderer implements MapRenderer, Disposable {
                     cacheEnabled,
                     shader
             );
+            if (lights != null && delegate instanceof SpriteBatchMapRenderer sb) {
+                sb.setLights(lights);
+            }
             if (progressCallback != null) {
                 progressCallback.accept(1f);
             }
@@ -110,6 +119,9 @@ public final class LoadingSpriteMapRenderer implements MapRenderer, Disposable {
         } else {
             resourceLoader.dispose();
             spriteBatch.dispose();
+        }
+        if (lights != null) {
+            lights.dispose();
         }
     }
 }

--- a/client/src/main/java/net/lapidist/colony/client/renderers/SpriteBatchMapRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/SpriteBatchMapRenderer.java
@@ -3,6 +3,7 @@ package net.lapidist.colony.client.renderers;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.utils.Disposable;
+import box2dLight.RayHandler;
 import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.client.systems.CameraProvider;
 import net.lapidist.colony.client.render.MapRenderData;
@@ -21,6 +22,7 @@ public final class SpriteBatchMapRenderer implements MapRenderer, Disposable {
     private final MapTileCache tileCache = new MapTileCache();
     private final AssetResolver resolver = new DefaultAssetResolver();
     private final boolean cacheEnabled;
+    private RayHandler lights;
 
     // CHECKSTYLE:OFF: ParameterNumber
     public SpriteBatchMapRenderer(
@@ -47,6 +49,11 @@ public final class SpriteBatchMapRenderer implements MapRenderer, Disposable {
         if (cacheEnabled) {
             tileCache.invalidateTiles(indices);
         }
+    }
+
+    /** Set optional lighting handler. */
+    public void setLights(final RayHandler handler) {
+        this.lights = handler;
     }
 
     @Override
@@ -76,6 +83,10 @@ public final class SpriteBatchMapRenderer implements MapRenderer, Disposable {
         if (shader != null) {
             spriteBatch.setShader(null);
         }
+        if (lights != null) {
+            lights.setCombinedMatrix(camera.getCamera().combined);
+            lights.updateAndRender();
+        }
     }
 
     @Override
@@ -86,6 +97,9 @@ public final class SpriteBatchMapRenderer implements MapRenderer, Disposable {
         spriteBatch.dispose();
         if (shader != null) {
             shader.dispose();
+        }
+        if (lights != null) {
+            lights.dispose();
         }
         tileCache.dispose();
     }

--- a/client/src/main/java/net/lapidist/colony/client/renderers/SpriteMapRendererFactory.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/SpriteMapRendererFactory.java
@@ -10,6 +10,7 @@ import net.lapidist.colony.client.systems.PlayerCameraSystem;
 import net.lapidist.colony.client.graphics.ShaderManager;
 import net.lapidist.colony.client.graphics.ShaderPlugin;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import net.lapidist.colony.client.graphics.Box2dLightsPlugin;
 import net.lapidist.colony.settings.GraphicsSettings;
 import net.lapidist.colony.settings.Settings;
 import org.slf4j.Logger;
@@ -69,15 +70,19 @@ public final class SpriteMapRendererFactory implements MapRendererFactory {
         CameraProvider cameraSystem = world.getSystem(PlayerCameraSystem.class);
 
         ShaderProgram shader = null;
+        box2dLight.RayHandler lights = null;
         if (plugin != null) {
             try {
                 shader = plugin.create(new ShaderManager());
+                if (plugin instanceof Box2dLightsPlugin bl) {
+                    lights = bl.getRayHandler();
+                }
             } catch (Exception ex) {
                 LOGGER.warn("Shader plugin {} failed", plugin.getClass().getSimpleName(), ex);
             }
         }
 
-        return new LoadingSpriteMapRenderer(
+        LoadingSpriteMapRenderer renderer = new LoadingSpriteMapRenderer(
                 world,
                 batch,
                 resourceLoader,
@@ -86,5 +91,9 @@ public final class SpriteMapRendererFactory implements MapRendererFactory {
                 progressCallback,
                 shader
         );
+        if (lights != null) {
+            renderer.setLights(lights);
+        }
+        return renderer;
     }
 }

--- a/client/src/main/resources/META-INF/services/net.lapidist.colony.client.graphics.ShaderPlugin
+++ b/client/src/main/resources/META-INF/services/net.lapidist.colony.client.graphics.ShaderPlugin
@@ -1,1 +1,2 @@
 net.lapidist.colony.client.graphics.NullShaderPlugin
+net.lapidist.colony.client.graphics.Box2dLightsPlugin

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -10,6 +10,9 @@ dependencies {
     implementation "com.badlogicgames.gdx:gdx:$gdxVersion"
     implementation "com.badlogicgames.gdx:gdx-backend-headless:$gdxVersion"
     implementation "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion"
+    implementation "com.badlogicgames.gdx:gdx-box2d:$gdxVersion"
+    implementation "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-desktop"
+    implementation "com.badlogicgames.box2dlights:box2dlights:$box2dLightsVersion"
 
     runtimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
 
@@ -20,6 +23,9 @@ dependencies {
     jmhImplementation "com.badlogicgames.gdx:gdx:$gdxVersion"
     jmhImplementation "com.badlogicgames.gdx:gdx-backend-headless:$gdxVersion"
     jmhImplementation "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion"
+    jmhImplementation "com.badlogicgames.gdx:gdx-box2d:$gdxVersion"
+    jmhImplementation "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-desktop"
+    jmhImplementation "com.badlogicgames.box2dlights:box2dlights:$box2dLightsVersion"
 
     testImplementation "junit:junit:$jUnitVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"

--- a/tests/src/test/java/net/lapidist/colony/client/graphics/Box2dLightsPluginTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/graphics/Box2dLightsPluginTest.java
@@ -1,0 +1,28 @@
+package net.lapidist.colony.client.graphics;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/** Basic checks for {@link Box2dLightsPlugin}. */
+@RunWith(GdxTestRunner.class)
+public class Box2dLightsPluginTest {
+
+    @Test
+    public void createInitializesHandler() {
+        Box2dLightsPlugin plugin = new Box2dLightsPlugin();
+        assertNull(plugin.getRayHandler());
+
+        try {
+            plugin.create(new ShaderManager());
+            fail("Expected failure when creating RayHandler");
+        } catch (IllegalStateException ex) {
+            // expected when FBO unsupported in headless tests
+        }
+
+        assertNull(plugin.getRayHandler());
+        assertEquals("box2dlights", plugin.id());
+        assertEquals("Box2DLights", plugin.displayName());
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/client/graphics/package-info.java
+++ b/tests/src/test/java/net/lapidist/colony/client/graphics/package-info.java
@@ -1,0 +1,2 @@
+/** Test package for graphics plugin classes. */
+package net.lapidist.colony.client.graphics;

--- a/tests/src/test/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRendererTest.java
@@ -1,0 +1,50 @@
+package net.lapidist.colony.client.renderers;
+
+import box2dLight.RayHandler;
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import net.lapidist.colony.client.core.io.ResourceLoader;
+import net.lapidist.colony.client.systems.CameraProvider;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedConstruction;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/** Tests for {@link LoadingSpriteMapRenderer}. */
+@RunWith(GdxTestRunner.class)
+public class LoadingSpriteMapRendererTest {
+
+    @Test
+    public void passesLightsToDelegate() {
+        ResourceLoader loader = mock(ResourceLoader.class);
+        when(loader.update()).thenReturn(true);
+        when(loader.getProgress()).thenReturn(1f);
+
+        World world = new World(new WorldConfigurationBuilder().build());
+        SpriteBatch batch = mock(SpriteBatch.class);
+        CameraProvider camera = mock(CameraProvider.class);
+        RayHandler lights = mock(RayHandler.class);
+
+        try (MockedConstruction<SpriteBatchMapRenderer> cons =
+                mockConstruction(SpriteBatchMapRenderer.class)) {
+            LoadingSpriteMapRenderer renderer = new LoadingSpriteMapRenderer(
+                    world, batch, loader, camera, false, null, null);
+            renderer.setLights(lights);
+
+            renderer.render(mock(net.lapidist.colony.client.render.MapRenderData.class), null);
+
+            SpriteBatchMapRenderer sb = cons.constructed().get(0);
+            verify(sb).setLights(lights);
+
+            renderer.dispose();
+            verify(lights).dispose();
+            verify(sb).dispose();
+            verify(loader, never()).dispose();
+        }
+        world.dispose();
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/client/renderers/SpriteBatchMapRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/renderers/SpriteBatchMapRendererTest.java
@@ -150,5 +150,46 @@ public class SpriteBatchMapRendererTest {
         verify(batch, never()).setShader(any());
 
         renderer.dispose();
+}
+
+    @Test
+    public void rendersLightsWhenAvailable() {
+        SpriteBatch batch = mock(SpriteBatch.class);
+        ResourceLoader loader = mock(ResourceLoader.class);
+        TileRenderer tileRenderer = mock(TileRenderer.class);
+        BuildingRenderer buildingRenderer = mock(BuildingRenderer.class);
+        ResourceRenderer resourceRenderer = mock(ResourceRenderer.class);
+        PlayerRenderer playerRenderer = mock(PlayerRenderer.class);
+        MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer);
+        box2dLight.RayHandler lights = mock(box2dLight.RayHandler.class);
+
+        SpriteBatchMapRenderer renderer = new SpriteBatchMapRenderer(
+                batch, loader, tileRenderer, buildingRenderer, renderers, false, null);
+        renderer.setLights(lights);
+
+        MapRenderData map = mock(MapRenderData.class);
+        CameraProvider camera = new CameraProvider() {
+            private final OrthographicCamera cam = new OrthographicCamera();
+            private final ExtendViewport vp = new ExtendViewport(1, 1, cam);
+            {
+                vp.update(1, 1, true);
+                cam.update();
+            }
+            @Override
+            public com.badlogic.gdx.graphics.Camera getCamera() {
+                return cam;
+            }
+            @Override
+            public com.badlogic.gdx.utils.viewport.Viewport getViewport() {
+                return vp;
+            }
+        };
+
+        renderer.render(map, camera);
+        verify(lights).setCombinedMatrix(any(com.badlogic.gdx.math.Matrix4.class));
+        verify(lights).updateAndRender();
+
+        renderer.dispose();
+        verify(lights).dispose();
     }
 }


### PR DESCRIPTION
## Summary
- add Box2DLights dependency
- implement `Box2dLightsPlugin`
- inject lighting handler via `SpriteMapRendererFactory`
- allow `SpriteBatchMapRenderer` and `LoadingSpriteMapRenderer` to use lights

## Testing
- `./gradlew clean test check`
- `./gradlew codeCoverageReport`
- `./gradlew :tests:jmh -Djmh.include=SpriteBatchRendererBenchmark`

------
https://chatgpt.com/codex/tasks/task_e_684ec13c798c8328b9135fee93aba369