### PR TITLE
feat: add normal map shader support

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/core/io/ResourceLoader.java
+++ b/client/src/main/java/net/lapidist/colony/client/core/io/ResourceLoader.java
@@ -58,6 +58,26 @@ public interface ResourceLoader extends Disposable {
      */
     TextureRegion findRegion(String name);
 
+    /**
+     * Find a normal map region for the given base texture name.
+     *
+     * @param name base region identifier
+     * @return matching normal map region or {@code null}
+     */
+    default TextureRegion findNormalRegion(final String name) {
+        return null;
+    }
+
+    /**
+     * Find a specular map region for the given base texture name.
+     *
+     * @param name base region identifier
+     * @return matching specular map region or {@code null}
+     */
+    default TextureRegion findSpecularRegion(final String name) {
+        return null;
+    }
+
 
     /**
      * Progress the asynchronous loading process once.

--- a/client/src/main/java/net/lapidist/colony/client/core/io/TextureAtlasResourceLoader.java
+++ b/client/src/main/java/net/lapidist/colony/client/core/io/TextureAtlasResourceLoader.java
@@ -142,6 +142,22 @@ public final class TextureAtlasResourceLoader implements ResourceLoader {
         return atlas.findRegion(name);
     }
 
+    @Override
+    public TextureRegion findNormalRegion(final String name) {
+        if (atlas == null) {
+            return null;
+        }
+        return atlas.findRegion(name + "_n");
+    }
+
+    @Override
+    public TextureRegion findSpecularRegion(final String name) {
+        if (atlas == null) {
+            return null;
+        }
+        return atlas.findRegion(name + "_s");
+    }
+
 
     @Override
     public void dispose() {

--- a/client/src/main/java/net/lapidist/colony/client/graphics/NormalMapShaderPlugin.java
+++ b/client/src/main/java/net/lapidist/colony/client/graphics/NormalMapShaderPlugin.java
@@ -1,0 +1,37 @@
+package net.lapidist.colony.client.graphics;
+
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import net.lapidist.colony.client.core.io.FileLocation;
+
+import java.io.IOException;
+
+/**
+ * Shader plugin blending diffuse, normal and specular maps.
+ */
+public final class NormalMapShaderPlugin implements ShaderPlugin {
+    @Override
+    public ShaderProgram create(final ShaderManager manager) {
+        try {
+            ShaderProgram program = manager.load(FileLocation.INTERNAL,
+                    "shaders/normal.vert", "shaders/normal.frag");
+            program.begin();
+            program.setUniformi("u_texture", 0);
+            program.setUniformi("u_normal", 1);
+            program.setUniformi("u_specular", 2);
+            program.end();
+            return program;
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public String id() {
+        return "normal";
+    }
+
+    @Override
+    public String displayName() {
+        return "Normal Mapping";
+    }
+}

--- a/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
@@ -25,6 +25,8 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
     private final CameraProvider cameraSystem;
     private final AssetResolver resolver;
     private final java.util.HashMap<String, TextureRegion> buildingRegions = new java.util.HashMap<>();
+    private final java.util.HashMap<String, TextureRegion> normalRegions = new java.util.HashMap<>();
+    private final java.util.HashMap<String, TextureRegion> specularRegions = new java.util.HashMap<>();
     private final BitmapFont font = new BitmapFont();
     private final GlyphLayout layout = new GlyphLayout();
     private static final float LABEL_OFFSET_Y = 8f;
@@ -45,8 +47,16 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
         for (BuildingDefinition def : Registries.buildings().all()) {
             String ref = resolver.buildingAsset(def.id());
             TextureRegion region = resourceLoader.findRegion(ref);
+            TextureRegion normal = resourceLoader.findNormalRegion(ref);
+            TextureRegion specular = resourceLoader.findSpecularRegion(ref);
             if (region != null) {
                 buildingRegions.put(def.id().toUpperCase(java.util.Locale.ROOT), region);
+            }
+            if (normal != null) {
+                normalRegions.put(def.id().toUpperCase(java.util.Locale.ROOT), normal);
+            }
+            if (specular != null) {
+                specularRegions.put(def.id().toUpperCase(java.util.Locale.ROOT), specular);
             }
         }
     }
@@ -69,7 +79,15 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
 
             String type = building.getBuildingType();
             TextureRegion region = buildingRegions.get(type.toUpperCase(java.util.Locale.ROOT));
+            TextureRegion normal = normalRegions.get(type.toUpperCase(java.util.Locale.ROOT));
+            TextureRegion specular = specularRegions.get(type.toUpperCase(java.util.Locale.ROOT));
             if (region != null) {
+                if (normal != null) {
+                    normal.getTexture().bind(1);
+                }
+                if (specular != null) {
+                    specular.getTexture().bind(2);
+                }
                 spriteBatch.draw(region, worldCoords.x, worldCoords.y);
             }
             if (!resolver.hasBuildingAsset(type)) {

--- a/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
@@ -27,6 +27,8 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
     private final CameraProvider cameraSystem;
     private final AssetResolver resolver;
     private final java.util.HashMap<String, TextureRegion> tileRegions = new java.util.HashMap<>();
+    private final java.util.HashMap<String, TextureRegion> normalRegions = new java.util.HashMap<>();
+    private final java.util.HashMap<String, TextureRegion> specularRegions = new java.util.HashMap<>();
     private final TextureRegion overlayRegion;
     private final BitmapFont font = new BitmapFont();
     private final GlyphLayout layout = new GlyphLayout();
@@ -53,8 +55,16 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
         for (TileDefinition def : Registries.tiles().all()) {
             String ref = resolver.tileAsset(def.id());
             TextureRegion region = resourceLoader.findRegion(ref);
+            TextureRegion normal = resourceLoader.findNormalRegion(ref);
+            TextureRegion specular = resourceLoader.findSpecularRegion(ref);
             if (region != null) {
                 tileRegions.put(def.id().toUpperCase(java.util.Locale.ROOT), region);
+            }
+            if (normal != null) {
+                normalRegions.put(def.id().toUpperCase(java.util.Locale.ROOT), normal);
+            }
+            if (specular != null) {
+                specularRegions.put(def.id().toUpperCase(java.util.Locale.ROOT), specular);
             }
         }
         this.overlayRegion = resourceLoader.findRegion("hoveredTile0");
@@ -100,7 +110,15 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
                 if (!overlayOnly) {
                     String type = tile.getTileType();
                     TextureRegion region = tileRegions.get(type.toUpperCase(java.util.Locale.ROOT));
+                    TextureRegion normal = normalRegions.get(type.toUpperCase(java.util.Locale.ROOT));
+                    TextureRegion specular = specularRegions.get(type.toUpperCase(java.util.Locale.ROOT));
                     if (region != null) {
+                        if (normal != null) {
+                            normal.getTexture().bind(1);
+                        }
+                        if (specular != null) {
+                            specular.getTexture().bind(2);
+                        }
                         String upper = type.toUpperCase(java.util.Locale.ROOT);
                         if ("GRASS".equals(upper) || "DIRT".equals(upper)) {
                             float rotation = TileRotationUtil.rotationFor(tile.getX(), tile.getY());

--- a/client/src/main/java/net/lapidist/colony/client/screens/GraphicsSettingsScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/GraphicsSettingsScreen.java
@@ -28,6 +28,8 @@ public final class GraphicsSettingsScreen extends BaseScreen {
     private final com.badlogic.gdx.utils.Array<String> pluginIds;
     private final CheckBox cacheBox;
     private final CheckBox lightingBox;
+    private final CheckBox normalBox;
+    private final CheckBox specularBox;
     private final SelectBox<String> rendererBox;
     private static final float PADDING = 10f;
 
@@ -67,6 +69,10 @@ public final class GraphicsSettingsScreen extends BaseScreen {
         cacheBox.setChecked(graphics.isSpriteCacheEnabled());
         lightingBox = new CheckBox(I18n.get("graphics.lighting"), getSkin());
         lightingBox.setChecked(graphics.isLightingEnabled());
+        normalBox = new CheckBox(I18n.get("graphics.normalmaps"), getSkin());
+        normalBox.setChecked(graphics.isNormalMapsEnabled());
+        specularBox = new CheckBox(I18n.get("graphics.specularmaps"), getSkin());
+        specularBox.setChecked(graphics.isSpecularMapsEnabled());
 
         rendererBox = new SelectBox<>(getSkin());
         rendererBox.setItems("sprite");
@@ -82,6 +88,8 @@ public final class GraphicsSettingsScreen extends BaseScreen {
         options.add(shaderBox).left().row();
         options.add(cacheBox).left().row();
         options.add(lightingBox).left().row();
+        options.add(normalBox).left().row();
+        options.add(specularBox).left().row();
         options.add(rendererBox).left().row();
 
         ScrollPane scroll = new ScrollPane(options, getSkin());
@@ -104,6 +112,8 @@ public final class GraphicsSettingsScreen extends BaseScreen {
                 graphics.setShaderPlugin(pluginIds.get(idx));
                 graphics.setSpriteCacheEnabled(cacheBox.isChecked());
                 graphics.setLightingEnabled(lightingBox.isChecked());
+                graphics.setNormalMapsEnabled(normalBox.isChecked());
+                graphics.setSpecularMapsEnabled(specularBox.isChecked());
                 graphics.setRenderer(rendererBox.getSelected());
                 save();
             }

--- a/client/src/main/resources/META-INF/services/net.lapidist.colony.client.graphics.ShaderPlugin
+++ b/client/src/main/resources/META-INF/services/net.lapidist.colony.client.graphics.ShaderPlugin
@@ -1,2 +1,3 @@
 net.lapidist.colony.client.graphics.NullShaderPlugin
 net.lapidist.colony.client.graphics.Box2dLightsPlugin
+net.lapidist.colony.client.graphics.NormalMapShaderPlugin

--- a/client/src/main/resources/shaders/normal.frag
+++ b/client/src/main/resources/shaders/normal.frag
@@ -1,0 +1,20 @@
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+varying vec4 v_color;
+varying vec2 v_texCoord;
+
+uniform sampler2D u_texture;
+uniform sampler2D u_normal;
+uniform sampler2D u_specular;
+uniform vec3 u_lightDir;
+
+void main() {
+    vec4 diff = texture2D(u_texture, v_texCoord);
+    vec3 n = texture2D(u_normal, v_texCoord).xyz * 2.0 - 1.0;
+    float d = max(0.0, dot(n, normalize(u_lightDir)));
+    float s = texture2D(u_specular, v_texCoord).r;
+    vec3 color = diff.rgb * d + vec3(s);
+    gl_FragColor = vec4(color, diff.a) * v_color;
+}

--- a/client/src/main/resources/shaders/normal.vert
+++ b/client/src/main/resources/shaders/normal.vert
@@ -1,0 +1,14 @@
+attribute vec4 a_position;
+attribute vec4 a_color;
+attribute vec2 a_texCoord0;
+
+uniform mat4 u_projTrans;
+
+varying vec4 v_color;
+varying vec2 v_texCoord;
+
+void main() {
+    v_color = a_color;
+    v_texCoord = a_texCoord0;
+    gl_Position = u_projTrans * a_position;
+}

--- a/core/src/main/java/net/lapidist/colony/settings/GraphicsSettings.java
+++ b/core/src/main/java/net/lapidist/colony/settings/GraphicsSettings.java
@@ -15,6 +15,8 @@ public final class GraphicsSettings {
     private static final String RENDERER_KEY = PREFIX + "renderer";
     private static final String CACHE_KEY = PREFIX + "spritecache";
     private static final String LIGHT_KEY = PREFIX + "lighting";
+    private static final String NORMAL_KEY = PREFIX + "normalmaps";
+    private static final String SPECULAR_KEY = PREFIX + "specularmaps";
 
     private boolean antialiasingEnabled = true;
     private boolean mipMapsEnabled = true;
@@ -23,6 +25,8 @@ public final class GraphicsSettings {
     private String renderer = "sprite";
     private boolean spriteCacheEnabled = true;
     private boolean lightingEnabled = true;
+    private boolean normalMapsEnabled = false;
+    private boolean specularMapsEnabled = false;
 
     public boolean isAntialiasingEnabled() {
         return antialiasingEnabled;
@@ -80,6 +84,22 @@ public final class GraphicsSettings {
         this.lightingEnabled = enabled;
     }
 
+    public boolean isNormalMapsEnabled() {
+        return normalMapsEnabled;
+    }
+
+    public void setNormalMapsEnabled(final boolean enabled) {
+        this.normalMapsEnabled = enabled;
+    }
+
+    public boolean isSpecularMapsEnabled() {
+        return specularMapsEnabled;
+    }
+
+    public void setSpecularMapsEnabled(final boolean enabled) {
+        this.specularMapsEnabled = enabled;
+    }
+
     /** Load graphics settings from the given preferences. */
     public static GraphicsSettings load(final Preferences prefs) {
         GraphicsSettings gs = new GraphicsSettings();
@@ -90,6 +110,8 @@ public final class GraphicsSettings {
         gs.renderer = prefs.getString(RENDERER_KEY, "sprite");
         gs.spriteCacheEnabled = prefs.getBoolean(CACHE_KEY, true);
         gs.lightingEnabled = prefs.getBoolean(LIGHT_KEY, true);
+        gs.normalMapsEnabled = prefs.getBoolean(NORMAL_KEY, false);
+        gs.specularMapsEnabled = prefs.getBoolean(SPECULAR_KEY, false);
         return gs;
     }
 
@@ -102,5 +124,7 @@ public final class GraphicsSettings {
         prefs.putString(RENDERER_KEY, renderer);
         prefs.putBoolean(CACHE_KEY, spriteCacheEnabled);
         prefs.putBoolean(LIGHT_KEY, lightingEnabled);
+        prefs.putBoolean(NORMAL_KEY, normalMapsEnabled);
+        prefs.putBoolean(SPECULAR_KEY, specularMapsEnabled);
     }
 }

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -66,3 +66,5 @@ ui.saving=Saving...
 modSelect.title=Mods
 modSelect.next=Next
 modSelect.back=Back
+graphics.normalmaps=Normal Maps
+graphics.specularmaps=Specular Maps

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -65,3 +65,5 @@ ui.saving=Speichern...
 modSelect.title=Mods
 modSelect.next=Weiter
 modSelect.back=Zurück
+graphics.normalmaps=Normal-Maps
+graphics.specularmaps=Spekular-Maps

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -65,3 +65,5 @@ ui.saving=Guardando...
 modSelect.title=Mods
 modSelect.next=Siguiente
 modSelect.back=Atrás
+graphics.normalmaps=Mapas Normales
+graphics.specularmaps=Mapas especulares

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -65,3 +65,5 @@ ui.saving=Sauvegarde...
 modSelect.title=Mods
 modSelect.next=Suivant
 modSelect.back=Retour
+graphics.normalmaps=Cartes de normales
+graphics.specularmaps=Cartes speculaires

--- a/docs/shaders.md
+++ b/docs/shaders.md
@@ -64,3 +64,11 @@ The `Box2dLightsPlugin` is included with the game and integrates the
 [box2d-lights](https://github.com/libgdx/box2dlights) library. It returns
 no shader program but exposes a `RayHandler` when frame buffers are supported.
 Headless or unsupported environments automatically skip lighting.
+
+## Normal map plugin
+
+The `NormalMapShaderPlugin` combines diffuse, normal and specular
+textures. Assets should follow the naming convention of appending
+`_n` for normal maps and `_s` for specular maps to the base region
+name inside the texture atlas. Enable the plugin through the graphics
+settings screen to see the effect.

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/BuildingRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/BuildingRendererTest.java
@@ -34,6 +34,12 @@ public class BuildingRendererTest {
         ResourceLoader loader = mock(ResourceLoader.class);
         TextureRegion region = mock(TextureRegion.class);
         when(loader.findRegion(anyString())).thenReturn(region);
+        when(loader.findNormalRegion(anyString())).thenReturn(null);
+        when(loader.findSpecularRegion(anyString())).thenReturn(null);
+        when(loader.findNormalRegion(anyString())).thenReturn(null);
+        when(loader.findSpecularRegion(anyString())).thenReturn(null);
+        when(loader.findNormalRegion(anyString())).thenReturn(null);
+        when(loader.findSpecularRegion(anyString())).thenReturn(null);
 
         new BaseDefinitionsMod().init();
 

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/TileRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/TileRendererTest.java
@@ -36,6 +36,14 @@ public class TileRendererTest {
         TextureRegion overlay = mock(TextureRegion.class);
         when(loader.findRegion(anyString())).thenReturn(region);
         when(loader.findRegion(eq("hoveredTile0"))).thenReturn(overlay);
+        when(loader.findNormalRegion(anyString())).thenReturn(null);
+        when(loader.findSpecularRegion(anyString())).thenReturn(null);
+        when(loader.findNormalRegion(anyString())).thenReturn(null);
+        when(loader.findSpecularRegion(anyString())).thenReturn(null);
+        when(loader.findNormalRegion(anyString())).thenReturn(null);
+        when(loader.findSpecularRegion(anyString())).thenReturn(null);
+        when(loader.findNormalRegion(anyString())).thenReturn(null);
+        when(loader.findSpecularRegion(anyString())).thenReturn(null);
 
         new BaseDefinitionsMod().init();
 


### PR DESCRIPTION
## Summary
- extend graphics settings and resource loader for normal/specular textures
- load normal/specular atlas regions with `_n` and `_s` suffixes
- bind extra textures in building and tile renderers
- add `NormalMapShaderPlugin` with sample shader code
- expose options in graphics settings screen
- document plugin and asset naming convention

## Testing
- `./gradlew spotlessApply`
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684ef55e6de48328814f76db93611975