### PR TITLE
feat: show logo in main menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,4 @@ tests/skin
 tests/textures
 tests/textures/textures.atlas
 tests/models
+tests/shaders

--- a/client/src/main/java/net/lapidist/colony/client/screens/MainMenuScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MainMenuScreen.java
@@ -2,8 +2,11 @@ package net.lapidist.colony.client.screens;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
+import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
+import com.badlogic.gdx.graphics.Texture;
 import net.lapidist.colony.util.I18n;
 import net.lapidist.colony.client.Colony;
 import net.lapidist.colony.io.Paths;
@@ -14,10 +17,12 @@ import java.nio.file.Path;
 
 public final class MainMenuScreen extends BaseScreen {
     private final Colony colony;
+    private static final float LOGO_PADDING = 10f;
 
     public MainMenuScreen(final Colony game) {
         this.colony = game;
 
+        Image logo = new Image(new TextureRegionDrawable(new Texture(Gdx.files.internal("textures/logo.png"))));
         TextButton continueButton = new TextButton(I18n.get("main.continue"), getSkin());
         TextButton newGameButton = new TextButton(I18n.get("main.newGame"), getSkin());
         TextButton loadGameButton = new TextButton(I18n.get("main.loadGame"), getSkin());
@@ -38,6 +43,7 @@ public final class MainMenuScreen extends BaseScreen {
 
         continueButton.setDisabled(!canContinue);
 
+        getRoot().add(logo).padBottom(LOGO_PADDING).row();
         getRoot().add(continueButton).row();
         getRoot().add(newGameButton).row();
         getRoot().add(loadGameButton).row();

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MainMenuScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MainMenuScreenTest.java
@@ -22,9 +22,9 @@ import static org.mockito.Mockito.*;
 @RunWith(GdxTestRunner.class)
 public class MainMenuScreenTest {
 
-    private static final int NEW_GAME_INDEX = 1;
-    private static final int LOAD_GAME_INDEX = 2;
-    private static final int SETTINGS_INDEX = 3;
+    private static final int NEW_GAME_INDEX = 2;
+    private static final int LOAD_GAME_INDEX = 3;
+    private static final int SETTINGS_INDEX = 4;
 
     private static Table getRoot(final MainMenuScreen screen) throws Exception {
         Field f = screen.getClass().getSuperclass().getDeclaredField("root");


### PR DESCRIPTION
## Summary
- display `logo.png` at the top of the main menu
- adjust tests to account for new layout
- ignore copied shader assets in tests

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684f3acb166083288997e84ce737ddd9