### PR TITLE
feat: add normal/specular atlas support

### DIFF
--- a/client/src/main/resources/assets/textures/textures.atlas
+++ b/client/src/main/resources/assets/textures/textures.atlas
@@ -62,3 +62,55 @@ player0
   orig: 64,64
   offset: 0,0
   index: -1
+
+grass_n.png
+size: 32,32
+format: RGBA8888
+filter: Linear,Linear
+repeat: none
+grass0_n
+  rotate: false
+  xy: 0,0
+  size: 32,32
+  orig: 32,32
+  offset: 0,0
+  index: -1
+
+grass_s.png
+size: 32,32
+format: RGBA8888
+filter: Linear,Linear
+repeat: none
+grass0_s
+  rotate: false
+  xy: 0,0
+  size: 32,32
+  orig: 32,32
+  offset: 0,0
+  index: -1
+
+dirt_n.png
+size: 32,32
+format: RGBA8888
+filter: Linear,Linear
+repeat: none
+dirt0_n
+  rotate: false
+  xy: 0,0
+  size: 32,32
+  orig: 32,32
+  offset: 0,0
+  index: -1
+
+dirt_s.png
+size: 32,32
+format: RGBA8888
+filter: Linear,Linear
+repeat: none
+dirt0_s
+  rotate: false
+  xy: 0,0
+  size: 32,32
+  orig: 32,32
+  offset: 0,0
+  index: -1

--- a/tests/src/test/java/net/lapidist/colony/tests/core/io/ResourceLoaderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/io/ResourceLoaderTest.java
@@ -33,6 +33,10 @@ public class ResourceLoaderTest {
             assertTrue(resourceLoader.getProgress() < 1f);
         }
         assertTrue(resourceLoader.isLoaded());
+        assertNotNull(resourceLoader.findNormalRegion("dirt0"));
+        assertNotNull(resourceLoader.findSpecularRegion("dirt0"));
+        assertNotNull(resourceLoader.findNormalRegion("grass0"));
+        assertNotNull(resourceLoader.findSpecularRegion("grass0"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- pack dirt and grass normal/specular maps in `textures.atlas`
- assert `TextureAtlasResourceLoader` finds normal and specular regions

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684f3b85f5d08328864b48e451f2b7ed