### PR TITLE
feat: add Docker support for server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM eclipse-temurin:21-jdk AS builder
+WORKDIR /app
+COPY . .
+RUN ./gradlew :server:build --no-daemon
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=builder /app .
+ENTRYPOINT ["./gradlew", ":server:run", "--no-daemon"]

--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ Both the client and dedicated server can be started directly from Gradle:
 - `./gradlew :client:run` – launches the game client.
 - `./gradlew :server:run` – starts a headless server.
 
+### Docker
+A `Dockerfile` is available to run the server in a container. Build the image and expose the default ports:
+
+```bash
+docker build -t colony-server .
+docker run -p 54555:54555/tcp -p 54777:54777/udp \
+           -v $(pwd)/colony-data:/root/.colony colony-server
+```
+
+Game data is stored in the mounted `colony-data` directory. An example compose file is included for convenience:
+
+```bash
+docker compose up
+```
+
 
 ## Controls
 Default keyboard mappings can be remapped in game. See

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  server:
+    build: .
+    ports:
+      - "54555:54555/tcp"
+      - "54777:54777/udp"
+    volumes:
+      - ./colony-data:/root/.colony


### PR DESCRIPTION
## Summary
- add Dockerfile that builds the server and runs via Gradle
- document image usage and compose file in README
- provide docker-compose.yml for convenient startup

## Testing
- `./gradlew spotlessApply`
- `./gradlew clean test` *(fails: Process 'Gradle Test Executor' finished with non-zero exit value 134)*
- `./gradlew check` *(fails: see test failures above)*
- `./gradlew codeCoverageReport`

------
https://chatgpt.com/codex/tasks/task_e_684eec67f1ec8328b2cd5c908fbe3c16