### PR TITLE
feat: add celestial system and renderer

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/renderers/CelestialRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/CelestialRenderer.java
@@ -1,0 +1,49 @@
+package net.lapidist.colony.client.renderers;
+
+import com.artemis.Aspect;
+import com.artemis.ComponentMapper;
+import com.artemis.Entity;
+import com.artemis.World;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.utils.Disposable;
+import net.lapidist.colony.client.core.io.ResourceLoader;
+import net.lapidist.colony.client.render.MapRenderData;
+import net.lapidist.colony.components.entities.CelestialBodyComponent;
+
+/** Draws celestial bodies like the sun and moon. */
+public final class CelestialRenderer implements EntityRenderer<Void>, Disposable {
+    private final SpriteBatch spriteBatch;
+    private final ResourceLoader resourceLoader;
+    private final World world;
+    private final ComponentMapper<CelestialBodyComponent> bodyMapper;
+
+    public CelestialRenderer(final SpriteBatch batch,
+                             final ResourceLoader loader,
+                             final World worldContext) {
+        this.spriteBatch = batch;
+        this.resourceLoader = loader;
+        this.world = worldContext;
+        this.bodyMapper = worldContext.getMapper(CelestialBodyComponent.class);
+    }
+
+    @Override
+    public void render(final MapRenderData map) {
+        var entities = world.getAspectSubscriptionManager()
+                .get(Aspect.all(CelestialBodyComponent.class))
+                .getEntities();
+        for (int i = 0; i < entities.size(); i++) {
+            Entity e = world.getEntity(entities.get(i));
+            CelestialBodyComponent body = bodyMapper.get(e);
+            TextureRegion region = resourceLoader.findRegion(body.getTexture());
+            if (region != null) {
+                spriteBatch.draw(region, body.getX(), body.getY());
+            }
+        }
+    }
+
+    @Override
+    public void dispose() {
+        // no-op
+    }
+}

--- a/client/src/main/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRenderer.java
@@ -85,12 +85,17 @@ public final class LoadingSpriteMapRenderer implements MapRenderer, Disposable {
                     resourceLoader,
                     world
             );
+            CelestialRenderer celestialRenderer = new CelestialRenderer(
+                    spriteBatch,
+                    resourceLoader,
+                    world
+            );
             ResourceRenderer resourceRenderer = new ResourceRenderer(
                     spriteBatch,
                     cameraSystem,
                     world.getSystem(MapRenderDataSystem.class)
             );
-            MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer);
+            MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer, celestialRenderer);
             delegate = new SpriteBatchMapRenderer(
                     spriteBatch,
                     resourceLoader,

--- a/client/src/main/java/net/lapidist/colony/client/renderers/MapEntityRenderers.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/MapEntityRenderers.java
@@ -3,6 +3,7 @@ package net.lapidist.colony.client.renderers;
 /** Holds auxiliary entity renderers used by the map renderer. */
 public record MapEntityRenderers(
         ResourceRenderer resourceRenderer,
-        PlayerRenderer playerRenderer
+        PlayerRenderer playerRenderer,
+        CelestialRenderer celestialRenderer
 ) {
 }

--- a/client/src/main/java/net/lapidist/colony/client/renderers/SpriteBatchMapRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/SpriteBatchMapRenderer.java
@@ -78,6 +78,7 @@ public final class SpriteBatchMapRenderer implements MapRenderer, Disposable {
         buildingRenderer.render(map);
         entityRenderers.resourceRenderer().render(map);
         entityRenderers.playerRenderer().render(map);
+        entityRenderers.celestialRenderer().render(map);
 
         spriteBatch.end();
         if (shader != null) {
@@ -94,6 +95,7 @@ public final class SpriteBatchMapRenderer implements MapRenderer, Disposable {
         resourceLoader.dispose();
         entityRenderers.resourceRenderer().dispose();
         entityRenderers.playerRenderer().dispose();
+        entityRenderers.celestialRenderer().dispose();
         spriteBatch.dispose();
         if (shader != null) {
             shader.dispose();

--- a/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -28,9 +28,11 @@ import net.lapidist.colony.client.systems.network.ChunkRequestQueueSystem;
 import net.lapidist.colony.client.systems.network.TileUpdateSystem;
 import net.lapidist.colony.client.systems.network.BuildingUpdateSystem;
 import net.lapidist.colony.client.systems.network.ResourceUpdateSystem;
+import net.lapidist.colony.client.systems.CelestialSystem;
 import net.lapidist.colony.client.systems.MapInitSystem;
 import net.lapidist.colony.client.systems.MapRenderDataSystem;
 import net.lapidist.colony.client.systems.PlayerInitSystem;
+import net.lapidist.colony.components.entities.CelestialBodyComponent;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.ResourceData;
 import net.lapidist.colony.components.state.PlayerPosition;
@@ -50,6 +52,8 @@ public final class MapWorldBuilder {
 
     private MapWorldBuilder() {
     }
+
+    private static final float HALF_ROTATION = 180f;
 
     /**
      * Create a base {@link WorldConfigurationBuilder} containing the default
@@ -167,6 +171,7 @@ public final class MapWorldBuilder {
                         new ResourceUpdateSystem(client),
                         new ChunkLoadSystem(client),
                         new ChunkRequestQueueSystem(client),
+                        new CelestialSystem(client, state.environment()),
                         new MapRenderSystem(),
                         particleSystem,
                         lighting,
@@ -238,6 +243,24 @@ public final class MapWorldBuilder {
             cameraSystem.getCamera().update();
         }
         Events.init(world.getSystem(EventSystem.class));
+        createCelestialEntities(world);
         return world;
+    }
+
+    private static void createCelestialEntities(final World world) {
+        float radius = 0f; // auto-calculated by system when zero
+        var sun = world.createEntity();
+        var sunComp = new CelestialBodyComponent();
+        sunComp.setTexture("player0");
+        sunComp.setOrbitRadius(radius);
+        sunComp.setOrbitOffset(0f);
+        sun.edit().add(sunComp);
+
+        var moon = world.createEntity();
+        var moonComp = new CelestialBodyComponent();
+        moonComp.setTexture("player0");
+        moonComp.setOrbitRadius(radius);
+        moonComp.setOrbitOffset(HALF_ROTATION);
+        moon.edit().add(moonComp);
     }
 }

--- a/client/src/main/java/net/lapidist/colony/client/systems/CelestialSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/CelestialSystem.java
@@ -1,0 +1,55 @@
+package net.lapidist.colony.client.systems;
+
+import com.artemis.Aspect;
+import com.artemis.BaseSystem;
+import com.artemis.ComponentMapper;
+import com.artemis.Entity;
+import com.badlogic.gdx.math.MathUtils;
+import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.components.entities.CelestialBodyComponent;
+import net.lapidist.colony.components.state.EnvironmentState;
+import net.lapidist.colony.components.state.MapState;
+
+/** Updates celestial body positions based on the current environment. */
+public final class CelestialSystem extends BaseSystem {
+    private final net.lapidist.colony.client.network.GameClient client;
+    private final EnvironmentState environment;
+    private ComponentMapper<CelestialBodyComponent> bodyMapper;
+
+    private static final float HOURS_PER_DAY = 24f;
+    private static final float FULL_ROTATION = 360f;
+    private static final float DAWN_OFFSET = 90f;
+
+    public CelestialSystem(final net.lapidist.colony.client.network.GameClient clientToUse,
+                           final EnvironmentState env) {
+        this.client = clientToUse;
+        this.environment = env;
+    }
+
+    @Override
+    public void initialize() {
+        bodyMapper = world.getMapper(CelestialBodyComponent.class);
+    }
+
+    @Override
+    protected void processSystem() {
+        int width = client != null ? client.getMapWidth() : MapState.DEFAULT_WIDTH;
+        int height = client != null ? client.getMapHeight() : MapState.DEFAULT_HEIGHT;
+        float centerX = width * GameConstants.TILE_SIZE / 2f;
+        float centerY = height * GameConstants.TILE_SIZE / 2f;
+        var entities = world.getAspectSubscriptionManager()
+                .get(Aspect.all(CelestialBodyComponent.class))
+                .getEntities();
+        for (int i = 0; i < entities.size(); i++) {
+            Entity e = world.getEntity(entities.get(i));
+            CelestialBodyComponent body = bodyMapper.get(e);
+            float radius = body.getOrbitRadius() > 0
+                    ? body.getOrbitRadius()
+                    : Math.max(width, height) * GameConstants.TILE_SIZE;
+            float angle = (environment.timeOfDay() / HOURS_PER_DAY) * FULL_ROTATION - DAWN_OFFSET
+                    + body.getOrbitOffset();
+            body.setX(centerX + MathUtils.cosDeg(angle) * radius);
+            body.setY(centerY + MathUtils.sinDeg(angle) * radius);
+        }
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/components/entities/CelestialBodyComponent.java
+++ b/core/src/main/java/net/lapidist/colony/components/entities/CelestialBodyComponent.java
@@ -1,0 +1,54 @@
+package net.lapidist.colony.components.entities;
+
+import com.artemis.Component;
+
+/**
+ * Component describing a celestial body sprite and its orbital parameters.
+ */
+public final class CelestialBodyComponent extends Component {
+    private String texture;
+    private float orbitRadius;
+    private float orbitOffset;
+    private float x;
+    private float y;
+
+    public String getTexture() {
+        return texture;
+    }
+
+    public void setTexture(final String textureToSet) {
+        this.texture = textureToSet;
+    }
+
+    public float getOrbitRadius() {
+        return orbitRadius;
+    }
+
+    public void setOrbitRadius(final float radius) {
+        this.orbitRadius = radius;
+    }
+
+    public float getOrbitOffset() {
+        return orbitOffset;
+    }
+
+    public void setOrbitOffset(final float offset) {
+        this.orbitOffset = offset;
+    }
+
+    public float getX() {
+        return x;
+    }
+
+    public void setX(final float xToSet) {
+        this.x = xToSet;
+    }
+
+    public float getY() {
+        return y;
+    }
+
+    public void setY(final float yToSet) {
+        this.y = yToSet;
+    }
+}

--- a/tests/src/jmh/java/net/lapidist/colony/tests/benchmarks/SpriteBatchRendererBenchmark.java
+++ b/tests/src/jmh/java/net/lapidist/colony/tests/benchmarks/SpriteBatchRendererBenchmark.java
@@ -23,6 +23,7 @@ import net.lapidist.colony.client.renderers.SpriteBatchMapRenderer;
 import net.lapidist.colony.client.renderers.TileRenderer;
 import net.lapidist.colony.client.renderers.PlayerRenderer;
 import net.lapidist.colony.client.renderers.MapEntityRenderers;
+import net.lapidist.colony.client.renderers.CelestialRenderer;
 import net.lapidist.colony.client.systems.CameraProvider;
 import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.components.maps.MapComponent;
@@ -66,7 +67,8 @@ public class SpriteBatchRendererBenchmark {
         BuildingRenderer buildingRenderer = new BuildingRenderer(batch, loader, camera, resolver);
         ResourceRenderer resourceRenderer = mock(ResourceRenderer.class);
         PlayerRenderer playerRenderer = mock(PlayerRenderer.class);
-        MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer);
+        CelestialRenderer celestialRenderer = mock(CelestialRenderer.class);
+        MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer, celestialRenderer);
         cachedRenderer = new SpriteBatchMapRenderer(
                 batch, loader, tileRenderer, buildingRenderer, renderers, true, null);
         plainRenderer = new SpriteBatchMapRenderer(

--- a/tests/src/test/java/net/lapidist/colony/client/renderers/SpriteBatchMapRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/renderers/SpriteBatchMapRendererTest.java
@@ -28,7 +28,8 @@ public class SpriteBatchMapRendererTest {
         BuildingRenderer buildingRenderer = mock(BuildingRenderer.class);
         ResourceRenderer resourceRenderer = mock(ResourceRenderer.class);
         PlayerRenderer playerRenderer = mock(PlayerRenderer.class);
-        MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer);
+        CelestialRenderer celestialRenderer = mock(CelestialRenderer.class);
+        MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer, celestialRenderer);
 
         SpriteBatchMapRenderer renderer = new SpriteBatchMapRenderer(
                 batch, loader, tileRenderer, buildingRenderer, renderers, true, null);
@@ -52,7 +53,8 @@ public class SpriteBatchMapRendererTest {
         BuildingRenderer buildingRenderer = mock(BuildingRenderer.class);
         ResourceRenderer resourceRenderer = mock(ResourceRenderer.class);
         PlayerRenderer playerRenderer = mock(PlayerRenderer.class);
-        MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer);
+        CelestialRenderer celestialRenderer = mock(CelestialRenderer.class);
+        MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer, celestialRenderer);
 
         SpriteBatchMapRenderer renderer = new SpriteBatchMapRenderer(
                 batch, loader, tileRenderer, buildingRenderer, renderers, false, null);
@@ -75,8 +77,9 @@ public class SpriteBatchMapRendererTest {
         BuildingRenderer buildingRenderer = mock(BuildingRenderer.class);
         ResourceRenderer resourceRenderer = mock(ResourceRenderer.class);
         PlayerRenderer playerRenderer = mock(PlayerRenderer.class);
+        CelestialRenderer celestialRenderer = mock(CelestialRenderer.class);
         ShaderProgram shader = mock(ShaderProgram.class);
-        MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer);
+        MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer, celestialRenderer);
 
         SpriteBatchMapRenderer renderer = new SpriteBatchMapRenderer(
                 batch, loader, tileRenderer, buildingRenderer, renderers, false, shader);
@@ -121,7 +124,8 @@ public class SpriteBatchMapRendererTest {
         BuildingRenderer buildingRenderer = mock(BuildingRenderer.class);
         ResourceRenderer resourceRenderer = mock(ResourceRenderer.class);
         PlayerRenderer playerRenderer = mock(PlayerRenderer.class);
-        MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer);
+        CelestialRenderer celestialRenderer = mock(CelestialRenderer.class);
+        MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer, celestialRenderer);
 
         SpriteBatchMapRenderer renderer = new SpriteBatchMapRenderer(
                 batch, loader, tileRenderer, buildingRenderer, renderers, false, null);
@@ -160,7 +164,8 @@ public class SpriteBatchMapRendererTest {
         BuildingRenderer buildingRenderer = mock(BuildingRenderer.class);
         ResourceRenderer resourceRenderer = mock(ResourceRenderer.class);
         PlayerRenderer playerRenderer = mock(PlayerRenderer.class);
-        MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer);
+        CelestialRenderer celestialRenderer = mock(CelestialRenderer.class);
+        MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer, celestialRenderer);
         box2dLight.RayHandler lights = mock(box2dLight.RayHandler.class);
 
         SpriteBatchMapRenderer renderer = new SpriteBatchMapRenderer(

--- a/tests/src/test/java/net/lapidist/colony/tests/client/systems/CelestialSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/systems/CelestialSystemTest.java
@@ -1,0 +1,41 @@
+package net.lapidist.colony.tests.client.systems;
+
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import net.lapidist.colony.client.systems.CelestialSystem;
+import net.lapidist.colony.components.entities.CelestialBodyComponent;
+import net.lapidist.colony.components.state.EnvironmentState;
+import net.lapidist.colony.components.state.Season;
+import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/** Tests for {@link CelestialSystem}. */
+@RunWith(GdxTestRunner.class)
+public class CelestialSystemTest {
+    private static final float TIME = 6f;
+    private static final float EPSILON = 0.01f;
+    @Test
+    public void updatesBodyPosition() {
+        EnvironmentState env = new EnvironmentState(TIME, Season.SPRING, 0f);
+        CelestialSystem system = new CelestialSystem(null, env);
+        World world = new World(new WorldConfigurationBuilder().with(system).build());
+        var e = world.createEntity();
+        CelestialBodyComponent body = new CelestialBodyComponent();
+        body.setTexture("player0");
+        body.setOrbitRadius(1f);
+        body.setOrbitOffset(0f);
+        e.edit().add(body);
+        world.setDelta(0f);
+        world.process();
+        float centerX = MapState.DEFAULT_WIDTH * GameConstants.TILE_SIZE / 2f;
+        float centerY = MapState.DEFAULT_HEIGHT * GameConstants.TILE_SIZE / 2f;
+        assertEquals(centerX + 1f, body.getX(), EPSILON);
+        assertEquals(centerY, body.getY(), EPSILON);
+        world.dispose();
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MapWorldBuilderConfigurationTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MapWorldBuilderConfigurationTest.java
@@ -69,6 +69,7 @@ public class MapWorldBuilderConfigurationTest {
             assertNull(world.getSystem(MapInitSystem.class));
             assertNull(world.getSystem(MapRenderDataSystem.class));
             assertNotNull(world.getSystem(DayNightSystem.class));
+            assertNotNull(world.getSystem(net.lapidist.colony.client.systems.CelestialSystem.class));
 
             world.dispose();
         }
@@ -106,6 +107,7 @@ public class MapWorldBuilderConfigurationTest {
             assertNotNull(world.getSystem(PlayerCameraSystem.class));
             assertNotNull(world.getSystem(PlayerMovementSystem.class));
             assertNotNull(world.getSystem(MapRenderDataSystem.class));
+            assertNotNull(world.getSystem(net.lapidist.colony.client.systems.CelestialSystem.class));
             assertEquals(1, world.getAspectSubscriptionManager()
                     .get(Aspect.all(PlayerResourceComponent.class))
                     .getEntities().size());


### PR DESCRIPTION
## Summary
- add `CelestialBodyComponent` with sprite and orbit properties
- update `MapWorldBuilder` to spawn sun and moon entities
- implement `CelestialSystem` and hook into world builder
- draw celestial bodies via new `CelestialRenderer`
- cover new functionality with tests

## Testing
- `./gradlew spotlessApply`
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684f201844748328b85371fad3d353f1