### PR TITLE
fix: tone down day-night colours

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/systems/DayNightSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/DayNightSystem.java
@@ -22,10 +22,10 @@ public final class DayNightSystem extends BaseSystem {
     private static final float SUNRISE_TIME = 6f;
     private static final float NOON_TIME = 12f;
     private static final float SUNSET_TIME = 18f;
-    private static final Color NIGHT_COLOR = new Color(0.02f, 0.02f, 0.05f, 1f);
-    private static final Color SUNRISE_COLOR = new Color(0.8f, 0.55f, 0.35f, 1f);
-    private static final Color DAY_COLOR = new Color(0.9f, 0.95f, 1f, 1f);
-    private static final Color MOON_COLOR = new Color(0.3f, 0.3f, 0.35f, 1f);
+    private static final Color NIGHT_COLOR = new Color(0.01f, 0.01f, 0.025f, 1f);
+    private static final Color SUNRISE_COLOR = new Color(0.6f, 0.5f, 0.4f, 1f);
+    private static final Color DAY_COLOR = new Color(0.8f, 0.85f, 0.9f, 1f);
+    private static final Color MOON_COLOR = new Color(0.2f, 0.2f, 0.25f, 1f);
 
     public DayNightSystem(final ClearScreenSystem clearSystem,
                           final LightingSystem lighting,

--- a/tests/src/test/java/net/lapidist/colony/tests/client/systems/DayNightSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/systems/DayNightSystemTest.java
@@ -21,12 +21,12 @@ import static org.mockito.Mockito.*;
 @SuppressWarnings("checkstyle:magicnumber")
 public class DayNightSystemTest {
 
-    private static final float DAY_RED = 0.9f;
-    private static final float DAY_GREEN = 0.95f;
-    private static final float DAY_BLUE = 1f;
-    private static final float NIGHT_RED = 0.02f;
-    private static final float NIGHT_BLUE = 0.05f;
-    private static final float MOON_RED = 0.32f;
+    private static final float DAY_RED = 0.8f;
+    private static final float DAY_GREEN = 0.85f;
+    private static final float DAY_BLUE = 0.9f;
+    private static final float NIGHT_RED = 0.01f;
+    private static final float NIGHT_BLUE = 0.025f;
+    private static final float MOON_RED = 0.21f;
     private static final float TOLERANCE = 0.01f;
 
     @Test


### PR DESCRIPTION
## Summary
- update colour constants in `DayNightSystem`
- adjust tests for new ambient light values

## Testing
- `./scripts/check.sh`
- `./gradlew codeCoverageReport`
- `./gradlew :tests:jmh`


------
https://chatgpt.com/codex/tasks/task_e_684f2bfffe608328b2bb7bd0c25cdccf