### PR TITLE
test: skip copyAssets when unchanged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,10 +141,4 @@ Thumbs.db
 /tests/out/
 
 ## Resources
-tests/assets
-tests/fonts
-tests/i18n
-tests/skin
-tests/textures
-tests/textures/textures.atlas
-tests/models
+tests/build/copiedAssets/

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -33,15 +33,19 @@ dependencies {
 }
 
 
+tasks.register('copyAssets', Copy) {
+    inputs.dir project(":client").file("src/main/resources/assets")
+    outputs.dir layout.buildDirectory.dir("copiedAssets")
+    destinationDir = outputs.files.singleFile
+    from project(":client").file("src/main/resources/assets")
+}
+
 test {
     testLogging {
         events "PASSED", "STARTED", "FAILED", "SKIPPED"
     }
-}
-
-tasks.register('copyAssets', Copy) {
-    from project(":client").file("src/main/resources/assets")
-    into file(".")
+    workingDir = tasks.named('copyAssets').get().outputs.files.singleFile
+    dependsOn tasks.named('copyAssets')
 }
 
 jmh {


### PR DESCRIPTION
## Summary
- copy test assets into build/copiedAssets instead of project root
- run tests from copiedAssets and depend on the copy task
- ignore copiedAssets folder

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_684f3c6e6cf083289c0e3e44121cd4bf