### PR TITLE
refactor: flatten client entity factories

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/entities/BuildingFactory.java
+++ b/client/src/main/java/net/lapidist/colony/client/entities/BuildingFactory.java
@@ -1,4 +1,4 @@
-package net.lapidist.colony.client.entities.factories;
+package net.lapidist.colony.client.entities;
 
 import com.artemis.Entity;
 import com.artemis.World;
@@ -8,7 +8,7 @@ import net.lapidist.colony.registry.BuildingDefinition;
 import net.lapidist.colony.registry.Registries;
 import java.util.Locale;
 
-import static net.lapidist.colony.client.entities.factories.SpriteFactoryUtil.createEntity;
+import static net.lapidist.colony.client.entities.SpriteFactoryUtil.createEntity;
 
 /**
  * Factory methods for creating building entities.

--- a/client/src/main/java/net/lapidist/colony/client/entities/SpriteFactoryUtil.java
+++ b/client/src/main/java/net/lapidist/colony/client/entities/SpriteFactoryUtil.java
@@ -1,4 +1,4 @@
-package net.lapidist.colony.client.entities.factories;
+package net.lapidist.colony.client.entities;
 
 import com.artemis.Entity;
 import com.artemis.World;

--- a/client/src/main/java/net/lapidist/colony/client/entities/TileFactory.java
+++ b/client/src/main/java/net/lapidist/colony/client/entities/TileFactory.java
@@ -1,4 +1,4 @@
-package net.lapidist.colony.client.entities.factories;
+package net.lapidist.colony.client.entities;
 
 import com.artemis.Entity;
 import com.artemis.World;
@@ -10,7 +10,7 @@ import net.lapidist.colony.registry.Registries;
 import net.lapidist.colony.registry.TileDefinition;
 import java.util.Locale;
 
-import static net.lapidist.colony.client.entities.factories.SpriteFactoryUtil.createEntity;
+import static net.lapidist.colony.client.entities.SpriteFactoryUtil.createEntity;
 
 public final class TileFactory {
 

--- a/client/src/main/java/net/lapidist/colony/client/entities/factories/package-info.java
+++ b/client/src/main/java/net/lapidist/colony/client/entities/factories/package-info.java
@@ -1,4 +1,0 @@
-/**
- * Factory classes for creating client-side entities.
- */
-package net.lapidist.colony.client.entities.factories;

--- a/client/src/main/java/net/lapidist/colony/client/systems/network/BuildingUpdateSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/network/BuildingUpdateSystem.java
@@ -3,7 +3,7 @@ package net.lapidist.colony.client.systems.network;
 import com.artemis.BaseSystem;
 import com.artemis.ComponentMapper;
 import com.badlogic.gdx.math.Vector2;
-import net.lapidist.colony.client.entities.factories.BuildingFactory;
+import net.lapidist.colony.client.entities.BuildingFactory;
 import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.components.entities.BuildingComponent;
 import net.lapidist.colony.components.maps.MapComponent;

--- a/tests/src/test/java/net/lapidist/colony/tests/client/entities/factories/BuildingFactoryTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/entities/factories/BuildingFactoryTest.java
@@ -3,7 +3,7 @@ package net.lapidist.colony.tests.client.entities.factories;
 import com.artemis.World;
 import com.artemis.WorldConfigurationBuilder;
 import com.badlogic.gdx.math.Vector2;
-import net.lapidist.colony.client.entities.factories.BuildingFactory;
+import net.lapidist.colony.client.entities.BuildingFactory;
 import net.lapidist.colony.components.entities.BuildingComponent;
 import org.junit.Test;
 

--- a/tests/src/test/java/net/lapidist/colony/tests/client/entities/factories/SpriteFactoryUtilTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/entities/factories/SpriteFactoryUtilTest.java
@@ -4,7 +4,7 @@ import com.artemis.World;
 import com.artemis.WorldConfigurationBuilder;
 import com.badlogic.gdx.math.Vector2;
 import net.lapidist.colony.components.entities.BuildingComponent;
-import net.lapidist.colony.client.entities.factories.SpriteFactoryUtil;
+import net.lapidist.colony.client.entities.SpriteFactoryUtil;
 import net.lapidist.colony.components.GameConstants;
 import org.junit.Test;
 

--- a/tests/src/test/java/net/lapidist/colony/tests/client/entities/factories/TileFactoryTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/entities/factories/TileFactoryTest.java
@@ -3,7 +3,7 @@ package net.lapidist.colony.tests.client.entities.factories;
 import com.artemis.World;
 import com.artemis.WorldConfigurationBuilder;
 import com.badlogic.gdx.math.Vector2;
-import net.lapidist.colony.client.entities.factories.TileFactory;
+import net.lapidist.colony.client.entities.TileFactory;
 import net.lapidist.colony.components.maps.TileComponent;
 import net.lapidist.colony.components.resources.ResourceComponent;
 import net.lapidist.colony.components.state.ResourceData;


### PR DESCRIPTION
## Summary
- move entity factories up one package level in the client module
- update imports referencing the new package
- remove the obsolete `factories` package-info

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684ecb62b1788328a868cf7e7399f2a0