### PR TITLE
feat: integrate optional lighting

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/graphics/Box2dLightsPlugin.java
+++ b/client/src/main/java/net/lapidist/colony/client/graphics/Box2dLightsPlugin.java
@@ -1,9 +1,10 @@
 package net.lapidist.colony.client.graphics;
 
 import box2dLight.RayHandler;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.physics.box2d.World;
-import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 
 /**
  * Shader plugin that adds Box2DLights rendering support.
@@ -14,8 +15,15 @@ public final class Box2dLightsPlugin implements ShaderPlugin {
 
     @Override
     public ShaderProgram create(final ShaderManager manager) {
-        World world = new World(new Vector2(), false);
-        rayHandler = new RayHandler(world);
+        if (Gdx.gl20 == null) {
+            return null;
+        }
+        try {
+            World world = new World(new Vector2(), false);
+            rayHandler = new RayHandler(world);
+        } catch (Exception ex) {
+            rayHandler = null;
+        }
         return null;
     }
 

--- a/client/src/main/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRenderer.java
@@ -120,8 +120,5 @@ public final class LoadingSpriteMapRenderer implements MapRenderer, Disposable {
             resourceLoader.dispose();
             spriteBatch.dispose();
         }
-        if (lights != null) {
-            lights.dispose();
-        }
     }
 }

--- a/client/src/main/java/net/lapidist/colony/client/renderers/SpriteBatchMapRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/SpriteBatchMapRenderer.java
@@ -85,7 +85,7 @@ public final class SpriteBatchMapRenderer implements MapRenderer, Disposable {
         }
         if (lights != null) {
             lights.setCombinedMatrix(camera.getCamera().combined);
-            lights.updateAndRender();
+            lights.render();
         }
     }
 
@@ -97,9 +97,6 @@ public final class SpriteBatchMapRenderer implements MapRenderer, Disposable {
         spriteBatch.dispose();
         if (shader != null) {
             shader.dispose();
-        }
-        if (lights != null) {
-            lights.dispose();
         }
         tileCache.dispose();
     }

--- a/client/src/main/java/net/lapidist/colony/client/screens/GraphicsSettingsScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/GraphicsSettingsScreen.java
@@ -27,6 +27,7 @@ public final class GraphicsSettingsScreen extends BaseScreen {
     private final SelectBox<String> shaderBox;
     private final com.badlogic.gdx.utils.Array<String> pluginIds;
     private final CheckBox cacheBox;
+    private final CheckBox lightingBox;
     private final SelectBox<String> rendererBox;
     private static final float PADDING = 10f;
 
@@ -64,6 +65,8 @@ public final class GraphicsSettingsScreen extends BaseScreen {
         }
         cacheBox = new CheckBox(I18n.get("graphics.spritecache"), getSkin());
         cacheBox.setChecked(graphics.isSpriteCacheEnabled());
+        lightingBox = new CheckBox(I18n.get("graphics.lighting"), getSkin());
+        lightingBox.setChecked(graphics.isLightingEnabled());
 
         rendererBox = new SelectBox<>(getSkin());
         rendererBox.setItems("sprite");
@@ -78,6 +81,7 @@ public final class GraphicsSettingsScreen extends BaseScreen {
         options.add(afBox).left().row();
         options.add(shaderBox).left().row();
         options.add(cacheBox).left().row();
+        options.add(lightingBox).left().row();
         options.add(rendererBox).left().row();
 
         ScrollPane scroll = new ScrollPane(options, getSkin());
@@ -99,6 +103,7 @@ public final class GraphicsSettingsScreen extends BaseScreen {
                 int idx = shaderBox.getSelectedIndex();
                 graphics.setShaderPlugin(pluginIds.get(idx));
                 graphics.setSpriteCacheEnabled(cacheBox.isChecked());
+                graphics.setLightingEnabled(lightingBox.isChecked());
                 graphics.setRenderer(rendererBox.getSelected());
                 save();
             }

--- a/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -16,6 +16,7 @@ import net.lapidist.colony.client.systems.CameraInputSystem;
 import net.lapidist.colony.client.systems.SelectionSystem;
 import net.lapidist.colony.client.systems.BuildPlacementSystem;
 import net.lapidist.colony.client.systems.MapRenderSystem;
+import net.lapidist.colony.client.systems.LightingSystem;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
 import net.lapidist.colony.client.systems.PlayerMovementSystem;
 import net.lapidist.colony.client.systems.UISystem;
@@ -155,6 +156,7 @@ public final class MapWorldBuilder {
                         new ChunkLoadSystem(client),
                         new ChunkRequestQueueSystem(client),
                         new MapRenderSystem(),
+                        new LightingSystem(),
                         new UISystem(stage)
                 );
 
@@ -206,6 +208,12 @@ public final class MapWorldBuilder {
             MapRenderer renderer = actualFactory.create(world, plugin);
             renderSystem.setMapRenderer(renderer);
             renderSystem.setCameraProvider(world.getSystem(PlayerCameraSystem.class));
+        }
+        LightingSystem lightingSystem = world.getSystem(LightingSystem.class);
+        if (lightingSystem != null && plugin instanceof net.lapidist.colony.client.graphics.Box2dLightsPlugin bl) {
+            if (settings == null || settings.getGraphicsSettings().isLightingEnabled()) {
+                lightingSystem.setRayHandler(bl.getRayHandler());
+            }
         }
         PlayerCameraSystem cameraSystem = world.getSystem(PlayerCameraSystem.class);
         if (cameraSystem != null && cameraPos != null) {

--- a/client/src/main/java/net/lapidist/colony/client/systems/LightingSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/LightingSystem.java
@@ -1,0 +1,37 @@
+package net.lapidist.colony.client.systems;
+
+import com.artemis.BaseSystem;
+import com.badlogic.gdx.utils.Disposable;
+import box2dLight.RayHandler;
+
+/**
+ * Updates an optional {@link RayHandler} each frame and disposes it when no longer needed.
+ */
+public final class LightingSystem extends BaseSystem implements Disposable {
+
+    private RayHandler rayHandler;
+
+    /** Assign the handler used for lighting. */
+    public void setRayHandler(final RayHandler handler) {
+        this.rayHandler = handler;
+    }
+
+    /** Current lighting handler or {@code null}. */
+    public RayHandler getRayHandler() {
+        return rayHandler;
+    }
+
+    @Override
+    protected void processSystem() {
+        if (rayHandler != null) {
+            rayHandler.update();
+        }
+    }
+
+    @Override
+    public void dispose() {
+        if (rayHandler != null) {
+            rayHandler.dispose();
+        }
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/settings/GraphicsSettings.java
+++ b/core/src/main/java/net/lapidist/colony/settings/GraphicsSettings.java
@@ -14,6 +14,7 @@ public final class GraphicsSettings {
     private static final String PLUGIN_KEY = PREFIX + "shaderPlugin";
     private static final String RENDERER_KEY = PREFIX + "renderer";
     private static final String CACHE_KEY = PREFIX + "spritecache";
+    private static final String LIGHT_KEY = PREFIX + "lighting";
 
     private boolean antialiasingEnabled = true;
     private boolean mipMapsEnabled = true;
@@ -21,6 +22,7 @@ public final class GraphicsSettings {
     private String shaderPlugin = "none";
     private String renderer = "sprite";
     private boolean spriteCacheEnabled = true;
+    private boolean lightingEnabled = true;
 
     public boolean isAntialiasingEnabled() {
         return antialiasingEnabled;
@@ -70,6 +72,14 @@ public final class GraphicsSettings {
         this.spriteCacheEnabled = enabled;
     }
 
+    public boolean isLightingEnabled() {
+        return lightingEnabled;
+    }
+
+    public void setLightingEnabled(final boolean enabled) {
+        this.lightingEnabled = enabled;
+    }
+
     /** Load graphics settings from the given preferences. */
     public static GraphicsSettings load(final Preferences prefs) {
         GraphicsSettings gs = new GraphicsSettings();
@@ -79,6 +89,7 @@ public final class GraphicsSettings {
         gs.shaderPlugin = prefs.getString(PLUGIN_KEY, "none");
         gs.renderer = prefs.getString(RENDERER_KEY, "sprite");
         gs.spriteCacheEnabled = prefs.getBoolean(CACHE_KEY, true);
+        gs.lightingEnabled = prefs.getBoolean(LIGHT_KEY, true);
         return gs;
     }
 
@@ -90,5 +101,6 @@ public final class GraphicsSettings {
         prefs.putString(PLUGIN_KEY, shaderPlugin);
         prefs.putString(RENDERER_KEY, renderer);
         prefs.putBoolean(CACHE_KEY, spriteCacheEnabled);
+        prefs.putBoolean(LIGHT_KEY, lightingEnabled);
     }
 }

--- a/core/src/main/java/net/lapidist/colony/settings/Settings.java
+++ b/core/src/main/java/net/lapidist/colony/settings/Settings.java
@@ -62,6 +62,7 @@ public final class Settings {
             }
             settings.graphicsSettings.setRenderer(gLoaded.getRenderer());
             settings.graphicsSettings.setSpriteCacheEnabled(gLoaded.isSpriteCacheEnabled());
+            settings.graphicsSettings.setLightingEnabled(gLoaded.isLightingEnabled());
         }
         return settings;
     }

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -60,6 +60,7 @@ graphics.anisotropic=Anisotropic Filtering
 graphics.shaderPlugin=Shader Plugin
 graphics.renderer=Renderer
 graphics.spritecache=Sprite Cache
+graphics.lighting=Lighting
 common.save=Save
 ui.saving=Saving...
 modSelect.title=Mods

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -59,6 +59,7 @@ graphics.anisotropic=Anisotropes Filtern
 graphics.shaderPlugin=Shader-Plugin
 graphics.renderer=Renderer
 graphics.spritecache=Sprite-Cache
+graphics.lighting=Beleuchtung
 common.save=Speichern
 ui.saving=Speichern...
 modSelect.title=Mods

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -59,6 +59,7 @@ graphics.anisotropic=Filtrado Anisotrópico
 graphics.shaderPlugin=Complemento Shader
 graphics.renderer=Renderizador
 graphics.spritecache=Cache de Sprites
+graphics.lighting=Iluminaci\u00f3n
 common.save=Guardar
 ui.saving=Guardando...
 modSelect.title=Mods

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -59,6 +59,7 @@ graphics.anisotropic=Filtrage Anisotrope
 graphics.shaderPlugin=Plugin de shader
 graphics.renderer=Moteur de rendu
 graphics.spritecache=Cache de Sprites
+graphics.lighting=\u00c9clairage
 common.save=Sauvegarder
 ui.saving=Sauvegarde...
 modSelect.title=Mods

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -30,6 +30,12 @@ per-frame lookups. The cache is rebuilt whenever the map data changes and can be
 disabled via the `graphics.spritecache` setting. Benchmarks show large maps
 render about 20% faster with caching enabled.
 
+## Lighting
+
+Dynamic lighting uses the box2d-lights library and requires additional frame buffer passes.
+On low end GPUs this can noticeably reduce frame rate. Disable the feature with
+`graphics.lighting=false` if performance is a concern.
+
 ## Asynchronous renderer loading
 
 `SpriteMapRendererFactory` now loads assets using LibGDX's `AssetManager` and

--- a/docs/shaders.md
+++ b/docs/shaders.md
@@ -57,3 +57,10 @@ public final class GrayShaderPlugin implements ShaderPlugin {
 
 Add `GrayShaderPlugin` to the service descriptor and set
 `graphics.shaderPlugin` to `com.example.GrayShaderPlugin` to enable it.
+
+## Built-in lighting
+
+The `Box2dLightsPlugin` is included with the game and integrates the
+[box2d-lights](https://github.com/libgdx/box2dlights) library. It returns
+no shader program but exposes a `RayHandler` when frame buffers are supported.
+Headless or unsupported environments automatically skip lighting.

--- a/tests/src/test/java/net/lapidist/colony/client/graphics/Box2dLightsPluginTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/graphics/Box2dLightsPluginTest.java
@@ -14,12 +14,7 @@ public class Box2dLightsPluginTest {
         Box2dLightsPlugin plugin = new Box2dLightsPlugin();
         assertNull(plugin.getRayHandler());
 
-        try {
-            plugin.create(new ShaderManager());
-            fail("Expected failure when creating RayHandler");
-        } catch (IllegalStateException ex) {
-            // expected when FBO unsupported in headless tests
-        }
+        assertNull(plugin.create(new ShaderManager()));
 
         assertNull(plugin.getRayHandler());
         assertEquals("box2dlights", plugin.id());

--- a/tests/src/test/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRendererTest.java
@@ -41,7 +41,6 @@ public class LoadingSpriteMapRendererTest {
             verify(sb).setLights(lights);
 
             renderer.dispose();
-            verify(lights).dispose();
             verify(sb).dispose();
             verify(loader, never()).dispose();
         }

--- a/tests/src/test/java/net/lapidist/colony/client/renderers/SpriteBatchMapRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/renderers/SpriteBatchMapRendererTest.java
@@ -187,9 +187,8 @@ public class SpriteBatchMapRendererTest {
 
         renderer.render(map, camera);
         verify(lights).setCombinedMatrix(any(com.badlogic.gdx.math.Matrix4.class));
-        verify(lights).updateAndRender();
+        verify(lights).render();
 
         renderer.dispose();
-        verify(lights).dispose();
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/systems/LightingSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/systems/LightingSystemTest.java
@@ -1,0 +1,42 @@
+package net.lapidist.colony.tests.client.systems;
+
+import box2dLight.RayHandler;
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import net.lapidist.colony.tests.GdxTestRunner;
+import net.lapidist.colony.client.systems.LightingSystem;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.mockito.Mockito.*;
+
+/** Tests for {@link LightingSystem}. */
+@RunWith(GdxTestRunner.class)
+public class LightingSystemTest {
+
+    @Test
+    public void updatesAndDisposesHandler() {
+        RayHandler handler = mock(RayHandler.class);
+        LightingSystem system = new LightingSystem();
+        system.setRayHandler(handler);
+
+        World world = new World(new WorldConfigurationBuilder().with(system).build());
+        world.setDelta(0f);
+        world.process();
+
+        verify(handler).update();
+        system.dispose();
+        verify(handler).dispose();
+        world.dispose();
+    }
+
+    @Test
+    public void skipsWhenHandlerMissing() {
+        LightingSystem system = new LightingSystem();
+        World world = new World(new WorldConfigurationBuilder().with(system).build());
+        world.setDelta(0f);
+        world.process();
+        system.dispose();
+        world.dispose();
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/core/settings/GraphicsSettingsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/settings/GraphicsSettingsTest.java
@@ -25,6 +25,7 @@ public class GraphicsSettingsTest {
         gs.setShaderPlugin("custom");
         gs.setRenderer("model");
         gs.setSpriteCacheEnabled(false);
+        gs.setLightingEnabled(false);
         gs.save(prefs);
         prefs.flush();
 
@@ -35,6 +36,7 @@ public class GraphicsSettingsTest {
         assertEquals("custom", loaded.getShaderPlugin());
         assertEquals("model", loaded.getRenderer());
         assertFalse(loaded.isSpriteCacheEnabled());
+        assertFalse(loaded.isLightingEnabled());
     }
 
     @Test
@@ -50,5 +52,6 @@ public class GraphicsSettingsTest {
         assertEquals("none", loaded.getShaderPlugin());
         assertEquals("sprite", loaded.getRenderer());
         assertTrue(loaded.isSpriteCacheEnabled());
+        assertTrue(loaded.isLightingEnabled());
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/core/settings/SettingsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/settings/SettingsTest.java
@@ -76,6 +76,7 @@ public class SettingsTest {
         graphics.setRenderer("model");
         graphics.setShaderPlugin("test");
         graphics.setSpriteCacheEnabled(false);
+        graphics.setLightingEnabled(false);
         settings.save();
 
         Settings loaded = Settings.load();
@@ -85,5 +86,6 @@ public class SettingsTest {
         assertEquals("test", loaded.getGraphicsSettings().getShaderPlugin());
         assertEquals("model", loaded.getGraphicsSettings().getRenderer());
         assertEquals(false, loaded.getGraphicsSettings().isSpriteCacheEnabled());
+        assertEquals(false, loaded.getGraphicsSettings().isLightingEnabled());
     }
 }


### PR DESCRIPTION
## Summary
- add Box2dLights plugin guard and minimal RayHandler creation
- introduce LightingSystem to manage RayHandler lifecycle
- attach lighting to renderer and expose toggle in settings
- update MapWorldBuilder and sprite renderer for new system
- document lighting usage and performance impact
- add unit tests for lighting components

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test check codeCoverageReport`

------
https://chatgpt.com/codex/tasks/task_e_684eef35ad848328bb9055177b6be64a