### PR TITLE
refactor(core): move I18n util to shared package

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/Colony.java
+++ b/client/src/main/java/net/lapidist/colony/client/Colony.java
@@ -8,7 +8,7 @@ import net.lapidist.colony.client.screens.MainMenuScreen;
 import net.lapidist.colony.client.screens.LoadingScreen;
 import net.lapidist.colony.client.screens.ErrorScreen;
 import net.lapidist.colony.client.screens.NewGameScreen;
-import net.lapidist.colony.i18n.I18n;
+import net.lapidist.colony.util.I18n;
 import net.lapidist.colony.settings.Settings;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.server.GameServer;

--- a/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
+++ b/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
@@ -135,7 +135,7 @@ public final class GameClient extends AbstractMessageEndpoint implements AutoClo
         this.handlers = java.util.List.of(
                 new MapMetadataHandler(meta -> {
                     if (loadMessageListener != null) {
-                        loadMessageListener.accept(net.lapidist.colony.i18n.I18n.get("loading.metadata"));
+                        loadMessageListener.accept(net.lapidist.colony.util.I18n.get("loading.metadata"));
                     }
                     mapBuilder = MapState.builder()
                             .version(meta.version())
@@ -165,7 +165,7 @@ public final class GameClient extends AbstractMessageEndpoint implements AutoClo
                         }
                     }
                     if (loadMessageListener != null) {
-                        loadMessageListener.accept(net.lapidist.colony.i18n.I18n.get("loading.chunks"));
+                        loadMessageListener.accept(net.lapidist.colony.util.I18n.get("loading.chunks"));
                     }
                 }),
                 new MapChunkHandler(this::handleChunk, client.getKryo()),
@@ -191,7 +191,7 @@ public final class GameClient extends AbstractMessageEndpoint implements AutoClo
         client.start();
         LOGGER.info("Connecting to server...");
         if (loadMessageListener != null) {
-            loadMessageListener.accept(net.lapidist.colony.i18n.I18n.get("loading.connect"));
+            loadMessageListener.accept(net.lapidist.colony.util.I18n.get("loading.connect"));
         }
 
         registerHandlers(handlers);

--- a/client/src/main/java/net/lapidist/colony/client/screens/ErrorScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/ErrorScreen.java
@@ -4,7 +4,7 @@ import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
-import net.lapidist.colony.i18n.I18n;
+import net.lapidist.colony.util.I18n;
 import net.lapidist.colony.client.Colony;
 
 /** Simple screen that displays an error message with a button to return to the main menu. */

--- a/client/src/main/java/net/lapidist/colony/client/screens/GraphicsSettingsScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/GraphicsSettingsScreen.java
@@ -11,7 +11,7 @@ import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.utils.viewport.ScreenViewport;
 import net.lapidist.colony.client.Colony;
 import net.lapidist.colony.client.graphics.ShaderPluginLoader;
-import net.lapidist.colony.i18n.I18n;
+import net.lapidist.colony.util.I18n;
 import net.lapidist.colony.settings.GraphicsSettings;
 
 import java.io.IOException;

--- a/client/src/main/java/net/lapidist/colony/client/screens/KeybindsScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/KeybindsScreen.java
@@ -11,7 +11,7 @@ import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.utils.viewport.ScreenViewport;
 import net.lapidist.colony.client.Colony;
-import net.lapidist.colony.i18n.I18n;
+import net.lapidist.colony.util.I18n;
 import net.lapidist.colony.settings.KeyAction;
 import net.lapidist.colony.settings.KeyBindings;
 

--- a/client/src/main/java/net/lapidist/colony/client/screens/LoadGameScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/LoadGameScreen.java
@@ -10,7 +10,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
-import net.lapidist.colony.i18n.I18n;
+import net.lapidist.colony.util.I18n;
 import net.lapidist.colony.client.Colony;
 import net.lapidist.colony.io.Paths;
 import net.lapidist.colony.server.io.GameStateIO;

--- a/client/src/main/java/net/lapidist/colony/client/screens/LoadingScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/LoadingScreen.java
@@ -4,7 +4,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.ProgressBar;
 import com.badlogic.gdx.scenes.scene2d.ui.ProgressBar.ProgressBarStyle;
 import com.badlogic.gdx.graphics.Color;
-import net.lapidist.colony.i18n.I18n;
+import net.lapidist.colony.util.I18n;
 
 /**
  * Simple loading screen with a progress bar.

--- a/client/src/main/java/net/lapidist/colony/client/screens/MainMenuScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MainMenuScreen.java
@@ -4,7 +4,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
-import net.lapidist.colony.i18n.I18n;
+import net.lapidist.colony.util.I18n;
 import net.lapidist.colony.client.Colony;
 import net.lapidist.colony.io.Paths;
 

--- a/client/src/main/java/net/lapidist/colony/client/screens/MapUiBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapUiBuilder.java
@@ -21,7 +21,7 @@ import net.lapidist.colony.client.ui.AutosaveProgressBar;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.client.systems.BuildPlacementSystem;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
-import net.lapidist.colony.i18n.I18n;
+import net.lapidist.colony.util.I18n;
 import net.lapidist.colony.settings.KeyBindings;
 import net.lapidist.colony.settings.GraphicsSettings;
 import net.lapidist.colony.settings.KeyAction;

--- a/client/src/main/java/net/lapidist/colony/client/screens/ModSelectionScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/ModSelectionScreen.java
@@ -10,7 +10,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import net.lapidist.colony.client.Colony;
-import net.lapidist.colony.i18n.I18n;
+import net.lapidist.colony.util.I18n;
 import net.lapidist.colony.mod.ModLoader.LoadedMod;
 
 import java.util.ArrayList;

--- a/client/src/main/java/net/lapidist/colony/client/screens/NewGameScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/NewGameScreen.java
@@ -11,7 +11,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.ui.TextField;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import net.lapidist.colony.client.Colony;
-import net.lapidist.colony.i18n.I18n;
+import net.lapidist.colony.util.I18n;
 import net.lapidist.colony.components.state.MapState;
 
 import java.util.UUID;

--- a/client/src/main/java/net/lapidist/colony/client/screens/SettingsScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/SettingsScreen.java
@@ -7,7 +7,7 @@ import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import net.lapidist.colony.client.Colony;
-import net.lapidist.colony.i18n.I18n;
+import net.lapidist.colony.util.I18n;
 
 import java.io.IOException;
 import java.util.Locale;

--- a/client/src/main/java/net/lapidist/colony/client/systems/UISystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/UISystem.java
@@ -7,7 +7,7 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.utils.viewport.ScreenViewport;
 import net.lapidist.colony.client.events.ResizeEvent;
-import net.lapidist.colony.i18n.I18n;
+import net.lapidist.colony.util.I18n;
 import net.mostlyoriginal.api.event.common.Subscribe;
 
 public final class UISystem extends BaseSystem {

--- a/client/src/main/java/net/lapidist/colony/client/ui/AutosaveLabel.java
+++ b/client/src/main/java/net/lapidist/colony/client/ui/AutosaveLabel.java
@@ -3,7 +3,7 @@ package net.lapidist.colony.client.ui;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import net.lapidist.colony.events.Events;
-import net.lapidist.colony.i18n.I18n;
+import net.lapidist.colony.util.I18n;
 import net.lapidist.colony.server.events.AutosaveEvent;
 import net.mostlyoriginal.api.event.common.Subscribe;
 

--- a/client/src/main/java/net/lapidist/colony/client/ui/ChatBox.java
+++ b/client/src/main/java/net/lapidist/colony/client/ui/ChatBox.java
@@ -9,7 +9,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.TextArea;
 import com.badlogic.gdx.scenes.scene2d.ui.TextField;
 import net.lapidist.colony.chat.ChatMessage;
 import net.lapidist.colony.client.network.GameClient;
-import net.lapidist.colony.i18n.I18n;
+import net.lapidist.colony.util.I18n;
 
 /**
  * Simple chat UI widget containing a log and input field.

--- a/core/src/main/java/net/lapidist/colony/base/BaseDefinitionsMod.java
+++ b/core/src/main/java/net/lapidist/colony/base/BaseDefinitionsMod.java
@@ -5,7 +5,7 @@ import net.lapidist.colony.registry.BuildingDefinition;
 import net.lapidist.colony.registry.Registries;
 import net.lapidist.colony.registry.TileDefinition;
 import net.lapidist.colony.components.state.ResourceData;
-import net.lapidist.colony.i18n.I18n;
+import net.lapidist.colony.util.I18n;
 
 /** Built-in mod registering standard tile and building definitions. */
 public final class BaseDefinitionsMod implements GameMod {

--- a/core/src/main/java/net/lapidist/colony/i18n/package-info.java
+++ b/core/src/main/java/net/lapidist/colony/i18n/package-info.java
@@ -1,5 +1,0 @@
-/**
- * Translation system backed by resource bundles.
- * Provides the {@link I18n} utility to access localized strings.
- */
-package net.lapidist.colony.i18n;

--- a/core/src/main/java/net/lapidist/colony/map/ChunkedMapGenerator.java
+++ b/core/src/main/java/net/lapidist/colony/map/ChunkedMapGenerator.java
@@ -6,7 +6,7 @@ import net.lapidist.colony.components.state.ResourceData;
 import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.components.state.ChunkPos;
-import net.lapidist.colony.i18n.I18n;
+import net.lapidist.colony.util.I18n;
 
 import java.util.Map;
 import java.util.Random;

--- a/core/src/main/java/net/lapidist/colony/settings/Settings.java
+++ b/core/src/main/java/net/lapidist/colony/settings/Settings.java
@@ -2,7 +2,7 @@ package net.lapidist.colony.settings;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Preferences;
-import net.lapidist.colony.i18n.I18n;
+import net.lapidist.colony.util.I18n;
 
 import java.io.IOException;
 import java.util.Locale;

--- a/core/src/main/java/net/lapidist/colony/util/I18n.java
+++ b/core/src/main/java/net/lapidist/colony/util/I18n.java
@@ -1,4 +1,4 @@
-package net.lapidist.colony.i18n;
+package net.lapidist.colony.util;
 
 import java.util.Locale;
 import java.util.MissingResourceException;

--- a/core/src/main/java/net/lapidist/colony/util/package-info.java
+++ b/core/src/main/java/net/lapidist/colony/util/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Utility classes shared across modules.
+ * Provides the {@link I18n} class to access localized strings.
+ */
+package net.lapidist.colony.util;

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -6,7 +6,7 @@ All user-facing text is stored in property files and retrieved at runtime throug
 
 ## I18n Utility
 
-The class `net.lapidist.colony.i18n.I18n` exposes two simple methods:
+The class `net.lapidist.colony.util.I18n` exposes two simple methods:
 
 - `I18n.get("key")` – return the translated string for `key`. Missing keys are
   returned as `!key!` so they are easy to spot during development.

--- a/tests/src/test/java/net/lapidist/colony/tests/client/ColonyTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/ColonyTest.java
@@ -13,7 +13,7 @@ import net.mostlyoriginal.api.event.common.EventSystem;
 import net.mostlyoriginal.api.event.common.Subscribe;
 import net.lapidist.colony.settings.Settings;
 import net.lapidist.colony.io.Paths;
-import net.lapidist.colony.i18n.I18n;
+import net.lapidist.colony.util.I18n;
 import net.lapidist.colony.server.io.GameStateIO;
 import net.lapidist.colony.components.state.MapState;
 import org.mockito.MockedStatic;

--- a/tests/src/test/java/net/lapidist/colony/tests/components/BuildingTypeTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/components/BuildingTypeTest.java
@@ -1,6 +1,6 @@
 package net.lapidist.colony.tests.components;
 
-import net.lapidist.colony.i18n.I18n;
+import net.lapidist.colony.util.I18n;
 import org.junit.Test;
 
 import java.util.Locale;

--- a/tests/src/test/java/net/lapidist/colony/tests/core/I18nTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/I18nTest.java
@@ -1,6 +1,6 @@
 package net.lapidist.colony.tests.core;
 
-import net.lapidist.colony.i18n.I18n;
+import net.lapidist.colony.util.I18n;
 import org.junit.Test;
 import java.util.Locale;
 

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MapUiBuilderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MapUiBuilderTest.java
@@ -17,7 +17,7 @@ import net.lapidist.colony.client.systems.PlayerCameraSystem;
 import net.lapidist.colony.tests.GdxTestRunner;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.Input;
-import net.lapidist.colony.i18n.I18n;
+import net.lapidist.colony.util.I18n;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 


### PR DESCRIPTION
## Summary
- move `I18n` from `core/i18n` to new `core/util` package
- update imports across modules and tests
- remove empty `i18n` package and add new `package-info`
- update i18n docs

## Testing
- `./scripts/check.sh`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684ecb6a40b8832885e4a86690ed3a9c