### PR TITLE
feat: sync environment across server and client

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
+++ b/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
@@ -9,6 +9,7 @@ import net.lapidist.colony.components.state.BuildingPlacementData;
 import net.lapidist.colony.components.state.BuildingRemovalData;
 import net.lapidist.colony.components.state.ResourceGatherRequestData;
 import net.lapidist.colony.components.state.ResourceUpdateData;
+import net.lapidist.colony.components.state.EnvironmentUpdate;
 import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.ChunkPos;
@@ -131,6 +132,7 @@ public final class GameClient extends AbstractMessageEndpoint implements AutoClo
         Queue<BuildingRemovalData> buildingRemovals = registerQueue(BuildingRemovalData.class);
         Queue<ChatMessage> chatMessages = registerQueue(ChatMessage.class);
         Queue<ResourceUpdateData> resourceUpdates = registerQueue(ResourceUpdateData.class);
+        Queue<EnvironmentUpdate> environmentUpdates = registerQueue(EnvironmentUpdate.class);
 
         this.handlers = java.util.List.of(
                 new MapMetadataHandler(meta -> {
@@ -173,7 +175,8 @@ public final class GameClient extends AbstractMessageEndpoint implements AutoClo
                 new QueueingMessageHandler<>(BuildingData.class, messageQueues),
                 new QueueingMessageHandler<>(BuildingRemovalData.class, messageQueues),
                 new QueueingMessageHandler<>(ChatMessage.class, messageQueues),
-                new ResourceUpdateHandler(messageQueues, () -> mapState, ms -> mapState = ms)
+                new ResourceUpdateHandler(messageQueues, () -> mapState, ms -> mapState = ms),
+                new QueueingMessageHandler<>(EnvironmentUpdate.class, messageQueues)
         );
     }
 
@@ -250,6 +253,11 @@ public final class GameClient extends AbstractMessageEndpoint implements AutoClo
      */
     public MapState getMapState() {
         return mapState;
+    }
+
+    /** Replace the current map state. */
+    public void setMapState(final MapState state) {
+        this.mapState = state;
     }
 
     /**
@@ -414,6 +422,12 @@ public final class GameClient extends AbstractMessageEndpoint implements AutoClo
     @SuppressWarnings("unchecked")
     public void injectResourceUpdate(final ResourceUpdateData data) {
         ((Queue<ResourceUpdateData>) messageQueues.get(ResourceUpdateData.class)).add(data);
+    }
+
+    /** Inject an environment update into the local message queue. */
+    @SuppressWarnings("unchecked")
+    public void injectEnvironmentUpdate(final EnvironmentUpdate data) {
+        ((Queue<EnvironmentUpdate>) messageQueues.get(EnvironmentUpdate.class)).add(data);
     }
 
 

--- a/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -28,6 +28,7 @@ import net.lapidist.colony.client.systems.network.ChunkRequestQueueSystem;
 import net.lapidist.colony.client.systems.network.TileUpdateSystem;
 import net.lapidist.colony.client.systems.network.BuildingUpdateSystem;
 import net.lapidist.colony.client.systems.network.ResourceUpdateSystem;
+import net.lapidist.colony.client.systems.network.EnvironmentUpdateSystem;
 import net.lapidist.colony.client.systems.CelestialSystem;
 import net.lapidist.colony.client.systems.MapInitSystem;
 import net.lapidist.colony.client.systems.MapRenderDataSystem;
@@ -169,9 +170,13 @@ public final class MapWorldBuilder {
                         new TileUpdateSystem(client),
                         new BuildingUpdateSystem(client),
                         new ResourceUpdateSystem(client),
+                        new EnvironmentUpdateSystem(client),
                         new ChunkLoadSystem(client),
                         new ChunkRequestQueueSystem(client),
-                        new CelestialSystem(client, state.environment()),
+                        new CelestialSystem(client, () ->
+                                client != null && client.getMapState() != null
+                                        ? client.getMapState().environment()
+                                        : state.environment()),
                         new MapRenderSystem(),
                         particleSystem,
                         lighting,
@@ -179,7 +184,10 @@ public final class MapWorldBuilder {
                 );
 
         if (graphics == null || (graphics.isLightingEnabled() && graphics.isDayNightCycleEnabled())) {
-            builder.with(new DayNightSystem(clear, lighting, state.environment()));
+            builder.with(new DayNightSystem(clear, lighting, () ->
+                    client != null && client.getMapState() != null
+                            ? client.getMapState().environment()
+                            : state.environment()));
         }
 
         if (provider != null) {

--- a/client/src/main/java/net/lapidist/colony/client/systems/CelestialSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/CelestialSystem.java
@@ -13,7 +13,7 @@ import net.lapidist.colony.components.state.MapState;
 /** Updates celestial body positions based on the current environment. */
 public final class CelestialSystem extends BaseSystem {
     private final net.lapidist.colony.client.network.GameClient client;
-    private final EnvironmentState environment;
+    private final java.util.function.Supplier<EnvironmentState> environment;
     private ComponentMapper<CelestialBodyComponent> bodyMapper;
 
     private static final float HOURS_PER_DAY = 24f;
@@ -21,7 +21,7 @@ public final class CelestialSystem extends BaseSystem {
     private static final float DAWN_OFFSET = 90f;
 
     public CelestialSystem(final net.lapidist.colony.client.network.GameClient clientToUse,
-                           final EnvironmentState env) {
+                           final java.util.function.Supplier<EnvironmentState> env) {
         this.client = clientToUse;
         this.environment = env;
     }
@@ -46,7 +46,8 @@ public final class CelestialSystem extends BaseSystem {
             float radius = body.getOrbitRadius() > 0
                     ? body.getOrbitRadius()
                     : Math.max(width, height) * GameConstants.TILE_SIZE;
-            float angle = (environment.timeOfDay() / HOURS_PER_DAY) * FULL_ROTATION - DAWN_OFFSET
+            EnvironmentState env = environment.get();
+            float angle = (env.timeOfDay() / HOURS_PER_DAY) * FULL_ROTATION - DAWN_OFFSET
                     + body.getOrbitOffset();
             body.setX(centerX + MathUtils.cosDeg(angle) * radius);
             body.setY(centerY + MathUtils.sinDeg(angle) * radius);

--- a/client/src/main/java/net/lapidist/colony/client/systems/DayNightSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/DayNightSystem.java
@@ -13,7 +13,7 @@ public final class DayNightSystem extends BaseSystem {
 
     private final ClearScreenSystem clearScreenSystem;
     private final LightingSystem lightingSystem;
-    private final EnvironmentState environment;
+    private final java.util.function.Supplier<EnvironmentState> environment;
     private float timeOfDay;
 
     private static final float HOURS_PER_DAY = 24f;
@@ -29,7 +29,7 @@ public final class DayNightSystem extends BaseSystem {
 
     public DayNightSystem(final ClearScreenSystem clearSystem,
                           final LightingSystem lighting,
-                          final EnvironmentState env) {
+                          final java.util.function.Supplier<EnvironmentState> env) {
         this.clearScreenSystem = clearSystem;
         this.lightingSystem = lighting;
         this.environment = env;
@@ -47,9 +47,11 @@ public final class DayNightSystem extends BaseSystem {
 
     @Override
     protected void processSystem() {
-        timeOfDay = wrap(timeOfDay + world.getDelta());
+        EnvironmentState env = environment.get();
+        timeOfDay = env != null ? wrap(env.timeOfDay()) : wrap(timeOfDay + world.getDelta());
         Color c = clearScreenSystem.getColor();
-        calculateColor(timeOfDay, environment.moonPhase(), c);
+        float moon = env != null ? env.moonPhase() : 0f;
+        calculateColor(timeOfDay, moon, c);
         RayHandler handler = lightingSystem.getRayHandler();
         if (handler != null) {
             handler.setAmbientLight(c.r, c.g, c.b, 1f);

--- a/client/src/main/java/net/lapidist/colony/client/systems/network/EnvironmentUpdateSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/network/EnvironmentUpdateSystem.java
@@ -1,0 +1,28 @@
+package net.lapidist.colony.client.systems.network;
+
+import com.artemis.BaseSystem;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.components.state.EnvironmentUpdate;
+import net.lapidist.colony.components.state.MapState;
+
+/** Applies environment updates received from the server. */
+public final class EnvironmentUpdateSystem extends BaseSystem {
+    private final GameClient client;
+
+    public EnvironmentUpdateSystem(final GameClient clientToUse) {
+        this.client = clientToUse;
+    }
+
+    @Override
+    protected void processSystem() {
+        EnvironmentUpdate update;
+        while ((update = client.poll(EnvironmentUpdate.class)) != null) {
+            MapState state = client.getMapState();
+            if (state != null) {
+                client.setMapState(state.toBuilder()
+                        .environment(update.state())
+                        .build());
+            }
+        }
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/components/state/EnvironmentUpdate.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/EnvironmentUpdate.java
@@ -1,0 +1,11 @@
+package net.lapidist.colony.components.state;
+
+import net.lapidist.colony.serialization.KryoType;
+
+/** Message broadcasting the latest environment state. */
+@KryoType
+public record EnvironmentUpdate(EnvironmentState state) {
+    public EnvironmentUpdate() {
+        this(new EnvironmentState());
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/serialization/SerializationRegistrar.java
+++ b/core/src/main/java/net/lapidist/colony/serialization/SerializationRegistrar.java
@@ -22,6 +22,7 @@ import net.lapidist.colony.components.state.CameraPosition;
 import net.lapidist.colony.components.state.PlayerPositionUpdate;
 import net.lapidist.colony.mod.ModMetadata;
 import net.lapidist.colony.components.state.EnvironmentState;
+import net.lapidist.colony.components.state.EnvironmentUpdate;
 import net.lapidist.colony.components.state.Season;
 
 /**
@@ -65,7 +66,7 @@ public final class SerializationRegistrar {
     }
 
     /** Precomputed registration hash for quick access. */
-    public static final int REGISTRATION_HASH = -95745047;
+    public static final int REGISTRATION_HASH = -841100379;
 
     private static final Class<?>[] REGISTERED_TYPES = {
             TileData.class,
@@ -93,6 +94,7 @@ public final class SerializationRegistrar {
             PlayerPositionUpdate.class,
             ModMetadata.class,
             EnvironmentState.class,
+            EnvironmentUpdate.class,
             Season.class
     };
 }

--- a/server/src/main/java/net/lapidist/colony/base/BaseGameplaySystemsMod.java
+++ b/server/src/main/java/net/lapidist/colony/base/BaseGameplaySystemsMod.java
@@ -13,5 +13,6 @@ public final class BaseGameplaySystemsMod implements GameMod {
         if (service != null) {
             srv.registerSystem(service);
         }
+        srv.registerSystem(new net.lapidist.colony.server.systems.EnvironmentSystem(s));
     }
 }

--- a/server/src/main/java/net/lapidist/colony/server/systems/EnvironmentSystem.java
+++ b/server/src/main/java/net/lapidist/colony/server/systems/EnvironmentSystem.java
@@ -1,0 +1,88 @@
+package net.lapidist.colony.server.systems;
+
+import net.lapidist.colony.components.state.EnvironmentState;
+import net.lapidist.colony.components.state.EnvironmentUpdate;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.Season;
+import net.lapidist.colony.mod.GameSystem;
+import net.lapidist.colony.server.GameServer;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/** Periodically advances the world environment and broadcasts updates. */
+public final class EnvironmentSystem implements GameSystem {
+    private static final int PERIOD_MS = 50;
+    private static final int DAYS_PER_SEASON = 30;
+    private static final float HOURS_PER_DAY = 24f;
+    private static final float MILLIS_IN_SECOND = 1000f;
+    private static final float SPRING_LENGTH = 14f;
+    private static final float SUMMER_LENGTH = 16f;
+    private static final float AUTUMN_LENGTH = 12f;
+    private static final float WINTER_LENGTH = 8f;
+
+    private final GameServer server;
+    private ScheduledExecutorService executor;
+    private int dayInSeason;
+
+    public EnvironmentSystem(final GameServer srv) {
+        this.server = srv;
+    }
+
+    @Override
+    public void start() {
+        executor = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r);
+            t.setDaemon(true);
+            return t;
+        });
+        executor.scheduleAtFixedRate(this::tick, PERIOD_MS, PERIOD_MS, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void stop() {
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+    }
+
+    private void tick() {
+        MapState state = server.getMapState();
+        EnvironmentState env = state.environment();
+        float dayLength = dayLength(env.season());
+        float increment = (PERIOD_MS / MILLIS_IN_SECOND) * HOURS_PER_DAY / dayLength;
+        float time = env.timeOfDay() + increment;
+        Season season = env.season();
+        float moon = env.moonPhase();
+        if (time >= HOURS_PER_DAY) {
+            time -= HOURS_PER_DAY;
+            dayInSeason++;
+            moon += 1f / DAYS_PER_SEASON;
+            if (moon >= 1f) {
+                moon -= 1f;
+            }
+            if (dayInSeason >= DAYS_PER_SEASON) {
+                dayInSeason = 0;
+                season = next(season);
+            }
+        }
+        EnvironmentState updated = new EnvironmentState(time, season, moon);
+        server.setMapState(state.toBuilder().environment(updated).build());
+        server.broadcast(new EnvironmentUpdate(updated));
+    }
+
+    private static Season next(final Season current) {
+        Season[] values = Season.values();
+        return values[(current.ordinal() + 1) % values.length];
+    }
+
+    private static float dayLength(final Season season) {
+        return switch (season) {
+            case SPRING -> SPRING_LENGTH;
+            case SUMMER -> SUMMER_LENGTH;
+            case AUTUMN -> AUTUMN_LENGTH;
+            case WINTER -> WINTER_LENGTH;
+        };
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/server/systems/package-info.java
+++ b/server/src/main/java/net/lapidist/colony/server/systems/package-info.java
@@ -1,0 +1,2 @@
+/** Server side game systems. */
+package net.lapidist.colony.server.systems;

--- a/tests/src/test/java/net/lapidist/colony/tests/client/systems/CelestialSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/systems/CelestialSystemTest.java
@@ -21,8 +21,9 @@ public class CelestialSystemTest {
     private static final float EPSILON = 0.01f;
     @Test
     public void updatesBodyPosition() {
-        EnvironmentState env = new EnvironmentState(TIME, Season.SPRING, 0f);
-        CelestialSystem system = new CelestialSystem(null, env);
+        java.util.concurrent.atomic.AtomicReference<EnvironmentState> ref =
+                new java.util.concurrent.atomic.AtomicReference<>(new EnvironmentState(TIME, Season.SPRING, 0f));
+        CelestialSystem system = new CelestialSystem(null, ref::get);
         World world = new World(new WorldConfigurationBuilder().with(system).build());
         var e = world.createEntity();
         CelestialBodyComponent body = new CelestialBodyComponent();

--- a/tests/src/test/java/net/lapidist/colony/tests/client/systems/DayNightSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/systems/DayNightSystemTest.java
@@ -25,6 +25,8 @@ public class DayNightSystemTest {
     private static final float NIGHT_BLUE = 0.1f;
     private static final float MOON_RED = 0.45f;
     private static final float TOLERANCE = 0.01f;
+    private static final float NOON = 12f;
+    private static final float WRAP_VALUE = 25f;
 
     @Test
     public void updatesLightAndColor() {
@@ -32,10 +34,10 @@ public class DayNightSystemTest {
         LightingSystem lighting = new LightingSystem();
         RayHandler handler = mock(RayHandler.class);
         lighting.setRayHandler(handler);
-        EnvironmentState env = new EnvironmentState(0f, Season.SPRING, 0f);
-        DayNightSystem system = new DayNightSystem(clear, lighting, env);
-        final float noon = 12f;
-        system.setTimeOfDay(noon);
+        java.util.concurrent.atomic.AtomicReference<EnvironmentState> ref =
+                new java.util.concurrent.atomic.AtomicReference<>(new EnvironmentState(0f, Season.SPRING, 0f));
+        DayNightSystem system = new DayNightSystem(clear, lighting, ref::get);
+        ref.set(new EnvironmentState(NOON, Season.SPRING, 0f));
         World world = new World(new WorldConfigurationBuilder()
                 .with(clear, lighting, system)
                 .build());
@@ -43,7 +45,7 @@ public class DayNightSystemTest {
         world.process();
         verify(handler).setAmbientLight(1f, 1f, 1f, 1f);
         assertEquals(1f, clear.getColor().r, TOLERANCE);
-        system.setTimeOfDay(0f);
+        ref.set(new EnvironmentState(0f, Season.SPRING, 0f));
         world.process();
 //CHECKSTYLE:OFF
         verify(handler).setAmbientLight(NIGHT_RED, NIGHT_RED, NIGHT_BLUE, 1f);
@@ -56,10 +58,9 @@ public class DayNightSystemTest {
     public void wrapsTimeOfDay() {
         ClearScreenSystem clear = new ClearScreenSystem(new Color());
         LightingSystem lighting = new LightingSystem();
-        EnvironmentState env = new EnvironmentState(0f, Season.SPRING, 0f);
-        DayNightSystem system = new DayNightSystem(clear, lighting, env);
-        final float wrapValue = 25f;
-        system.setTimeOfDay(wrapValue);
+        java.util.concurrent.atomic.AtomicReference<EnvironmentState> ref =
+                new java.util.concurrent.atomic.AtomicReference<>(new EnvironmentState(WRAP_VALUE, Season.SPRING, 0f));
+        DayNightSystem system = new DayNightSystem(clear, lighting, ref::get);
         World world = new World(new WorldConfigurationBuilder()
                 .with(clear, lighting, system)
                 .build());
@@ -76,12 +77,12 @@ public class DayNightSystemTest {
         LightingSystem lighting = new LightingSystem();
         RayHandler handler = mock(RayHandler.class);
         lighting.setRayHandler(handler);
-        EnvironmentState env = new EnvironmentState(0f, Season.SPRING, 1f);
-        DayNightSystem system = new DayNightSystem(clear, lighting, env);
+        java.util.concurrent.atomic.AtomicReference<EnvironmentState> ref =
+                new java.util.concurrent.atomic.AtomicReference<>(new EnvironmentState(0f, Season.SPRING, 1f));
+        DayNightSystem system = new DayNightSystem(clear, lighting, ref::get);
         World world = new World(new WorldConfigurationBuilder()
                 .with(clear, lighting, system)
                 .build());
-        system.setTimeOfDay(0f);
         world.setDelta(0f);
         world.process();
 //CHECKSTYLE:OFF

--- a/tests/src/test/java/net/lapidist/colony/tests/network/GameServerEnvironmentBroadcastTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/network/GameServerEnvironmentBroadcastTest.java
@@ -1,0 +1,41 @@
+package net.lapidist.colony.tests.network;
+
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.server.GameServer;
+import net.lapidist.colony.server.GameServerConfig;
+import net.lapidist.colony.components.state.EnvironmentUpdate;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertNotNull;
+
+public class GameServerEnvironmentBroadcastTest {
+    private static final int WAIT_MS = 200;
+
+    @Test
+    public void serverBroadcastsEnvironment() throws Exception {
+        GameServerConfig config = GameServerConfig.builder()
+                .saveName("env-broadcast")
+                .build();
+        net.lapidist.colony.io.Paths.get().deleteAutosave("env-broadcast");
+        try (GameServer server = new GameServer(config);
+             GameClient clientA = new GameClient();
+             GameClient clientB = new GameClient()) {
+            server.start();
+
+            CountDownLatch latchA = new CountDownLatch(1);
+            clientA.start(state -> latchA.countDown());
+            CountDownLatch latchB = new CountDownLatch(1);
+            clientB.start(state -> latchB.countDown());
+            latchA.await(1, TimeUnit.SECONDS);
+            latchB.await(1, TimeUnit.SECONDS);
+
+            Thread.sleep(WAIT_MS);
+
+            EnvironmentUpdate update = clientB.poll(EnvironmentUpdate.class);
+            assertNotNull(update);
+        }
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/server/EnvironmentSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/EnvironmentSystemTest.java
@@ -1,0 +1,38 @@
+package net.lapidist.colony.tests.server;
+
+import net.lapidist.colony.components.state.EnvironmentUpdate;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.server.systems.EnvironmentSystem;
+import net.lapidist.colony.server.GameServer;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.*;
+
+public class EnvironmentSystemTest {
+    private static final int WAIT_MS = 60;
+
+    @Test
+    public void advancesEnvironmentAndBroadcasts() throws Exception {
+        MapState state = new MapState();
+        AtomicReference<MapState> ref = new AtomicReference<>(state);
+        GameServer server = mock(GameServer.class);
+        when(server.getMapState()).thenAnswer(inv -> ref.get());
+        doAnswer(inv -> {
+            ref.set((MapState) inv.getArguments()[0]);
+            return null;
+        }).when(server).setMapState(any());
+        when(server.getStateLock()).thenReturn(new ReentrantLock());
+
+        EnvironmentSystem system = new EnvironmentSystem(server);
+        system.start();
+        Thread.sleep(WAIT_MS);
+        system.stop();
+
+        verify(server, atLeastOnce()).broadcast(isA(EnvironmentUpdate.class));
+        assertNotNull(ref.get().environment());
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/EnvironmentUpdateSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/EnvironmentUpdateSystemTest.java
@@ -1,0 +1,39 @@
+package net.lapidist.colony.tests.systems;
+
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.client.systems.network.EnvironmentUpdateSystem;
+import net.lapidist.colony.client.systems.network.MapLoadSystem;
+import net.lapidist.colony.components.state.EnvironmentState;
+import net.lapidist.colony.components.state.EnvironmentUpdate;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.Season;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link EnvironmentUpdateSystem}. */
+@RunWith(GdxTestRunner.class)
+public class EnvironmentUpdateSystemTest {
+    private static final float NEW_TIME = 12f;
+    @Test
+    public void appliesEnvironmentUpdates() {
+        MapState state = new MapState();
+        GameClient client = new GameClient();
+        client.setMapState(state);
+        World world = new World(new WorldConfigurationBuilder()
+                .with(new MapLoadSystem(state), new EnvironmentUpdateSystem(client))
+                .build());
+        world.process();
+
+        client.injectEnvironmentUpdate(new EnvironmentUpdate(new EnvironmentState(NEW_TIME, Season.SUMMER, 0f)));
+        world.process();
+
+        assertEquals(NEW_TIME, client.getMapState().environment().timeOfDay(), 0f);
+        assertEquals(Season.SUMMER, client.getMapState().environment().season());
+        world.dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- run server-side EnvironmentSystem to tick EnvironmentState
- broadcast EnvironmentUpdate messages
- queue and apply updates on the client
- update world builder and time systems to use server values
- cover new environment flow with unit tests

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test check codeCoverageReport`

------
https://chatgpt.com/codex/tasks/task_e_684f2a237bf48328a3c2a3c320f54adb