### PR TITLE
feat: toggle normal and specular maps via settings

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
@@ -14,6 +14,7 @@ import net.lapidist.colony.client.render.data.RenderBuilding;
 import net.lapidist.colony.client.render.MapRenderData;
 import net.lapidist.colony.registry.BuildingDefinition;
 import net.lapidist.colony.registry.Registries;
+import net.lapidist.colony.settings.GraphicsSettings;
 
 /**
  * Renders building entities.
@@ -24,6 +25,7 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
     private final ResourceLoader resourceLoader;
     private final CameraProvider cameraSystem;
     private final AssetResolver resolver;
+    private final GraphicsSettings graphicsSettings;
     private final java.util.HashMap<String, TextureRegion> buildingRegions = new java.util.HashMap<>();
     private final java.util.HashMap<String, TextureRegion> normalRegions = new java.util.HashMap<>();
     private final java.util.HashMap<String, TextureRegion> specularRegions = new java.util.HashMap<>();
@@ -33,16 +35,20 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
     private final Rectangle viewBounds = new Rectangle();
     private final Vector2 worldCoords = new Vector2();
 
+    // CHECKSTYLE:OFF: ParameterNumber
     public BuildingRenderer(
             final SpriteBatch spriteBatchToSet,
             final ResourceLoader resourceLoaderToSet,
             final CameraProvider cameraSystemToSet,
-            final AssetResolver resolverToSet
+            final AssetResolver resolverToSet,
+            final GraphicsSettings graphicsSettingsToSet
     ) {
+        // CHECKSTYLE:ON: ParameterNumber
         this.spriteBatch = spriteBatchToSet;
         this.resourceLoader = resourceLoaderToSet;
         this.cameraSystem = cameraSystemToSet;
         this.resolver = resolverToSet;
+        this.graphicsSettings = graphicsSettingsToSet;
 
         for (BuildingDefinition def : Registries.buildings().all()) {
             String ref = resolver.buildingAsset(def.id());
@@ -84,11 +90,11 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
                 TextureRegion spec = specularRegions.get(type.toUpperCase(java.util.Locale.ROOT));
                 com.badlogic.gdx.graphics.glutils.ShaderProgram shader = spriteBatch.getShader();
                 if (shader != null) {
-                    if (nrm != null) {
+                    if (nrm != null && graphicsSettings.isNormalMapsEnabled()) {
                         nrm.getTexture().bind(1);
                         shader.setUniformi("u_normal", 1);
                     }
-                    if (spec != null) {
+                    if (spec != null && graphicsSettings.isSpecularMapsEnabled()) {
                         spec.getTexture().bind(2);
                         shader.setUniformi("u_specular", 2);
                     }

--- a/client/src/main/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRenderer.java
@@ -8,6 +8,7 @@ import net.lapidist.colony.client.systems.CameraProvider;
 import net.lapidist.colony.client.systems.MapRenderDataSystem;
 import net.lapidist.colony.components.maps.MapComponent;
 import net.lapidist.colony.client.render.MapRenderData;
+import net.lapidist.colony.settings.GraphicsSettings;
 
 import java.util.function.Consumer;
 
@@ -23,10 +24,12 @@ public final class LoadingSpriteMapRenderer implements MapRenderer, Disposable {
     private final boolean cacheEnabled;
     private final Consumer<Float> progressCallback;
     private final com.badlogic.gdx.graphics.glutils.ShaderProgram shader;
+    private final GraphicsSettings graphicsSettings;
     private box2dLight.RayHandler lights;
 
     private MapRenderer delegate;
 
+    // CHECKSTYLE:OFF: ParameterNumber
     public LoadingSpriteMapRenderer(
             final World worldContext,
             final SpriteBatch batchToUse,
@@ -34,7 +37,8 @@ public final class LoadingSpriteMapRenderer implements MapRenderer, Disposable {
             final CameraProvider camera,
             final boolean cache,
             final Consumer<Float> callback,
-            final com.badlogic.gdx.graphics.glutils.ShaderProgram shaderProgram
+            final com.badlogic.gdx.graphics.glutils.ShaderProgram shaderProgram,
+            final GraphicsSettings graphicsSettingsToUse
     ) {
         this.world = worldContext;
         this.spriteBatch = batchToUse;
@@ -43,9 +47,11 @@ public final class LoadingSpriteMapRenderer implements MapRenderer, Disposable {
         this.cacheEnabled = cache;
         this.progressCallback = callback;
         this.shader = shaderProgram;
+        this.graphicsSettings = graphicsSettingsToUse;
         // ensure mapper initialization for render systems
         worldContext.getMapper(MapComponent.class);
     }
+    // CHECKSTYLE:ON: ParameterNumber
 
     /** Assign lighting handler. */
     public void setLights(final box2dLight.RayHandler handler) {
@@ -72,13 +78,15 @@ public final class LoadingSpriteMapRenderer implements MapRenderer, Disposable {
                     resourceLoader,
                     cameraSystem,
                     new DefaultAssetResolver(),
-                    gc
+                    gc,
+                    graphicsSettings
             );
             BuildingRenderer buildingRenderer = new BuildingRenderer(
                     spriteBatch,
                     resourceLoader,
                     cameraSystem,
-                    new DefaultAssetResolver()
+                    new DefaultAssetResolver(),
+                    graphicsSettings
             );
             PlayerRenderer playerRenderer = new PlayerRenderer(
                     spriteBatch,

--- a/client/src/main/java/net/lapidist/colony/client/renderers/SpriteMapRendererFactory.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/SpriteMapRendererFactory.java
@@ -89,7 +89,8 @@ public final class SpriteMapRendererFactory implements MapRendererFactory {
                 cameraSystem,
                 graphics.isSpriteCacheEnabled(),
                 progressCallback,
-                shader
+                shader,
+                graphics
         );
         if (lights != null) {
             renderer.setLights(lights);

--- a/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
@@ -12,6 +12,7 @@ import net.lapidist.colony.client.graphics.CameraUtils;
 import net.lapidist.colony.client.render.data.RenderTile;
 import net.lapidist.colony.client.render.MapRenderData;
 import net.lapidist.colony.client.TileRotationUtil;
+import net.lapidist.colony.settings.GraphicsSettings;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.registry.Registries;
 import net.lapidist.colony.registry.TileDefinition;
@@ -26,6 +27,7 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
     private final ResourceLoader resourceLoader;
     private final CameraProvider cameraSystem;
     private final AssetResolver resolver;
+    private final GraphicsSettings graphicsSettings;
     private final java.util.HashMap<String, TextureRegion> tileRegions = new java.util.HashMap<>();
     private final java.util.HashMap<String, TextureRegion> normalRegions = new java.util.HashMap<>();
     private final java.util.HashMap<String, TextureRegion> specularRegions = new java.util.HashMap<>();
@@ -39,18 +41,22 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
     private final Vector2 worldCoords = new Vector2();
     private boolean overlayOnly;
 
+    // CHECKSTYLE:OFF: ParameterNumber
     public TileRenderer(
             final SpriteBatch spriteBatchToSet,
             final ResourceLoader resourceLoaderToSet,
             final CameraProvider cameraSystemToSet,
             final AssetResolver resolverToSet,
-            final net.lapidist.colony.client.network.GameClient clientToUse
+            final net.lapidist.colony.client.network.GameClient clientToUse,
+            final GraphicsSettings graphicsSettingsToUse
     ) {
+        // CHECKSTYLE:ON: ParameterNumber
         this.client = clientToUse;
         this.spriteBatch = spriteBatchToSet;
         this.resourceLoader = resourceLoaderToSet;
         this.cameraSystem = cameraSystemToSet;
         this.resolver = resolverToSet;
+        this.graphicsSettings = graphicsSettingsToUse;
 
         for (TileDefinition def : Registries.tiles().all()) {
             String ref = resolver.tileAsset(def.id());
@@ -115,11 +121,11 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
                         TextureRegion spec = specularRegions.get(type.toUpperCase(java.util.Locale.ROOT));
                         com.badlogic.gdx.graphics.glutils.ShaderProgram shader = spriteBatch.getShader();
                         if (shader != null) {
-                            if (nrm != null) {
+                            if (nrm != null && graphicsSettings.isNormalMapsEnabled()) {
                                 nrm.getTexture().bind(1);
                                 shader.setUniformi("u_normal", 1);
                             }
-                            if (spec != null) {
+                            if (spec != null && graphicsSettings.isSpecularMapsEnabled()) {
                                 spec.getTexture().bind(2);
                                 shader.setUniformi("u_specular", 2);
                             }

--- a/tests/src/jmh/java/net/lapidist/colony/tests/benchmarks/SpriteBatchRendererBenchmark.java
+++ b/tests/src/jmh/java/net/lapidist/colony/tests/benchmarks/SpriteBatchRendererBenchmark.java
@@ -39,6 +39,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.mockito.MockedConstruction;
+import net.lapidist.colony.settings.GraphicsSettings;
 
 import static org.mockito.Mockito.*;
 
@@ -63,8 +64,9 @@ public class SpriteBatchRendererBenchmark {
         resolver = new DefaultAssetResolver();
         camera = createCamera();
         SpriteBatch batch = mock(SpriteBatch.class);
-        TileRenderer tileRenderer = new TileRenderer(batch, loader, camera, resolver, null);
-        BuildingRenderer buildingRenderer = new BuildingRenderer(batch, loader, camera, resolver);
+        GraphicsSettings gs = new GraphicsSettings();
+        TileRenderer tileRenderer = new TileRenderer(batch, loader, camera, resolver, null, gs);
+        BuildingRenderer buildingRenderer = new BuildingRenderer(batch, loader, camera, resolver, gs);
         ResourceRenderer resourceRenderer = mock(ResourceRenderer.class);
         PlayerRenderer playerRenderer = mock(PlayerRenderer.class);
         CelestialRenderer celestialRenderer = mock(CelestialRenderer.class);

--- a/tests/src/test/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRendererTest.java
@@ -6,6 +6,7 @@ import com.artemis.WorldConfigurationBuilder;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.client.systems.CameraProvider;
+import net.lapidist.colony.settings.GraphicsSettings;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,8 +32,9 @@ public class LoadingSpriteMapRendererTest {
 
         try (MockedConstruction<SpriteBatchMapRenderer> cons =
                 mockConstruction(SpriteBatchMapRenderer.class)) {
+            GraphicsSettings gs = new GraphicsSettings();
             LoadingSpriteMapRenderer renderer = new LoadingSpriteMapRenderer(
-                    world, batch, loader, camera, false, null, null);
+                    world, batch, loader, camera, false, null, null, gs);
             renderer.setLights(lights);
 
             renderer.render(mock(net.lapidist.colony.client.render.MapRenderData.class), null);

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/BuildingRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/BuildingRendererTest.java
@@ -7,6 +7,7 @@ import com.badlogic.gdx.graphics.g2d.GlyphLayout;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.utils.viewport.ExtendViewport;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import net.lapidist.colony.client.renderers.BuildingRenderer;
 import net.lapidist.colony.client.renderers.DefaultAssetResolver;
 import net.lapidist.colony.client.renderers.AssetResolver;
@@ -19,6 +20,7 @@ import net.lapidist.colony.client.render.SimpleMapRenderData;
 import net.lapidist.colony.client.render.data.RenderTile;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.tests.GdxTestRunner;
+import net.lapidist.colony.settings.GraphicsSettings;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import static org.mockito.Mockito.*;
@@ -45,7 +47,8 @@ public class BuildingRendererTest {
         when(camera.getCamera()).thenReturn(cam);
         when(camera.getViewport()).thenReturn(viewport);
 
-        BuildingRenderer renderer = new BuildingRenderer(batch, loader, camera, new DefaultAssetResolver());
+        GraphicsSettings gs = new GraphicsSettings();
+        BuildingRenderer renderer = new BuildingRenderer(batch, loader, camera, new DefaultAssetResolver(), gs);
         reset(loader);
 
         Array<RenderBuilding> buildings = new Array<>();
@@ -77,7 +80,8 @@ public class BuildingRendererTest {
         when(camera.getCamera()).thenReturn(cam);
         when(camera.getViewport()).thenReturn(viewport);
 
-        BuildingRenderer renderer = new BuildingRenderer(batch, loader, camera, new DefaultAssetResolver());
+        GraphicsSettings gs = new GraphicsSettings();
+        BuildingRenderer renderer = new BuildingRenderer(batch, loader, camera, new DefaultAssetResolver(), gs);
         reset(loader);
 
         Array<RenderBuilding> buildings = new Array<>();
@@ -112,7 +116,8 @@ public class BuildingRendererTest {
         when(resolver.buildingAsset(anyString())).thenReturn("house0");
         when(resolver.hasBuildingAsset(anyString())).thenReturn(false);
 
-        BuildingRenderer renderer = new BuildingRenderer(batch, loader, camera, resolver);
+        GraphicsSettings gs = new GraphicsSettings();
+        BuildingRenderer renderer = new BuildingRenderer(batch, loader, camera, resolver, gs);
 
         java.lang.reflect.Field fontField = BuildingRenderer.class.getDeclaredField("font");
         fontField.setAccessible(true);
@@ -133,5 +138,54 @@ public class BuildingRendererTest {
         renderer.render(map);
 
         verify(font).draw(eq(batch), eq(layout), anyFloat(), anyFloat());
+    }
+
+    @Test
+    public void doesNotBindTexturesWhenDisabled() {
+        SpriteBatch batch = mock(SpriteBatch.class);
+        ShaderProgram shader = mock(ShaderProgram.class);
+        when(batch.getShader()).thenReturn(shader);
+
+        ResourceLoader loader = mock(ResourceLoader.class);
+        TextureRegion region = mock(TextureRegion.class);
+        TextureRegion normal = mock(TextureRegion.class);
+        TextureRegion spec = mock(TextureRegion.class);
+        com.badlogic.gdx.graphics.Texture texN = mock(com.badlogic.gdx.graphics.Texture.class);
+        com.badlogic.gdx.graphics.Texture texS = mock(com.badlogic.gdx.graphics.Texture.class);
+        when(normal.getTexture()).thenReturn(texN);
+        when(spec.getTexture()).thenReturn(texS);
+        when(loader.findRegion(anyString())).thenReturn(region);
+        when(loader.findNormalRegion(anyString())).thenReturn(normal);
+        when(loader.findSpecularRegion(anyString())).thenReturn(spec);
+
+        new BaseDefinitionsMod().init();
+
+        CameraProvider camera = mock(CameraProvider.class);
+        OrthographicCamera cam = new OrthographicCamera();
+        ExtendViewport viewport = new ExtendViewport(VIEW_SIZE, VIEW_SIZE, cam);
+        viewport.update(VIEW_SIZE, VIEW_SIZE, true);
+        cam.update();
+        when(camera.getCamera()).thenReturn(cam);
+        when(camera.getViewport()).thenReturn(viewport);
+
+        GraphicsSettings gs = new GraphicsSettings();
+        gs.setNormalMapsEnabled(false);
+        gs.setSpecularMapsEnabled(false);
+        BuildingRenderer renderer = new BuildingRenderer(batch, loader, camera, new DefaultAssetResolver(), gs);
+        reset(loader);
+
+        Array<RenderBuilding> buildings = new Array<>();
+        RenderBuilding building = RenderBuilding.builder().x(0).y(0).buildingType("house").build();
+        buildings.add(building);
+
+        MapRenderData map = new SimpleMapRenderData(new Array<RenderTile>(), buildings,
+                new RenderTile[MapState.DEFAULT_WIDTH][MapState.DEFAULT_HEIGHT]);
+
+        renderer.render(map);
+
+        verify(texN, never()).bind(anyInt());
+        verify(texS, never()).bind(anyInt());
+        verify(shader, never()).setUniformi(eq("u_normal"), anyInt());
+        verify(shader, never()).setUniformi(eq("u_specular"), anyInt());
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/RendererEnumMapTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/RendererEnumMapTest.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import net.lapidist.colony.client.renderers.BuildingRenderer;
 import net.lapidist.colony.client.renderers.DefaultAssetResolver;
 import net.lapidist.colony.client.renderers.TileRenderer;
+import net.lapidist.colony.settings.GraphicsSettings;
 import net.lapidist.colony.base.BaseDefinitionsMod;
 import net.lapidist.colony.registry.Registries;
 import net.lapidist.colony.client.core.io.ResourceLoader;
@@ -27,12 +28,14 @@ public class RendererEnumMapTest {
         ResourceLoader loader = mock(ResourceLoader.class);
         when(loader.findRegion(anyString())).thenReturn(new TextureRegion());
         new BaseDefinitionsMod().init();
+        GraphicsSettings gs = new GraphicsSettings();
         TileRenderer renderer = new TileRenderer(
                 batch,
                 loader,
                 mock(CameraProvider.class),
                 new DefaultAssetResolver(),
-                null
+                null,
+                gs
         );
 
         Field f = TileRenderer.class.getDeclaredField("tileRegions");
@@ -52,11 +55,13 @@ public class RendererEnumMapTest {
         ResourceLoader loader = mock(ResourceLoader.class);
         when(loader.findRegion(anyString())).thenReturn(new TextureRegion());
         new BaseDefinitionsMod().init();
+        GraphicsSettings gs = new GraphicsSettings();
         BuildingRenderer renderer = new BuildingRenderer(
                 batch,
                 loader,
                 mock(CameraProvider.class),
-                new DefaultAssetResolver()
+                new DefaultAssetResolver(),
+                gs
         );
 
         Field f = BuildingRenderer.class.getDeclaredField("buildingRegions");


### PR DESCRIPTION
## Summary
- inject `GraphicsSettings` into map renderers
- respect normal/specular flags in tile and building renderers
- update factory and tests for the new constructor
- ensure bindings aren't issued when settings are off

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684f427e22f8832886554a88af3a0e83