### PR TITLE
feat: add day-night cycle system

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/GraphicsSettingsScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/GraphicsSettingsScreen.java
@@ -30,6 +30,7 @@ public final class GraphicsSettingsScreen extends BaseScreen {
     private final com.badlogic.gdx.utils.Array<String> pluginIds;
     private final CheckBox cacheBox;
     private final CheckBox lightingBox;
+    private final CheckBox dayNightBox;
     private final SelectBox<String> rendererBox;
     private static final float PADDING = 10f;
 
@@ -73,6 +74,8 @@ public final class GraphicsSettingsScreen extends BaseScreen {
         cacheBox.setChecked(graphics.isSpriteCacheEnabled());
         lightingBox = new CheckBox(I18n.get("graphics.lighting"), getSkin());
         lightingBox.setChecked(graphics.isLightingEnabled());
+        dayNightBox = new CheckBox(I18n.get("graphics.dayNightCycle"), getSkin());
+        dayNightBox.setChecked(graphics.isDayNightCycleEnabled());
 
         rendererBox = new SelectBox<>(getSkin());
         rendererBox.setItems("sprite");
@@ -90,6 +93,7 @@ public final class GraphicsSettingsScreen extends BaseScreen {
         options.add(shaderBox).left().row();
         options.add(cacheBox).left().row();
         options.add(lightingBox).left().row();
+        options.add(dayNightBox).left().row();
         options.add(rendererBox).left().row();
 
         ScrollPane scroll = new ScrollPane(options, getSkin());
@@ -114,6 +118,7 @@ public final class GraphicsSettingsScreen extends BaseScreen {
                 graphics.setShaderPlugin(pluginIds.get(idx));
                 graphics.setSpriteCacheEnabled(cacheBox.isChecked());
                 graphics.setLightingEnabled(lightingBox.isChecked());
+                graphics.setDayNightCycleEnabled(dayNightBox.isChecked());
                 graphics.setRenderer(rendererBox.getSelected());
                 save();
             }

--- a/client/src/main/java/net/lapidist/colony/client/screens/MapScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapScreen.java
@@ -25,7 +25,13 @@ public final class MapScreen implements Screen {
         this.colony = colonyToSet;
         stage = new Stage(new ScreenViewport());
         world = MapWorldBuilder.build(
-                MapWorldBuilder.builder(state, client, stage, colony.getSettings().getKeyBindings()),
+                MapWorldBuilder.builder(
+                        state,
+                        client,
+                        stage,
+                        colony.getSettings().getKeyBindings(),
+                        colony.getSettings().getGraphicsSettings()
+                ),
                 null,
                 colony.getSettings(),
                 state.cameraPos()

--- a/client/src/main/java/net/lapidist/colony/client/systems/ClearScreenSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/ClearScreenSystem.java
@@ -13,6 +13,11 @@ public final class ClearScreenSystem extends BaseSystem {
         this.color = colorToClear;
     }
 
+    /** Access the mutable clear color used each frame. */
+    public Color getColor() {
+        return color;
+    }
+
     @Override
     protected void processSystem() {
         Gdx.gl.glClearColor(color.r, color.g, color.b, color.a);

--- a/client/src/main/java/net/lapidist/colony/client/systems/DayNightSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/DayNightSystem.java
@@ -1,0 +1,61 @@
+package net.lapidist.colony.client.systems;
+
+import com.artemis.BaseSystem;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.math.MathUtils;
+import box2dLight.RayHandler;
+
+/**
+ * System that updates ambient lighting and clear color based on the time of day.
+ */
+public final class DayNightSystem extends BaseSystem {
+
+    private final ClearScreenSystem clearScreenSystem;
+    private final LightingSystem lightingSystem;
+    private float timeOfDay;
+
+    private static final float HOURS_PER_DAY = 24f;
+    private static final float FULL_ROTATION = 360f;
+    private static final float DAWN_OFFSET = 90f;
+
+    public DayNightSystem(final ClearScreenSystem clearSystem,
+                          final LightingSystem lighting) {
+        this.clearScreenSystem = clearSystem;
+        this.lightingSystem = lighting;
+    }
+
+    /** Current time of day between 0 and 24. */
+    public float getTimeOfDay() {
+        return timeOfDay;
+    }
+
+    /** Set the time of day, values wrap to the 0-24 range. */
+    public void setTimeOfDay(final float time) {
+        timeOfDay = wrap(time);
+    }
+
+    @Override
+    protected void processSystem() {
+        timeOfDay = wrap(timeOfDay + world.getDelta());
+        float brightness = calculateBrightness(timeOfDay);
+        Color c = clearScreenSystem.getColor();
+        c.set(brightness, brightness, brightness, 1f);
+        RayHandler handler = lightingSystem.getRayHandler();
+        if (handler != null) {
+            handler.setAmbientLight(brightness, brightness, brightness, 1f);
+        }
+    }
+
+    private static float wrap(final float time) {
+        float t = time % HOURS_PER_DAY;
+        if (t < 0f) {
+            t += HOURS_PER_DAY;
+        }
+        return t;
+    }
+
+    private static float calculateBrightness(final float time) {
+        float angle = (time / HOURS_PER_DAY) * FULL_ROTATION - DAWN_OFFSET;
+        return (MathUtils.sinDeg(angle) + 1f) / 2f;
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/settings/GraphicsSettings.java
+++ b/core/src/main/java/net/lapidist/colony/settings/GraphicsSettings.java
@@ -17,6 +17,7 @@ public final class GraphicsSettings {
     private static final String LIGHT_KEY = PREFIX + "lighting";
     private static final String NORMAL_KEY = PREFIX + "normalmaps";
     private static final String SPECULAR_KEY = PREFIX + "specularmaps";
+    private static final String DAY_NIGHT_KEY = PREFIX + "dayNightCycle";
 
     private boolean antialiasingEnabled = true;
     private boolean mipMapsEnabled = true;
@@ -27,6 +28,7 @@ public final class GraphicsSettings {
     private boolean lightingEnabled = true;
     private boolean normalMapsEnabled;
     private boolean specularMapsEnabled;
+    private boolean dayNightCycleEnabled = true;
 
     public boolean isAntialiasingEnabled() {
         return antialiasingEnabled;
@@ -100,6 +102,14 @@ public final class GraphicsSettings {
         this.specularMapsEnabled = enabled;
     }
 
+    public boolean isDayNightCycleEnabled() {
+        return dayNightCycleEnabled;
+    }
+
+    public void setDayNightCycleEnabled(final boolean enabled) {
+        this.dayNightCycleEnabled = enabled;
+    }
+
     /** Load graphics settings from the given preferences. */
     public static GraphicsSettings load(final Preferences prefs) {
         GraphicsSettings gs = new GraphicsSettings();
@@ -112,6 +122,7 @@ public final class GraphicsSettings {
         gs.lightingEnabled = prefs.getBoolean(LIGHT_KEY, true);
         gs.normalMapsEnabled = prefs.getBoolean(NORMAL_KEY, false);
         gs.specularMapsEnabled = prefs.getBoolean(SPECULAR_KEY, false);
+        gs.dayNightCycleEnabled = prefs.getBoolean(DAY_NIGHT_KEY, true);
         return gs;
     }
 
@@ -126,5 +137,6 @@ public final class GraphicsSettings {
         prefs.putBoolean(LIGHT_KEY, lightingEnabled);
         prefs.putBoolean(NORMAL_KEY, normalMapsEnabled);
         prefs.putBoolean(SPECULAR_KEY, specularMapsEnabled);
+        prefs.putBoolean(DAY_NIGHT_KEY, dayNightCycleEnabled);
     }
 }

--- a/core/src/main/java/net/lapidist/colony/settings/Settings.java
+++ b/core/src/main/java/net/lapidist/colony/settings/Settings.java
@@ -65,6 +65,7 @@ public final class Settings {
             settings.graphicsSettings.setLightingEnabled(gLoaded.isLightingEnabled());
             settings.graphicsSettings.setNormalMapsEnabled(gLoaded.isNormalMapsEnabled());
             settings.graphicsSettings.setSpecularMapsEnabled(gLoaded.isSpecularMapsEnabled());
+            settings.graphicsSettings.setDayNightCycleEnabled(gLoaded.isDayNightCycleEnabled());
         }
         return settings;
     }

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -63,6 +63,7 @@ graphics.shaderPlugin=Shader Plugin
 graphics.renderer=Renderer
 graphics.spritecache=Sprite Cache
 graphics.lighting=Lighting
+graphics.dayNightCycle=Day/Night Cycle
 common.save=Save
 ui.saving=Saving...
 modSelect.title=Mods

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -62,6 +62,7 @@ graphics.shaderPlugin=Shader-Plugin
 graphics.renderer=Renderer
 graphics.spritecache=Sprite-Cache
 graphics.lighting=Beleuchtung
+graphics.dayNightCycle=Tag-/Nachtzyklus
 common.save=Speichern
 ui.saving=Speichern...
 modSelect.title=Mods

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -62,6 +62,7 @@ graphics.shaderPlugin=Complemento Shader
 graphics.renderer=Renderizador
 graphics.spritecache=Cache de Sprites
 graphics.lighting=Iluminaci\u00f3n
+graphics.dayNightCycle=Ciclo d\u00eda/noche
 common.save=Guardar
 ui.saving=Guardando...
 modSelect.title=Mods

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -62,6 +62,7 @@ graphics.shaderPlugin=Plugin de shader
 graphics.renderer=Moteur de rendu
 graphics.spritecache=Cache de Sprites
 graphics.lighting=\u00c9clairage
+graphics.dayNightCycle=Cycle jour/nuit
 common.save=Sauvegarder
 ui.saving=Sauvegarde...
 modSelect.title=Mods

--- a/tests/src/test/java/net/lapidist/colony/tests/client/systems/DayNightSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/systems/DayNightSystemTest.java
@@ -1,0 +1,61 @@
+package net.lapidist.colony.tests.client.systems;
+
+import box2dLight.RayHandler;
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import com.badlogic.gdx.graphics.Color;
+import net.lapidist.colony.client.systems.ClearScreenSystem;
+import net.lapidist.colony.client.systems.DayNightSystem;
+import net.lapidist.colony.client.systems.LightingSystem;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/** Tests for {@link DayNightSystem}. */
+@RunWith(GdxTestRunner.class)
+public class DayNightSystemTest {
+
+    @Test
+    public void updatesLightAndColor() {
+        ClearScreenSystem clear = new ClearScreenSystem(new Color());
+        LightingSystem lighting = new LightingSystem();
+        RayHandler handler = mock(RayHandler.class);
+        lighting.setRayHandler(handler);
+        DayNightSystem system = new DayNightSystem(clear, lighting);
+        final float noon = 12f;
+        system.setTimeOfDay(noon);
+        World world = new World(new WorldConfigurationBuilder()
+                .with(clear, lighting, system)
+                .build());
+        world.setDelta(0f);
+        world.process();
+        verify(handler).setAmbientLight(1f, 1f, 1f, 1f);
+        final float tolerance = 0.01f;
+        assertEquals(1f, clear.getColor().r, tolerance);
+        system.setTimeOfDay(0f);
+        world.process();
+        verify(handler).setAmbientLight(0f, 0f, 0f, 1f);
+        assertEquals(0f, clear.getColor().r, tolerance);
+        world.dispose();
+    }
+
+    @Test
+    public void wrapsTimeOfDay() {
+        ClearScreenSystem clear = new ClearScreenSystem(new Color());
+        LightingSystem lighting = new LightingSystem();
+        DayNightSystem system = new DayNightSystem(clear, lighting);
+        final float wrapValue = 25f;
+        system.setTimeOfDay(wrapValue);
+        World world = new World(new WorldConfigurationBuilder()
+                .with(clear, lighting, system)
+                .build());
+        world.setDelta(0f);
+        world.process();
+        final float small = 0.001f;
+        assertEquals(1f, system.getTimeOfDay(), small);
+        world.dispose();
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/core/settings/GraphicsSettingsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/settings/GraphicsSettingsTest.java
@@ -28,6 +28,7 @@ public class GraphicsSettingsTest {
         gs.setLightingEnabled(false);
         gs.setNormalMapsEnabled(true);
         gs.setSpecularMapsEnabled(true);
+        gs.setDayNightCycleEnabled(false);
         gs.save(prefs);
         prefs.flush();
 
@@ -41,6 +42,7 @@ public class GraphicsSettingsTest {
         assertFalse(loaded.isLightingEnabled());
         assertTrue(loaded.isNormalMapsEnabled());
         assertTrue(loaded.isSpecularMapsEnabled());
+        assertFalse(loaded.isDayNightCycleEnabled());
     }
 
     @Test
@@ -59,5 +61,6 @@ public class GraphicsSettingsTest {
         assertTrue(loaded.isLightingEnabled());
         assertFalse(loaded.isNormalMapsEnabled());
         assertFalse(loaded.isSpecularMapsEnabled());
+        assertTrue(loaded.isDayNightCycleEnabled());
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/core/settings/SettingsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/settings/SettingsTest.java
@@ -79,6 +79,7 @@ public class SettingsTest {
         graphics.setLightingEnabled(false);
         graphics.setNormalMapsEnabled(true);
         graphics.setSpecularMapsEnabled(true);
+        graphics.setDayNightCycleEnabled(false);
         settings.save();
 
         Settings loaded = Settings.load();
@@ -91,5 +92,6 @@ public class SettingsTest {
         assertEquals(false, loaded.getGraphicsSettings().isLightingEnabled());
         assertEquals(true, loaded.getGraphicsSettings().isNormalMapsEnabled());
         assertEquals(true, loaded.getGraphicsSettings().isSpecularMapsEnabled());
+        assertEquals(false, loaded.getGraphicsSettings().isDayNightCycleEnabled());
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationSpawnNetworkTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationSpawnNetworkTest.java
@@ -68,7 +68,13 @@ public class GameSimulationSpawnNetworkTest {
             Settings settings = new Settings();
             try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
                 var world = MapWorldBuilder.build(
-                        MapWorldBuilder.builder(client.getMapState(), client, stage, new KeyBindings()),
+                        MapWorldBuilder.builder(
+                                client.getMapState(),
+                                client,
+                                stage,
+                                new KeyBindings(),
+                                settings.getGraphicsSettings()
+                        ),
                         null,
                         settings,
                         client.getMapState().cameraPos()

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/GraphicsSettingsScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/GraphicsSettingsScreenTest.java
@@ -30,6 +30,7 @@ public class GraphicsSettingsScreenTest {
     private static final int SCROLL_INDEX = 0;
     private static final int BUTTON_TABLE_INDEX = 1;
     private static final int AA_INDEX = 0;
+    private static final int DAY_NIGHT_INDEX = 8;
     private static final int BACK_INDEX = 0;
     private static final int SAVE_INDEX = 1;
 
@@ -60,10 +61,13 @@ public class GraphicsSettingsScreenTest {
         Table options = getOptions(screen);
         CheckBox aa = (CheckBox) options.getChildren().get(AA_INDEX);
         aa.setChecked(true);
+        CheckBox dn = (CheckBox) options.getChildren().get(DAY_NIGHT_INDEX);
+        dn.setChecked(false);
         Table buttons = getButtons(screen);
         TextButton save = (TextButton) buttons.getChildren().get(SAVE_INDEX);
         save.fire(new ChangeListener.ChangeEvent());
         assertTrue(settings.getGraphicsSettings().isAntialiasingEnabled());
+        assertFalse(settings.getGraphicsSettings().isDayNightCycleEnabled());
     }
 
     @Test

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MapScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MapScreenTest.java
@@ -44,7 +44,7 @@ public class MapScreenTest {
              MockedStatic<MapWorldBuilder> worldStatic = mockStatic(MapWorldBuilder.class);
              MockedStatic<MapUiBuilder> uiStatic = mockStatic(MapUiBuilder.class)) {
             worldStatic.when(() -> MapWorldBuilder.builder(eq(state), eq(client),
-                    any(Stage.class), eq(settings.getKeyBindings())))
+                    any(Stage.class), eq(settings.getKeyBindings()), eq(settings.getGraphicsSettings())))
                     .thenReturn(new WorldConfigurationBuilder());
             worldStatic.when(() -> MapWorldBuilder.build(any(), isNull(), eq(settings), any()))
                     .thenReturn(world);

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MapWorldBuilderConfigurationTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MapWorldBuilderConfigurationTest.java
@@ -17,6 +17,7 @@ import net.lapidist.colony.client.systems.SelectionSystem;
 import net.lapidist.colony.client.systems.PlayerInitSystem;
 import net.lapidist.colony.client.systems.MapRenderSystem;
 import net.lapidist.colony.client.systems.MapRenderDataSystem;
+import net.lapidist.colony.client.systems.DayNightSystem;
 import net.lapidist.colony.components.resources.PlayerResourceComponent;
 import net.lapidist.colony.components.entities.PlayerComponent;
 import net.lapidist.colony.components.state.MapState;
@@ -50,11 +51,12 @@ public class MapWorldBuilderConfigurationTest {
         Stage stage = new Stage(new ScreenViewport(), batch);
         GameClient client = mock(GameClient.class);
         KeyBindings keys = new KeyBindings();
+        net.lapidist.colony.settings.Settings settings = new net.lapidist.colony.settings.Settings();
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
             World world = MapWorldBuilder.build(
-                    MapWorldBuilder.baseBuilder(client, stage, keys),
+                    MapWorldBuilder.baseBuilder(client, stage, keys, settings.getGraphicsSettings()),
                     null,
-                    new net.lapidist.colony.settings.Settings(),
+                    settings,
                     null
             );
 
@@ -66,6 +68,7 @@ public class MapWorldBuilderConfigurationTest {
             assertNotNull(world.getSystem(MapRenderSystem.class));
             assertNull(world.getSystem(MapInitSystem.class));
             assertNull(world.getSystem(MapRenderDataSystem.class));
+            assertNotNull(world.getSystem(DayNightSystem.class));
 
             world.dispose();
         }
@@ -83,11 +86,18 @@ public class MapWorldBuilderConfigurationTest {
         Stage stage = new Stage(new ScreenViewport(), batch);
         GameClient client = mock(GameClient.class);
         KeyBindings keys = new KeyBindings();
+        net.lapidist.colony.settings.Settings settings = new net.lapidist.colony.settings.Settings();
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
             World world = MapWorldBuilder.build(
-                    MapWorldBuilder.builder(new ProvidedMapStateProvider(state), client, stage, keys),
+                    MapWorldBuilder.builder(
+                            new ProvidedMapStateProvider(state),
+                            client,
+                            stage,
+                            keys,
+                            settings.getGraphicsSettings()
+                    ),
                     null,
-                    new net.lapidist.colony.settings.Settings(),
+                    settings,
                     null
             );
             world.process();
@@ -116,11 +126,12 @@ public class MapWorldBuilderConfigurationTest {
         Stage stage = new Stage(new ScreenViewport(), batch);
         GameClient client = mock(GameClient.class);
         KeyBindings keys = new KeyBindings();
+        net.lapidist.colony.settings.Settings settings = new net.lapidist.colony.settings.Settings();
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
             World world = MapWorldBuilder.build(
-                    MapWorldBuilder.builder(state, client, stage, keys),
+                    MapWorldBuilder.builder(state, client, stage, keys, settings.getGraphicsSettings()),
                     null,
-                    new net.lapidist.colony.settings.Settings(),
+                    settings,
                     null
             );
             PlayerCameraSystem camera = world.getSystem(PlayerCameraSystem.class);
@@ -149,11 +160,12 @@ public class MapWorldBuilderConfigurationTest {
         Stage stage = new Stage(new ScreenViewport(), batch);
         GameClient client = mock(GameClient.class);
         KeyBindings keys = new KeyBindings();
+        net.lapidist.colony.settings.Settings settings = new net.lapidist.colony.settings.Settings();
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
             World world = MapWorldBuilder.build(
-                    MapWorldBuilder.baseBuilder(client, stage, keys, resources),
+                    MapWorldBuilder.baseBuilder(client, stage, keys, resources, settings.getGraphicsSettings()),
                     null,
-                    new net.lapidist.colony.settings.Settings(),
+                    settings,
                     null
             );
             world.process();
@@ -185,11 +197,12 @@ public class MapWorldBuilderConfigurationTest {
         Stage stage = new Stage(new ScreenViewport(), batch);
         GameClient client = mock(GameClient.class);
         KeyBindings keys = new KeyBindings();
+        net.lapidist.colony.settings.Settings settings = new net.lapidist.colony.settings.Settings();
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
             World world = MapWorldBuilder.build(
-                    MapWorldBuilder.builder(state, client, stage, keys),
+                    MapWorldBuilder.builder(state, client, stage, keys, settings.getGraphicsSettings()),
                     null,
-                    new net.lapidist.colony.settings.Settings(),
+                    settings,
                     null
             );
             PlayerCameraSystem camera = world.getSystem(PlayerCameraSystem.class);
@@ -216,5 +229,27 @@ public class MapWorldBuilderConfigurationTest {
         World world = MapWorldBuilder.build(new com.artemis.WorldConfigurationBuilder(), null, settings, null);
         assertNotNull(world.getSystem(PlayerCameraSystem.class));
         world.dispose();
+    }
+
+    @Test
+    public void disablesDayNightWhenLightingOff() {
+        Batch batch = mock(Batch.class);
+        when(batch.getTransformMatrix()).thenReturn(new com.badlogic.gdx.math.Matrix4());
+        when(batch.getProjectionMatrix()).thenReturn(new com.badlogic.gdx.math.Matrix4());
+        Stage stage = new Stage(new ScreenViewport(), batch);
+        GameClient client = mock(GameClient.class);
+        KeyBindings keys = new KeyBindings();
+        net.lapidist.colony.settings.Settings settings = new net.lapidist.colony.settings.Settings();
+        settings.getGraphicsSettings().setLightingEnabled(false);
+        try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
+            World world = MapWorldBuilder.build(
+                    MapWorldBuilder.baseBuilder(client, stage, keys, settings.getGraphicsSettings()),
+                    null,
+                    settings,
+                    null
+            );
+            assertNull(world.getSystem(DayNightSystem.class));
+            world.dispose();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement DayNightSystem to change lighting and clear colour
- allow ClearScreenSystem colour adjustments
- support day-night setting in GraphicsSettings and UI
- register the new system in MapWorldBuilder
- update MapScreen and tests for new parameters
- add comprehensive unit tests

## Testing
- `./scripts/check.sh`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684f0ef3cd488328881d657616b10ef0