### PR TITLE
feat: add normal map lighting plugin

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/graphics/LightingPlugin.java
+++ b/client/src/main/java/net/lapidist/colony/client/graphics/LightingPlugin.java
@@ -1,0 +1,12 @@
+package net.lapidist.colony.client.graphics;
+
+import box2dLight.RayHandler;
+
+/**
+ * Marker interface for shader plugins that also provide lighting support.
+ */
+public interface LightingPlugin extends ShaderPlugin {
+
+    /** Return the initialized {@link RayHandler} or {@code null} if unavailable. */
+    RayHandler getRayHandler();
+}

--- a/client/src/main/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPlugin.java
+++ b/client/src/main/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPlugin.java
@@ -5,12 +5,12 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.physics.box2d.World;
-
+import net.lapidist.colony.client.core.io.FileLocation;
 
 /**
- * Shader plugin that adds Box2DLights rendering support.
+ * Shader plugin that enables Box2DLights along with normal mapping.
  */
-public final class Box2dLightsPlugin implements LightingPlugin {
+public final class LightsNormalMapShaderPlugin implements LightingPlugin {
 
     private RayHandler rayHandler;
 
@@ -23,29 +23,27 @@ public final class Box2dLightsPlugin implements LightingPlugin {
             World world = new World(new Vector2(), false);
             rayHandler = new RayHandler(world);
             rayHandler.setAmbientLight(1f, 1f, 1f, 1f);
+            return manager.load(FileLocation.INTERNAL,
+                    "shaders/normal.vert", "shaders/normal.frag");
         } catch (Exception ex) {
             rayHandler = null;
+            return null;
         }
-        return null;
     }
 
-    /**
-     * Access the created {@link RayHandler} instance.
-     *
-     * @return the handler or {@code null} if {@link #create(ShaderManager)} has not been called
-     */
+    @Override
     public RayHandler getRayHandler() {
         return rayHandler;
     }
 
     @Override
     public String id() {
-        return "box2dlights";
+        return "lights-normalmap";
     }
 
     @Override
     public String displayName() {
-        return "Box2DLights";
+        return "Lighting Normal Map";
     }
 
     @Override

--- a/client/src/main/java/net/lapidist/colony/client/renderers/SpriteMapRendererFactory.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/SpriteMapRendererFactory.java
@@ -10,7 +10,7 @@ import net.lapidist.colony.client.systems.PlayerCameraSystem;
 import net.lapidist.colony.client.graphics.ShaderManager;
 import net.lapidist.colony.client.graphics.ShaderPlugin;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
-import net.lapidist.colony.client.graphics.Box2dLightsPlugin;
+import net.lapidist.colony.client.graphics.LightingPlugin;
 import net.lapidist.colony.settings.GraphicsSettings;
 import net.lapidist.colony.settings.Settings;
 import org.slf4j.Logger;
@@ -74,8 +74,8 @@ public final class SpriteMapRendererFactory implements MapRendererFactory {
         if (plugin != null) {
             try {
                 shader = plugin.create(new ShaderManager());
-                if (plugin instanceof Box2dLightsPlugin bl) {
-                    lights = bl.getRayHandler();
+                if (plugin instanceof LightingPlugin lp) {
+                    lights = lp.getRayHandler();
                 }
             } catch (Exception ex) {
                 LOGGER.warn("Shader plugin {} failed", plugin.getClass().getSimpleName(), ex);

--- a/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -238,9 +238,9 @@ public final class MapWorldBuilder {
             renderSystem.setCameraProvider(world.getSystem(PlayerCameraSystem.class));
         }
         LightingSystem lightingSystem = world.getSystem(LightingSystem.class);
-        if (lightingSystem != null && plugin instanceof net.lapidist.colony.client.graphics.Box2dLightsPlugin bl) {
+        if (lightingSystem != null && plugin instanceof net.lapidist.colony.client.graphics.LightingPlugin lp) {
             if (settings == null || settings.getGraphicsSettings().isLightingEnabled()) {
-                lightingSystem.setRayHandler(bl.getRayHandler());
+                lightingSystem.setRayHandler(lp.getRayHandler());
             }
         }
         PlayerCameraSystem cameraSystem = world.getSystem(PlayerCameraSystem.class);

--- a/client/src/main/resources/META-INF/services/net.lapidist.colony.client.graphics.ShaderPlugin
+++ b/client/src/main/resources/META-INF/services/net.lapidist.colony.client.graphics.ShaderPlugin
@@ -1,3 +1,4 @@
 net.lapidist.colony.client.graphics.NullShaderPlugin
 net.lapidist.colony.client.graphics.Box2dLightsPlugin
 net.lapidist.colony.client.graphics.NormalMapShaderPlugin
+net.lapidist.colony.client.graphics.LightsNormalMapShaderPlugin

--- a/core/src/main/java/net/lapidist/colony/settings/GraphicsSettings.java
+++ b/core/src/main/java/net/lapidist/colony/settings/GraphicsSettings.java
@@ -21,7 +21,7 @@ public final class GraphicsSettings {
     private boolean antialiasingEnabled = true;
     private boolean mipMapsEnabled = true;
     private boolean anisotropicFilteringEnabled = true;
-    private String shaderPlugin = "none";
+    private String shaderPlugin = "lights-normalmap";
     private String renderer = "sprite";
     private boolean spriteCacheEnabled = true;
     private boolean lightingEnabled = true;
@@ -115,7 +115,7 @@ public final class GraphicsSettings {
         gs.antialiasingEnabled = Boolean.parseBoolean(props.getProperty(AA_KEY, "true"));
         gs.mipMapsEnabled = Boolean.parseBoolean(props.getProperty(MIP_KEY, "true"));
         gs.anisotropicFilteringEnabled = Boolean.parseBoolean(props.getProperty(AF_KEY, "true"));
-        gs.shaderPlugin = props.getProperty(PLUGIN_KEY, "none");
+        gs.shaderPlugin = props.getProperty(PLUGIN_KEY, "lights-normalmap");
         gs.renderer = props.getProperty(RENDERER_KEY, "sprite");
         gs.spriteCacheEnabled = Boolean.parseBoolean(props.getProperty(CACHE_KEY, "true"));
         gs.lightingEnabled = Boolean.parseBoolean(props.getProperty(LIGHT_KEY, "true"));

--- a/docs/shaders.md
+++ b/docs/shaders.md
@@ -60,7 +60,12 @@ Add `GrayShaderPlugin` to the service descriptor and set
 
 ## Built-in lighting
 
-The `Box2dLightsPlugin` is included with the game and integrates the
-[box2d-lights](https://github.com/libgdx/box2dlights) library. It returns
-no shader program but exposes a `RayHandler` when frame buffers are supported.
-Headless or unsupported environments automatically skip lighting.
+The engine ships with two lighting plugins powered by
+[box2d-lights](https://github.com/libgdx/box2dlights):
+
+* `Box2dLightsPlugin` – exposes a `RayHandler` but uses the default sprite shader.
+* `LightsNormalMapShaderPlugin` – combines the normal mapping shader with the same `RayHandler`.
+
+The second plugin is now selected by default through the
+`graphics.shaderPlugin` setting. Lighting will be skipped automatically when
+frame buffers are unavailable such as in headless tests.

--- a/tests/src/test/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPluginTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPluginTest.java
@@ -1,0 +1,28 @@
+package net.lapidist.colony.client.graphics;
+
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/** Basic checks for {@link LightsNormalMapShaderPlugin}. */
+@RunWith(GdxTestRunner.class)
+public class LightsNormalMapShaderPluginTest {
+
+    @Test
+    public void createInitializesShaderAndLights() {
+        LightsNormalMapShaderPlugin plugin = new LightsNormalMapShaderPlugin();
+        assertNull(plugin.getRayHandler());
+
+        ShaderProgram program = plugin.create(new ShaderManager());
+        if (program != null) {
+            assertNotNull(plugin.getRayHandler());
+            program.dispose();
+        } else {
+            assertNull(plugin.getRayHandler());
+        }
+        assertEquals("lights-normalmap", plugin.id());
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/core/settings/GraphicsSettingsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/settings/GraphicsSettingsTest.java
@@ -49,7 +49,7 @@ public class GraphicsSettingsTest {
         assertTrue(loaded.isAntialiasingEnabled());
         assertTrue(loaded.isMipMapsEnabled());
         assertTrue(loaded.isAnisotropicFilteringEnabled());
-        assertEquals("none", loaded.getShaderPlugin());
+        assertEquals("lights-normalmap", loaded.getShaderPlugin());
         assertEquals("sprite", loaded.getRenderer());
         assertTrue(loaded.isSpriteCacheEnabled());
         assertTrue(loaded.isLightingEnabled());


### PR DESCRIPTION
## Summary
- add LightsNormalMapShaderPlugin and LightingPlugin interface
- allow map renderer and world builder to use any lighting plugin
- register lighting plugin service
- set default shader plugin id to lights-normalmap
- test LightsNormalMapShaderPlugin and update GraphicsSettingsTest
- document lighting plugins

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684f3bddd08483288281cd6d59740f52