### PR TITLE
feat: respect graphics settings in renderers

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
@@ -14,6 +14,7 @@ import net.lapidist.colony.client.render.data.RenderBuilding;
 import net.lapidist.colony.client.render.MapRenderData;
 import net.lapidist.colony.registry.BuildingDefinition;
 import net.lapidist.colony.registry.Registries;
+import net.lapidist.colony.settings.GraphicsSettings;
 
 /**
  * Renders building entities.
@@ -32,17 +33,20 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
     private static final float LABEL_OFFSET_Y = 8f;
     private final Rectangle viewBounds = new Rectangle();
     private final Vector2 worldCoords = new Vector2();
+    private final GraphicsSettings graphicsSettings;
 
     public BuildingRenderer(
             final SpriteBatch spriteBatchToSet,
             final ResourceLoader resourceLoaderToSet,
             final CameraProvider cameraSystemToSet,
-            final AssetResolver resolverToSet
+            final AssetResolver resolverToSet,
+            final GraphicsSettings settings
     ) {
         this.spriteBatch = spriteBatchToSet;
         this.resourceLoader = resourceLoaderToSet;
         this.cameraSystem = cameraSystemToSet;
         this.resolver = resolverToSet;
+        this.graphicsSettings = settings;
 
         for (BuildingDefinition def : Registries.buildings().all()) {
             String ref = resolver.buildingAsset(def.id());
@@ -84,11 +88,11 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
                 TextureRegion spec = specularRegions.get(type.toUpperCase(java.util.Locale.ROOT));
                 com.badlogic.gdx.graphics.glutils.ShaderProgram shader = spriteBatch.getShader();
                 if (shader != null) {
-                    if (nrm != null) {
+                    if (nrm != null && graphicsSettings.isNormalMapsEnabled()) {
                         nrm.getTexture().bind(1);
                         shader.setUniformi("u_normal", 1);
                     }
-                    if (spec != null) {
+                    if (spec != null && graphicsSettings.isSpecularMapsEnabled()) {
                         spec.getTexture().bind(2);
                         shader.setUniformi("u_specular", 2);
                     }

--- a/client/src/main/java/net/lapidist/colony/client/renderers/SpriteBatchMapRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/SpriteBatchMapRenderer.java
@@ -19,13 +19,12 @@ public final class SpriteBatchMapRenderer implements MapRenderer, Disposable {
     private final BuildingRenderer buildingRenderer;
     private final MapEntityRenderers entityRenderers;
     private final ShaderProgram shader;
-    private final net.lapidist.colony.client.graphics.ShaderPlugin plugin;
+    private net.lapidist.colony.client.graphics.ShaderPlugin plugin;
     private final MapTileCache tileCache = new MapTileCache();
     private final AssetResolver resolver = new DefaultAssetResolver();
     private final boolean cacheEnabled;
     private RayHandler lights;
 
-    // CHECKSTYLE:OFF: ParameterNumber
     public SpriteBatchMapRenderer(
             final SpriteBatch spriteBatchToSet,
             final ResourceLoader resourceLoaderToSet,
@@ -33,8 +32,7 @@ public final class SpriteBatchMapRenderer implements MapRenderer, Disposable {
             final BuildingRenderer buildingRendererToSet,
             final MapEntityRenderers entityRenderersToSet,
             final boolean cacheEnabledToSet,
-            final ShaderProgram shaderToSet,
-            final net.lapidist.colony.client.graphics.ShaderPlugin pluginToSet
+            final ShaderProgram shaderToSet
     ) {
         this.spriteBatch = spriteBatchToSet;
         this.resourceLoader = resourceLoaderToSet;
@@ -43,9 +41,12 @@ public final class SpriteBatchMapRenderer implements MapRenderer, Disposable {
         this.entityRenderers = entityRenderersToSet;
         this.cacheEnabled = cacheEnabledToSet;
         this.shader = shaderToSet;
+    }
+
+    /** Assign optional shader plugin. */
+    public void setPlugin(final net.lapidist.colony.client.graphics.ShaderPlugin pluginToSet) {
         this.plugin = pluginToSet;
     }
-    // CHECKSTYLE:ON: ParameterNumber
 
     /** Invalidate cache segments for the given tile indices. */
     public void invalidateTiles(final com.badlogic.gdx.utils.IntArray indices) {

--- a/client/src/main/java/net/lapidist/colony/client/renderers/SpriteMapRendererFactory.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/SpriteMapRendererFactory.java
@@ -89,9 +89,10 @@ public final class SpriteMapRendererFactory implements MapRendererFactory {
                 cameraSystem,
                 graphics.isSpriteCacheEnabled(),
                 progressCallback,
-                shader,
                 plugin
         );
+        renderer.setShader(shader);
+        renderer.setGraphicsSettings(graphics);
         if (lights != null) {
             renderer.setLights(lights);
         }

--- a/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
@@ -15,6 +15,7 @@ import net.lapidist.colony.client.TileRotationUtil;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.registry.Registries;
 import net.lapidist.colony.registry.TileDefinition;
+import net.lapidist.colony.settings.GraphicsSettings;
 
 /**
  * Renders tile entities.
@@ -37,6 +38,7 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
     private final Vector2 tmpStart = new Vector2();
     private final Vector2 tmpEnd = new Vector2();
     private final Vector2 worldCoords = new Vector2();
+    private final GraphicsSettings graphicsSettings;
     private boolean overlayOnly;
 
     public TileRenderer(
@@ -44,13 +46,15 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
             final ResourceLoader resourceLoaderToSet,
             final CameraProvider cameraSystemToSet,
             final AssetResolver resolverToSet,
-            final net.lapidist.colony.client.network.GameClient clientToUse
+            final net.lapidist.colony.client.network.GameClient clientToUse,
+            final GraphicsSettings settings
     ) {
         this.client = clientToUse;
         this.spriteBatch = spriteBatchToSet;
         this.resourceLoader = resourceLoaderToSet;
         this.cameraSystem = cameraSystemToSet;
         this.resolver = resolverToSet;
+        this.graphicsSettings = settings;
 
         for (TileDefinition def : Registries.tiles().all()) {
             String ref = resolver.tileAsset(def.id());
@@ -115,11 +119,11 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
                         TextureRegion spec = specularRegions.get(type.toUpperCase(java.util.Locale.ROOT));
                         com.badlogic.gdx.graphics.glutils.ShaderProgram shader = spriteBatch.getShader();
                         if (shader != null) {
-                            if (nrm != null) {
+                            if (nrm != null && graphicsSettings.isNormalMapsEnabled()) {
                                 nrm.getTexture().bind(1);
                                 shader.setUniformi("u_normal", 1);
                             }
-                            if (spec != null) {
+                            if (spec != null && graphicsSettings.isSpecularMapsEnabled()) {
                                 spec.getTexture().bind(2);
                                 shader.setUniformi("u_specular", 2);
                             }

--- a/tests/src/jmh/java/net/lapidist/colony/tests/benchmarks/SpriteBatchRendererBenchmark.java
+++ b/tests/src/jmh/java/net/lapidist/colony/tests/benchmarks/SpriteBatchRendererBenchmark.java
@@ -32,6 +32,7 @@ import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.map.MapFactory;
 import net.lapidist.colony.tests.GdxBenchmarkEnvironment;
+import net.lapidist.colony.settings.GraphicsSettings;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Scope;
@@ -63,16 +64,19 @@ public class SpriteBatchRendererBenchmark {
         resolver = new DefaultAssetResolver();
         camera = createCamera();
         SpriteBatch batch = mock(SpriteBatch.class);
-        TileRenderer tileRenderer = new TileRenderer(batch, loader, camera, resolver, null);
-        BuildingRenderer buildingRenderer = new BuildingRenderer(batch, loader, camera, resolver);
+        GraphicsSettings graphics = new GraphicsSettings();
+        TileRenderer tileRenderer = new TileRenderer(batch, loader, camera, resolver, null, graphics);
+        BuildingRenderer buildingRenderer = new BuildingRenderer(batch, loader, camera, resolver, graphics);
         ResourceRenderer resourceRenderer = mock(ResourceRenderer.class);
         PlayerRenderer playerRenderer = mock(PlayerRenderer.class);
         CelestialRenderer celestialRenderer = mock(CelestialRenderer.class);
         MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer, celestialRenderer);
         cachedRenderer = new SpriteBatchMapRenderer(
-                batch, loader, tileRenderer, buildingRenderer, renderers, true, null, null);
+                batch, loader, tileRenderer, buildingRenderer, renderers, true, null);
+        cachedRenderer.setPlugin(null);
         plainRenderer = new SpriteBatchMapRenderer(
-                batch, loader, tileRenderer, buildingRenderer, renderers, false, null, null);
+                batch, loader, tileRenderer, buildingRenderer, renderers, false, null);
+        plainRenderer.setPlugin(null);
         data = createData(MAP_SIZE, MAP_SIZE);
         construction = mockConstruction(SpriteCache.class, (mock, ctx) -> {
             when(mock.getProjectionMatrix()).thenReturn(new Matrix4());

--- a/tests/src/test/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRendererTest.java
@@ -10,6 +10,7 @@ import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.MockedConstruction;
+import net.lapidist.colony.settings.GraphicsSettings;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -32,7 +33,8 @@ public class LoadingSpriteMapRendererTest {
         try (MockedConstruction<SpriteBatchMapRenderer> cons =
                 mockConstruction(SpriteBatchMapRenderer.class)) {
             LoadingSpriteMapRenderer renderer = new LoadingSpriteMapRenderer(
-                    world, batch, loader, camera, false, null, null, null);
+                    world, batch, loader, camera, false, null, null);
+            renderer.setGraphicsSettings(new GraphicsSettings());
             renderer.setLights(lights);
 
             renderer.render(mock(net.lapidist.colony.client.render.MapRenderData.class), null);

--- a/tests/src/test/java/net/lapidist/colony/client/renderers/SpriteBatchMapRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/renderers/SpriteBatchMapRendererTest.java
@@ -32,7 +32,8 @@ public class SpriteBatchMapRendererTest {
         MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer, celestialRenderer);
 
         SpriteBatchMapRenderer renderer = new SpriteBatchMapRenderer(
-                batch, loader, tileRenderer, buildingRenderer, renderers, true, null, null);
+                batch, loader, tileRenderer, buildingRenderer, renderers, true, null);
+        renderer.setPlugin(null);
 
         Field cacheField = SpriteBatchMapRenderer.class.getDeclaredField("tileCache");
         cacheField.setAccessible(true);
@@ -57,7 +58,8 @@ public class SpriteBatchMapRendererTest {
         MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer, celestialRenderer);
 
         SpriteBatchMapRenderer renderer = new SpriteBatchMapRenderer(
-                batch, loader, tileRenderer, buildingRenderer, renderers, false, null, null);
+                batch, loader, tileRenderer, buildingRenderer, renderers, false, null);
+        renderer.setPlugin(null);
 
         Field cacheField = SpriteBatchMapRenderer.class.getDeclaredField("tileCache");
         cacheField.setAccessible(true);
@@ -82,7 +84,8 @@ public class SpriteBatchMapRendererTest {
         MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer, celestialRenderer);
 
         SpriteBatchMapRenderer renderer = new SpriteBatchMapRenderer(
-                batch, loader, tileRenderer, buildingRenderer, renderers, false, shader, null);
+                batch, loader, tileRenderer, buildingRenderer, renderers, false, shader);
+        renderer.setPlugin(null);
 
         MapRenderData map = mock(MapRenderData.class);
         CameraProvider camera = new CameraProvider() {
@@ -128,7 +131,8 @@ public class SpriteBatchMapRendererTest {
         MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer, celestialRenderer);
 
         SpriteBatchMapRenderer renderer = new SpriteBatchMapRenderer(
-                batch, loader, tileRenderer, buildingRenderer, renderers, false, null, null);
+                batch, loader, tileRenderer, buildingRenderer, renderers, false, null);
+        renderer.setPlugin(null);
 
         MapRenderData map = mock(MapRenderData.class);
         CameraProvider camera = new CameraProvider() {
@@ -169,7 +173,8 @@ public class SpriteBatchMapRendererTest {
         box2dLight.RayHandler lights = mock(box2dLight.RayHandler.class);
 
         SpriteBatchMapRenderer renderer = new SpriteBatchMapRenderer(
-                batch, loader, tileRenderer, buildingRenderer, renderers, false, null, null);
+                batch, loader, tileRenderer, buildingRenderer, renderers, false, null);
+        renderer.setPlugin(null);
         renderer.setLights(lights);
 
         MapRenderData map = mock(MapRenderData.class);

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/RendererEnumMapTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/RendererEnumMapTest.java
@@ -9,6 +9,7 @@ import net.lapidist.colony.base.BaseDefinitionsMod;
 import net.lapidist.colony.registry.Registries;
 import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.client.systems.CameraProvider;
+import net.lapidist.colony.settings.GraphicsSettings;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,12 +28,14 @@ public class RendererEnumMapTest {
         ResourceLoader loader = mock(ResourceLoader.class);
         when(loader.findRegion(anyString())).thenReturn(new TextureRegion());
         new BaseDefinitionsMod().init();
+        GraphicsSettings graphics = new GraphicsSettings();
         TileRenderer renderer = new TileRenderer(
                 batch,
                 loader,
                 mock(CameraProvider.class),
                 new DefaultAssetResolver(),
-                null
+                null,
+                graphics
         );
 
         Field f = TileRenderer.class.getDeclaredField("tileRegions");
@@ -52,11 +55,13 @@ public class RendererEnumMapTest {
         ResourceLoader loader = mock(ResourceLoader.class);
         when(loader.findRegion(anyString())).thenReturn(new TextureRegion());
         new BaseDefinitionsMod().init();
+        GraphicsSettings graphics = new GraphicsSettings();
         BuildingRenderer renderer = new BuildingRenderer(
                 batch,
                 loader,
                 mock(CameraProvider.class),
-                new DefaultAssetResolver()
+                new DefaultAssetResolver(),
+                graphics
         );
 
         Field f = BuildingRenderer.class.getDeclaredField("buildingRegions");

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/TileRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/TileRendererTest.java
@@ -16,6 +16,9 @@ import net.lapidist.colony.client.render.MapRenderData;
 import net.lapidist.colony.client.render.SimpleMapRenderData;
 import net.lapidist.colony.client.render.data.RenderBuilding;
 import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.settings.GraphicsSettings;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import com.badlogic.gdx.graphics.Texture;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,7 +50,8 @@ public class TileRendererTest {
         when(camera.getViewport()).thenReturn(viewport);
         when(camera.getCamera()).thenReturn(cam);
 
-        TileRenderer renderer = new TileRenderer(batch, loader, camera, new DefaultAssetResolver(), null);
+        GraphicsSettings graphics = new GraphicsSettings();
+        TileRenderer renderer = new TileRenderer(batch, loader, camera, new DefaultAssetResolver(), null, graphics);
         reset(loader);
 
         Array<RenderTile> tiles = new Array<>();
@@ -110,7 +114,8 @@ public class TileRendererTest {
         when(camera.getViewport()).thenReturn(viewport);
         when(camera.getCamera()).thenReturn(cam);
 
-        TileRenderer renderer = new TileRenderer(batch, loader, camera, new DefaultAssetResolver(), null);
+        GraphicsSettings graphics = new GraphicsSettings();
+        TileRenderer renderer = new TileRenderer(batch, loader, camera, new DefaultAssetResolver(), null, graphics);
         reset(loader);
 
         Array<RenderTile> tiles = new Array<>();
@@ -158,7 +163,8 @@ public class TileRendererTest {
         when(resolver.tileAsset(anyString())).thenReturn("dirt0");
         when(resolver.hasTileAsset(anyString())).thenReturn(false);
 
-        TileRenderer renderer = new TileRenderer(batch, loader, camera, resolver, null);
+        GraphicsSettings graphics = new GraphicsSettings();
+        TileRenderer renderer = new TileRenderer(batch, loader, camera, resolver, null, graphics);
 
         java.lang.reflect.Field fontField = TileRenderer.class.getDeclaredField("font");
         fontField.setAccessible(true);
@@ -207,7 +213,8 @@ public class TileRendererTest {
         when(camera.getViewport()).thenReturn(viewport);
         when(camera.getCamera()).thenReturn(cam);
 
-        TileRenderer renderer = new TileRenderer(batch, loader, camera, new DefaultAssetResolver(), null);
+        GraphicsSettings graphics = new GraphicsSettings();
+        TileRenderer renderer = new TileRenderer(batch, loader, camera, new DefaultAssetResolver(), null, graphics);
         reset(loader);
 
         Array<RenderTile> tiles = new Array<>();
@@ -254,5 +261,63 @@ public class TileRendererTest {
         List<Float> values = rotCaptor.getAllValues();
         assertEquals(2, values.size());
         assertNotEquals(values.get(0), values.get(1));
+    }
+
+    @Test
+    public void doesNotBindTexturesWhenDisabled() {
+        SpriteBatch batch = mock(SpriteBatch.class);
+        ShaderProgram shader = mock(ShaderProgram.class);
+        when(batch.getShader()).thenReturn(shader);
+        ResourceLoader loader = mock(ResourceLoader.class);
+        TextureRegion region = mock(TextureRegion.class);
+        TextureRegion overlay = mock(TextureRegion.class);
+        TextureRegion normal = mock(TextureRegion.class);
+        TextureRegion spec = mock(TextureRegion.class);
+        Texture normalTex = mock(Texture.class);
+        Texture specTex = mock(Texture.class);
+        when(normal.getTexture()).thenReturn(normalTex);
+        when(spec.getTexture()).thenReturn(specTex);
+        when(loader.findRegion(anyString())).thenReturn(region);
+        when(loader.findRegion(eq("hoveredTile0"))).thenReturn(overlay);
+        when(loader.findNormalRegion(anyString())).thenReturn(normal);
+        when(loader.findSpecularRegion(anyString())).thenReturn(spec);
+
+        new BaseDefinitionsMod().init();
+
+        CameraProvider camera = mock(CameraProvider.class);
+        com.badlogic.gdx.graphics.OrthographicCamera cam = new com.badlogic.gdx.graphics.OrthographicCamera();
+        com.badlogic.gdx.utils.viewport.ExtendViewport viewport =
+                new com.badlogic.gdx.utils.viewport.ExtendViewport(1f, 1f, cam);
+        cam.update();
+        when(camera.getViewport()).thenReturn(viewport);
+        when(camera.getCamera()).thenReturn(cam);
+
+        GraphicsSettings graphics = new GraphicsSettings();
+        graphics.setNormalMapsEnabled(false);
+        graphics.setSpecularMapsEnabled(false);
+
+        TileRenderer renderer = new TileRenderer(batch, loader, camera, new DefaultAssetResolver(), null, graphics);
+        reset(loader);
+
+        Array<RenderTile> tiles = new Array<>();
+        RenderTile tile = RenderTile.builder()
+                .x(0)
+                .y(0)
+                .tileType("GRASS")
+                .selected(false)
+                .wood(0)
+                .stone(0)
+                .food(0)
+                .build();
+        tiles.add(tile);
+
+        RenderTile[][] grid = new RenderTile[MapState.DEFAULT_WIDTH][MapState.DEFAULT_HEIGHT];
+        grid[0][0] = tile;
+        MapRenderData map = new SimpleMapRenderData(tiles, new Array<RenderBuilding>(), grid);
+
+        renderer.render(map);
+
+        verify(normalTex, never()).bind(anyInt());
+        verify(specTex, never()).bind(anyInt());
     }
 }


### PR DESCRIPTION
## Summary
- allow renderers to check graphics settings for normal/specular map usage
- pass graphics settings to renderers via factory
- update renderer constructors and unit tests

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684f4632035083288cc9f54a1fbeb847