### PR TITLE
feat: persist save names in config file

### DIFF
--- a/core/src/main/java/net/lapidist/colony/io/AbstractPathService.java
+++ b/core/src/main/java/net/lapidist/colony/io/AbstractPathService.java
@@ -16,6 +16,7 @@ abstract class AbstractPathService implements PathService {
 
     private static final String AUTOSAVE_SUFFIX = Paths.AUTOSAVE_SUFFIX;
     private static final String SETTINGS_FILE = "settings.properties";
+    private static final String CONFIG_FILE = "config.conf";
 
     protected abstract String getGameFolderPath();
 
@@ -32,6 +33,10 @@ abstract class AbstractPathService implements PathService {
 
     private FileHandle getSettingsHandle() {
         return getGameFolder().child(SETTINGS_FILE);
+    }
+
+    private FileHandle getConfigHandle() {
+        return getGameFolder().child(CONFIG_FILE);
     }
 
     private void ensureExists(final FileHandle handle) {
@@ -101,6 +106,12 @@ abstract class AbstractPathService implements PathService {
         if (file.exists()) {
             file.delete();
         }
+    }
+
+    @Override
+    public Path getConfigFile() throws IOException {
+        createGameFoldersIfNotExists();
+        return getConfigHandle().file().toPath();
     }
 
     @Override

--- a/core/src/main/java/net/lapidist/colony/io/PathService.java
+++ b/core/src/main/java/net/lapidist/colony/io/PathService.java
@@ -24,5 +24,7 @@ public interface PathService {
 
     void deleteAutosave(String saveName) throws IOException;
 
+    Path getConfigFile() throws IOException;
+
     Path getModsFolder() throws IOException;
 }

--- a/core/src/main/java/net/lapidist/colony/io/Paths.java
+++ b/core/src/main/java/net/lapidist/colony/io/Paths.java
@@ -70,6 +70,10 @@ public final class Paths {
         service.deleteAutosave(saveName);
     }
 
+    public Path getConfigFile() throws IOException {
+        return service.getConfigFile();
+    }
+
     public Path getModsFolder() throws IOException {
         return service.getModsFolder();
     }

--- a/server/src/main/java/net/lapidist/colony/server/services/MapService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/MapService.java
@@ -56,6 +56,15 @@ public final class MapService {
                     .autosaveName(saveName + Paths.AUTOSAVE_SUFFIX)
                     .build();
             Files.writeString(Paths.get().getLastAutosaveMarker(), saveName);
+            java.nio.file.Path config = Paths.get().getConfigFile();
+            java.util.List<String> lines = new java.util.ArrayList<>();
+            if (java.nio.file.Files.exists(config)) {
+                lines.addAll(java.nio.file.Files.readAllLines(config));
+            }
+            if (!lines.contains(saveName)) {
+                lines.add(saveName);
+                java.nio.file.Files.write(config, lines);
+            }
             return state;
         } finally {
             lock.unlock();

--- a/tests/src/test/java/net/lapidist/colony/tests/core/io/AbstractPathServiceTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/io/AbstractPathServiceTest.java
@@ -38,11 +38,13 @@ public class AbstractPathServiceTest {
         Paths paths = new Paths(service);
 
         Path settings = paths.getSettingsFile();
+        Path config = paths.getConfigFile();
 
         assertTrue(java.nio.file.Files.exists(gameFolder));
         assertTrue(java.nio.file.Files.exists(gameFolder.resolve("saves")));
         assertTrue(java.nio.file.Files.exists(gameFolder.resolve("mods")));
         assertEquals(gameFolder.resolve("settings.properties"), settings);
+        assertEquals(gameFolder.resolve("config.conf"), config);
     }
 
     @Test

--- a/tests/src/test/java/net/lapidist/colony/tests/core/io/PathsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/io/PathsTest.java
@@ -93,6 +93,18 @@ public class PathsTest {
     }
 
     @Test
+    public void delegatesGetConfigFile() throws Exception {
+        PathService service = mock(PathService.class);
+        Path expected = java.nio.file.Paths.get("config.conf");
+        when(service.getConfigFile()).thenReturn(expected);
+        Paths paths = new Paths(service);
+
+        Path actual = paths.getConfigFile();
+        assertEquals(expected, actual);
+        verify(service).getConfigFile();
+    }
+
+    @Test
     public void delegatesGetModsFolder() throws Exception {
         PathService service = mock(PathService.class);
         Path expected = java.nio.file.Paths.get("mods");

--- a/tests/src/test/java/net/lapidist/colony/tests/server/MapServiceConfigTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/MapServiceConfigTest.java
@@ -1,0 +1,44 @@
+package net.lapidist.colony.tests.server;
+
+import net.lapidist.colony.io.Paths;
+import net.lapidist.colony.io.TestPathService;
+import net.lapidist.colony.map.ChunkedMapGenerator;
+import net.lapidist.colony.server.services.MapService;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.junit.Assert.assertTrue;
+
+public class MapServiceConfigTest {
+
+    private static final int SIZE = 8;
+
+    @Test
+    public void loadWritesConfigFile() throws Exception {
+        Path temp = Files.createTempDirectory("mapservice-config");
+        Paths paths = new Paths(new TestPathService(temp));
+        Path config = paths.getConfigFile();
+
+        try (MockedStatic<Paths> mock = Mockito.mockStatic(Paths.class)) {
+            mock.when(Paths::get).thenReturn(paths);
+            MapService service = new MapService(
+                    new ChunkedMapGenerator(),
+                    "cfg-test",
+                    SIZE,
+                    SIZE,
+                    new ReentrantLock()
+            );
+
+            service.load();
+        }
+
+        assertTrue(Files.exists(config));
+        java.util.List<String> lines = Files.readAllLines(config);
+        assertTrue(lines.contains("cfg-test"));
+    }
+}


### PR DESCRIPTION
## Summary
- expose `getConfigFile` in `PathService` and `Paths`
- implement config file handling in `AbstractPathService`
- store loaded save names into `config.conf`
- test new path method delegation
- test config file creation when loading a map

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684f12b34aa08328bf85205c6070c948