### PR TITLE
fix: tone down day-night brightness

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/systems/DayNightSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/DayNightSystem.java
@@ -22,10 +22,10 @@ public final class DayNightSystem extends BaseSystem {
     private static final float SUNRISE_TIME = 6f;
     private static final float NOON_TIME = 12f;
     private static final float SUNSET_TIME = 18f;
-    private static final Color NIGHT_COLOR = new Color(0.05f, 0.05f, 0.1f, 1f);
-    private static final Color SUNRISE_COLOR = new Color(1f, 0.6f, 0.4f, 1f);
-    private static final Color DAY_COLOR = new Color(1f, 1f, 1f, 1f);
-    private static final Color MOON_COLOR = new Color(0.4f, 0.4f, 0.5f, 1f);
+    private static final Color NIGHT_COLOR = new Color(0.02f, 0.02f, 0.05f, 1f);
+    private static final Color SUNRISE_COLOR = new Color(0.8f, 0.55f, 0.35f, 1f);
+    private static final Color DAY_COLOR = new Color(0.9f, 0.95f, 1f, 1f);
+    private static final Color MOON_COLOR = new Color(0.3f, 0.3f, 0.35f, 1f);
 
     public DayNightSystem(final ClearScreenSystem clearSystem,
                           final LightingSystem lighting,

--- a/tests/src/test/java/net/lapidist/colony/tests/client/systems/DayNightSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/systems/DayNightSystemTest.java
@@ -21,9 +21,12 @@ import static org.mockito.Mockito.*;
 @SuppressWarnings("checkstyle:magicnumber")
 public class DayNightSystemTest {
 
-    private static final float NIGHT_RED = 0.05f;
-    private static final float NIGHT_BLUE = 0.1f;
-    private static final float MOON_RED = 0.45f;
+    private static final float DAY_RED = 0.9f;
+    private static final float DAY_GREEN = 0.95f;
+    private static final float DAY_BLUE = 1f;
+    private static final float NIGHT_RED = 0.02f;
+    private static final float NIGHT_BLUE = 0.05f;
+    private static final float MOON_RED = 0.32f;
     private static final float TOLERANCE = 0.01f;
 
     @Test
@@ -41,8 +44,8 @@ public class DayNightSystemTest {
                 .build());
         world.setDelta(0f);
         world.process();
-        verify(handler).setAmbientLight(1f, 1f, 1f, 1f);
-        assertEquals(1f, clear.getColor().r, TOLERANCE);
+        verify(handler).setAmbientLight(DAY_RED, DAY_GREEN, DAY_BLUE, 1f);
+        assertEquals(DAY_RED, clear.getColor().r, TOLERANCE);
         system.setTimeOfDay(0f);
         world.process();
 //CHECKSTYLE:OFF


### PR DESCRIPTION
## Summary
- desaturate day and night lighting colors
- update DayNightSystem tests for new color constants

## Testing
- `./scripts/check.sh`
- `./gradlew codeCoverageReport`

------
https://chatgpt.com/codex/tasks/task_e_684f2a64bcc48328a59109e44e41a38b