### PR TITLE
feat(client): set ambient light for Box2DLights

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/graphics/Box2dLightsPlugin.java
+++ b/client/src/main/java/net/lapidist/colony/client/graphics/Box2dLightsPlugin.java
@@ -21,6 +21,7 @@ public final class Box2dLightsPlugin implements ShaderPlugin {
         try {
             World world = new World(new Vector2(), false);
             rayHandler = new RayHandler(world);
+            rayHandler.setAmbientLight(1f, 1f, 1f, 1f);
         } catch (Exception ex) {
             rayHandler = null;
         }

--- a/tests/src/test/java/net/lapidist/colony/client/graphics/Box2dLightsPluginTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/graphics/Box2dLightsPluginTest.java
@@ -1,4 +1,7 @@
 package net.lapidist.colony.client.graphics;
+
+import box2dLight.RayHandler;
+import com.badlogic.gdx.graphics.Color;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,8 +18,21 @@ public class Box2dLightsPluginTest {
         assertNull(plugin.getRayHandler());
 
         assertNull(plugin.create(new ShaderManager()));
-
-        assertNull(plugin.getRayHandler());
+        if (plugin.getRayHandler() != null) {
+            try {
+                java.lang.reflect.Field field = RayHandler.class.getDeclaredField("ambientLight");
+                field.setAccessible(true);
+                Color color = (Color) field.get(plugin.getRayHandler());
+                assertEquals(1f, color.r, 0f);
+                assertEquals(1f, color.g, 0f);
+                assertEquals(1f, color.b, 0f);
+                assertEquals(1f, color.a, 0f);
+            } catch (Exception ex) {
+                fail("Could not access ambient light: " + ex.getMessage());
+            }
+        } else {
+            assertNull(plugin.getRayHandler());
+        }
         assertEquals("box2dlights", plugin.id());
         assertEquals("Box2DLights", plugin.displayName());
     }


### PR DESCRIPTION
## Summary
- set ambient light in Box2dLightsPlugin
- test that ambient light is configured when possible

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`

------
https://chatgpt.com/codex/tasks/task_e_684f0a7cc058832897c89042f63f054c