### PR TITLE
Add developer workflow guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@ Each module contains its own `AGENTS.md` with extra notes.
 - Run `./gradlew clean test` to compile and execute tests.
 - Run `./gradlew check` to verify Checkstyle and Spotless rules.
 - The helper script `./scripts/check.sh` performs all steps at once.
+- See `docs/developer_workflow.md` for a detailed walkthrough of these commands and
+  save-migration steps.
 
 ## Running the game
 - `./gradlew :client:run` – start the desktop client.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You can also run all of these steps at once:
 ```
 
 The `tests:copyAssets` task is required so that resources used by the test suite are available. `spotlessApply` will automatically format all Java sources and must be executed before committing. After running the tasks above, open `build/reports/jacoco/test/html/index.html` to review coverage results. New code should maintain at least 80% line coverage.
+For more details on the developer workflow, see [docs/developer_workflow.md](docs/developer_workflow.md).
 
 ### Running the Game
 Both the client and dedicated server can be started directly from Gradle:
@@ -87,6 +88,7 @@ Configuration details are in [docs/configuration.md](docs/configuration.md).
 Performance benchmark numbers are tracked in [docs/performance.md](docs/performance.md).
 Translation instructions are in [docs/i18n.md](docs/i18n.md).
 Scenario test utilities are covered in [docs/tests.md](docs/tests.md).
+Developer build steps are summarized in [docs/developer_workflow.md](docs/developer_workflow.md).
 Shader plugins are described in [docs/shaders.md](docs/shaders.md).
 
 ## License

--- a/client/AGENTS.md
+++ b/client/AGENTS.md
@@ -7,5 +7,5 @@ Desktop LibGDX client providing the game loop, rendering and user interface.
 
 # Testing notes
 - Ensure assets remain under the `assets` directory for packaging.
-- Full build and style checks are triggered via `./gradlew clean test check`.
-- Use `./gradlew codeCoverageReport` to review test coverage.
+- See [`../docs/developer_workflow.md`](../docs/developer_workflow.md) for build,
+  style and coverage commands.

--- a/core/AGENTS.md
+++ b/core/AGENTS.md
@@ -7,5 +7,4 @@ Shared ECS components, constants and serialization code used by the client and s
 
 # Testing notes
 - Run `./gradlew tests:copyAssets` before executing the main test suite.
-- Execute `./gradlew clean test` and `./gradlew check` to verify changes.
-- Run `./gradlew codeCoverageReport` to generate coverage data.
+- See [`../docs/developer_workflow.md`](../docs/developer_workflow.md) for build, style and coverage commands.

--- a/docs/developer_workflow.md
+++ b/docs/developer_workflow.md
@@ -1,0 +1,25 @@
+# Developer Workflow
+
+This guide summarizes the common build and test steps for all modules.
+
+## Build and Style
+1. `./gradlew tests:copyAssets` – copy client assets into the test module.
+2. `./gradlew spotlessApply` – automatically format the source code.
+3. `./gradlew clean test` – compile and run all tests.
+4. `./gradlew check` – run Checkstyle and Spotless verification.
+5. `./gradlew codeCoverageReport` – generate the JaCoCo coverage report.
+
+Running `./scripts/check.sh` performs the first four steps at once.
+
+## Coverage
+New or modified code should maintain **at least 80% line coverage**. After running the coverage task, open
+`build/reports/jacoco/test/html/index.html` to inspect the results.
+
+## Save Format Migrations
+Whenever a change affects the serialized save format:
+1. Add the next constant in `SaveVersion`.
+2. Implement the migration in `SaveMigrator`.
+3. Write tests covering the migration.
+4. Update the Kryo registration hash.
+
+Documentation-only changes do not require a migration.

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -6,5 +6,5 @@ Headless game server running the same ECS logic as the client and exposing netwo
 - Broadcast state updates to connected clients.
 
 # Testing notes
-- Follow the root module steps before running tests: `tests:copyAssets`, `clean test`, and `check`.
-- Generate coverage with `./gradlew codeCoverageReport` after tests.
+- Follow the root module steps before running tests.
+- See [`../docs/developer_workflow.md`](../docs/developer_workflow.md) for build, style and coverage commands.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -6,5 +6,4 @@ JUnit tests and utilities including `GdxTestRunner` for headless LibGDX executio
 - Copy assets from the client module via `./gradlew tests:copyAssets` before running tests.
 
 # Testing notes
-- Run `./gradlew clean test` followed by `./gradlew check` to ensure style and coverage.
-- Generate the coverage report with `./gradlew codeCoverageReport`.
+- See [`../docs/developer_workflow.md`](../docs/developer_workflow.md) for build, style and coverage commands.


### PR DESCRIPTION
## Summary
- document the full build/test workflow in `docs/developer_workflow.md`
- point module guides at the shared workflow docs
- mention the guide in the root AGENTS and README

## Testing
- `./scripts/check.sh`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_684f40af15108328bf10a29ade08c643