### PR TITLE
feat: add environment state record

### DIFF
--- a/core/src/main/java/net/lapidist/colony/components/state/EnvironmentState.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/EnvironmentState.java
@@ -1,0 +1,17 @@
+package net.lapidist.colony.components.state;
+
+import net.lapidist.colony.serialization.KryoType;
+
+/**
+ * World environment information shared between server and clients.
+ *
+ * @param timeOfDay current time of day between 0 and 24
+ * @param season    current season of the year
+ * @param moonPhase phase of the moon between 0 and 1
+ */
+@KryoType
+public record EnvironmentState(float timeOfDay, Season season, float moonPhase) {
+    public EnvironmentState() {
+        this(0f, Season.SPRING, 0f);
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/components/state/MapState.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/MapState.java
@@ -23,6 +23,7 @@ public record MapState(
         ResourceData playerResources,
         PlayerPosition playerPos,
         CameraPosition cameraPos,
+        EnvironmentState environment,
         int width,
         int height
 ) {
@@ -42,6 +43,7 @@ public record MapState(
                 new ResourceData(),
                 new PlayerPosition(DEFAULT_WIDTH / 2, DEFAULT_HEIGHT / 2),
                 new CameraPosition(DEFAULT_WIDTH / 2f, DEFAULT_HEIGHT / 2f),
+                new EnvironmentState(),
                 DEFAULT_WIDTH,
                 DEFAULT_HEIGHT
         );
@@ -129,6 +131,7 @@ public record MapState(
         private ResourceData playerResources;
         private PlayerPosition playerPos;
         private CameraPosition cameraPos;
+        private EnvironmentState environment;
         private int width;
         private int height;
 
@@ -147,6 +150,7 @@ public record MapState(
             this.playerResources = state.playerResources;
             this.playerPos = state.playerPos;
             this.cameraPos = state.cameraPos;
+            this.environment = state.environment;
             this.width = state.width();
             this.height = state.height();
         }
@@ -201,6 +205,11 @@ public record MapState(
             return this;
         }
 
+        public Builder environment(final EnvironmentState newEnvironment) {
+            this.environment = newEnvironment;
+            return this;
+        }
+
         public Builder width(final int newWidth) {
             this.width = newWidth;
             return this;
@@ -223,6 +232,7 @@ public record MapState(
                     playerResources,
                     playerPos,
                     cameraPos,
+                    environment,
                     width,
                     height
             );

--- a/core/src/main/java/net/lapidist/colony/components/state/Season.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/Season.java
@@ -1,0 +1,12 @@
+package net.lapidist.colony.components.state;
+
+import net.lapidist.colony.serialization.KryoType;
+
+/** Enumerates the possible world seasons. */
+@KryoType
+public enum Season {
+    SPRING,
+    SUMMER,
+    AUTUMN,
+    WINTER
+}

--- a/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
@@ -47,6 +47,7 @@ public final class SaveMigrator {
         register(new V31ToV32Migration());
         register(new V32ToV33Migration());
         register(new V33ToV34Migration());
+        register(new V34ToV35Migration());
     }
 
     private SaveMigrator() {

--- a/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
@@ -37,9 +37,10 @@ public enum SaveVersion {
     V31(31),
     V32(32),
     V33(33),
-    V34(34);
+    V34(34),
+    V35(35);
 
-    public static final SaveVersion CURRENT = V34;
+    public static final SaveVersion CURRENT = V35;
 
     private final int number;
 

--- a/core/src/main/java/net/lapidist/colony/save/V34ToV35Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V34ToV35Migration.java
@@ -1,0 +1,25 @@
+package net.lapidist.colony.save;
+
+import net.lapidist.colony.components.state.EnvironmentState;
+import net.lapidist.colony.components.state.MapState;
+
+/** Migration from save version 34 to 35 adding environment state. */
+public final class V34ToV35Migration implements MapStateMigration {
+    @Override
+    public int fromVersion() {
+        return SaveVersion.V34.number();
+    }
+
+    @Override
+    public int toVersion() {
+        return SaveVersion.V35.number();
+    }
+
+    @Override
+    public MapState apply(final MapState state) {
+        return state.toBuilder()
+                .environment(new EnvironmentState())
+                .version(toVersion())
+                .build();
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/serialization/SerializationRegistrar.java
+++ b/core/src/main/java/net/lapidist/colony/serialization/SerializationRegistrar.java
@@ -21,6 +21,8 @@ import net.lapidist.colony.components.state.PlayerPosition;
 import net.lapidist.colony.components.state.CameraPosition;
 import net.lapidist.colony.components.state.PlayerPositionUpdate;
 import net.lapidist.colony.mod.ModMetadata;
+import net.lapidist.colony.components.state.EnvironmentState;
+import net.lapidist.colony.components.state.Season;
 
 /**
  * Registers all serializable classes with a given Kryo instance.
@@ -63,7 +65,7 @@ public final class SerializationRegistrar {
     }
 
     /** Precomputed registration hash for quick access. */
-    public static final int REGISTRATION_HASH = 23376500;
+    public static final int REGISTRATION_HASH = -95745047;
 
     private static final Class<?>[] REGISTERED_TYPES = {
             TileData.class,
@@ -89,6 +91,8 @@ public final class SerializationRegistrar {
             SaveData.class,
             CameraPosition.class,
             PlayerPositionUpdate.class,
-            ModMetadata.class
+            ModMetadata.class,
+            EnvironmentState.class,
+            Season.class
     };
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/components/MapStateBuilderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/components/MapStateBuilderTest.java
@@ -2,6 +2,7 @@ package net.lapidist.colony.tests.components;
 
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.ResourceData;
+import net.lapidist.colony.components.state.EnvironmentState;
 import org.junit.Test;
 
 import net.lapidist.colony.components.state.ChunkPos;
@@ -23,13 +24,15 @@ public class MapStateBuilderTest {
                 .description("d")
                 .chunks(new HashMap<>())
                 .buildings(List.of())
-                .playerResources(new ResourceData());
+                .playerResources(new ResourceData())
+                .environment(new EnvironmentState());
         MapState state = builder.build();
         assertEquals(2, state.version());
         assertEquals("n", state.name());
         assertEquals("s", state.saveName());
         assertEquals("a", state.autosaveName());
         assertEquals("d", state.description());
+        assertNotNull(state.environment());
     }
 
     @Test

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV34Test.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV34Test.java
@@ -1,0 +1,42 @@
+package net.lapidist.colony.tests.server;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Output;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.serialization.KryoRegistry;
+import net.lapidist.colony.save.SaveData;
+import net.lapidist.colony.save.SaveVersion;
+import net.lapidist.colony.serialization.SerializationRegistrar;
+import net.lapidist.colony.save.io.GameStateIO;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.*;
+
+public class GameStateIOMigrationV34Test {
+
+    @Test
+    public void migratesV34ToCurrent() throws Exception {
+        Path file = Files.createTempFile("state", ".dat");
+        MapState state = MapState.builder()
+                .version(SaveVersion.V34.number())
+                .build();
+        Kryo kryo = new Kryo();
+        KryoRegistry.register(kryo);
+        try (Output output = new Output(Files.newOutputStream(file))) {
+            SaveData data = new SaveData(
+                    SaveVersion.V34.number(),
+                    SerializationRegistrar.registrationHash(),
+                    state
+            );
+            kryo.writeObject(output, data);
+        }
+
+        MapState loaded = GameStateIO.load(file);
+        Files.deleteIfExists(file);
+        assertEquals(SaveVersion.CURRENT.number(), loaded.version());
+        assertNotNull(loaded.environment());
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `EnvironmentState` and `Season` in core
- include environment state in `MapState` and builder
- bump save version and register new migration
- update serializer registration
- add migration tests and default builder checks

## Testing
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684f16c1d96c83288af6c8a976ff3208