### PR TITLE
feat: add per-region specular power

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Translation instructions are in [docs/i18n.md](docs/i18n.md).
 Scenario test utilities are covered in [docs/tests.md](docs/tests.md).
 Developer build steps are summarized in [docs/developer_workflow.md](docs/developer_workflow.md).
 Shader plugins are described in [docs/shaders.md](docs/shaders.md).
+The asset pipeline is documented in [docs/asset_pipeline.md](docs/asset_pipeline.md).
 
 ## License
 This project is licensed under the [MIT License](LICENSE).

--- a/client/src/main/java/net/lapidist/colony/client/core/io/ResourceLoader.java
+++ b/client/src/main/java/net/lapidist/colony/client/core/io/ResourceLoader.java
@@ -13,6 +13,9 @@ import java.io.IOException;
  */
 public interface ResourceLoader extends Disposable {
 
+    /** Default specular exponent applied when metadata is missing. */
+    int DEFAULT_SPECULAR_POWER = 16;
+
     /**
      * Load texture regions from the given atlas.
      *
@@ -77,6 +80,16 @@ public interface ResourceLoader extends Disposable {
      */
     default TextureRegion findSpecularRegion(final String name) {
         return null;
+    }
+
+    /**
+     * Retrieve the specular power associated with a region if present.
+     *
+     * @param name base region identifier
+     * @return specular exponent or {@code 16} when undefined
+     */
+    default int getSpecularPower(final String name) {
+        return DEFAULT_SPECULAR_POWER;
     }
 
     /**

--- a/client/src/main/java/net/lapidist/colony/client/core/io/TextureAtlasResourceLoader.java
+++ b/client/src/main/java/net/lapidist/colony/client/core/io/TextureAtlasResourceLoader.java
@@ -173,6 +173,21 @@ public final class TextureAtlasResourceLoader implements ResourceLoader {
         return atlas.findRegion(name + "_s");
     }
 
+    @Override
+    public int getSpecularPower(final String name) {
+        if (atlas == null) {
+            return ResourceLoader.DEFAULT_SPECULAR_POWER;
+        }
+        TextureAtlas.AtlasRegion region = atlas.findRegion(name);
+        if (region != null) {
+            int[] values = region.findValue("specularPower");
+            if (values != null && values.length > 0) {
+                return values[0];
+            }
+        }
+        return ResourceLoader.DEFAULT_SPECULAR_POWER;
+    }
+
 
     @Override
     public void dispose() {

--- a/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
@@ -28,6 +28,7 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
     private final java.util.HashMap<String, TextureRegion> buildingRegions = new java.util.HashMap<>();
     private final java.util.HashMap<String, TextureRegion> normalRegions = new java.util.HashMap<>();
     private final java.util.HashMap<String, TextureRegion> specularRegions = new java.util.HashMap<>();
+    private final java.util.HashMap<String, Integer> specularPowers = new java.util.HashMap<>();
     private final BitmapFont font = new BitmapFont();
     private final GlyphLayout layout = new GlyphLayout();
     private static final float LABEL_OFFSET_Y = 8f;
@@ -62,6 +63,8 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
             if (s != null) {
                 specularRegions.put(def.id().toUpperCase(java.util.Locale.ROOT), s);
             }
+            int power = resourceLoader.getSpecularPower(ref);
+            specularPowers.put(def.id().toUpperCase(java.util.Locale.ROOT), power);
         }
     }
 
@@ -96,6 +99,11 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
                         spec.getTexture().bind(2);
                         shader.setUniformi("u_specular", 2);
                     }
+                    Integer power = specularPowers.get(type.toUpperCase(java.util.Locale.ROOT));
+                    shader.setUniformf(
+                            "u_specularPower",
+                            power != null ? (float) power : ResourceLoader.DEFAULT_SPECULAR_POWER
+                    );
                     com.badlogic.gdx.Gdx.gl.glActiveTexture(com.badlogic.gdx.graphics.GL20.GL_TEXTURE0);
                 }
                 spriteBatch.draw(region, worldCoords.x, worldCoords.y);

--- a/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
@@ -30,6 +30,7 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
     private final java.util.HashMap<String, TextureRegion> tileRegions = new java.util.HashMap<>();
     private final java.util.HashMap<String, TextureRegion> normalRegions = new java.util.HashMap<>();
     private final java.util.HashMap<String, TextureRegion> specularRegions = new java.util.HashMap<>();
+    private final java.util.HashMap<String, Integer> specularPowers = new java.util.HashMap<>();
     private final TextureRegion overlayRegion;
     private final BitmapFont font = new BitmapFont();
     private final GlyphLayout layout = new GlyphLayout();
@@ -70,6 +71,8 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
             if (s != null) {
                 specularRegions.put(def.id().toUpperCase(java.util.Locale.ROOT), s);
             }
+            int power = resourceLoader.getSpecularPower(ref);
+            specularPowers.put(def.id().toUpperCase(java.util.Locale.ROOT), power);
         }
         this.overlayRegion = resourceLoader.findRegion("hoveredTile0");
     }
@@ -123,12 +126,17 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
                                 nrm.getTexture().bind(1);
                                 shader.setUniformi("u_normal", 1);
                             }
-                            if (spec != null && graphicsSettings.isSpecularMapsEnabled()) {
-                                spec.getTexture().bind(2);
-                                shader.setUniformi("u_specular", 2);
-                            }
-                            com.badlogic.gdx.Gdx.gl.glActiveTexture(com.badlogic.gdx.graphics.GL20.GL_TEXTURE0);
+                        if (spec != null && graphicsSettings.isSpecularMapsEnabled()) {
+                            spec.getTexture().bind(2);
+                            shader.setUniformi("u_specular", 2);
                         }
+                        Integer power = specularPowers.get(type.toUpperCase(java.util.Locale.ROOT));
+                        shader.setUniformf(
+                                "u_specularPower",
+                                power != null ? (float) power : ResourceLoader.DEFAULT_SPECULAR_POWER
+                        );
+                        com.badlogic.gdx.Gdx.gl.glActiveTexture(com.badlogic.gdx.graphics.GL20.GL_TEXTURE0);
+                    }
                         String upper = type.toUpperCase(java.util.Locale.ROOT);
                         if ("GRASS".equals(upper) || "DIRT".equals(upper)) {
                             float rotation = TileRotationUtil.rotationFor(tile.getX(), tile.getY());

--- a/client/src/main/resources/assets/shaders/normal.frag
+++ b/client/src/main/resources/assets/shaders/normal.frag
@@ -10,6 +10,7 @@ uniform sampler2D u_normal;
 uniform sampler2D u_specular;
 uniform vec3 u_lightDir;
 uniform vec3 u_viewDir;
+uniform float u_specularPower;
 
 void main() {
     vec4 diffuse = texture2D(u_texture, v_texCoords);
@@ -18,7 +19,7 @@ void main() {
     vec3 viewDir = normalize(u_viewDir);
     float diff = max(dot(normal, lightDir), 0.0);
     vec3 halfDir = normalize(lightDir + viewDir);
-    float specIntensity = pow(max(dot(normal, halfDir), 0.0), 16.0);
+    float specIntensity = pow(max(dot(normal, halfDir), 0.0), u_specularPower);
     float specMap = texture2D(u_specular, v_texCoords).r;
     vec3 color = diffuse.rgb * diff + vec3(specIntensity * specMap);
     gl_FragColor = vec4(color, diffuse.a) * v_color;

--- a/client/src/main/resources/assets/textures/textures.atlas
+++ b/client/src/main/resources/assets/textures/textures.atlas
@@ -10,6 +10,7 @@ grass0
   orig: 32,32
   offset: 0,0
   index: -1
+  specularPower: 8
 
 dirt.png
 size: 32,32
@@ -36,6 +37,7 @@ house0
   orig: 32,32
   offset: 0,0
   index: -1
+  specularPower: 24
 
 hoveredTile.png
 size: 32,32

--- a/docs/asset_pipeline.md
+++ b/docs/asset_pipeline.md
@@ -1,0 +1,12 @@
+# Asset Pipeline
+
+Textures are packed using LibGDX's `TexturePacker` into a single `.atlas` file. Each
+region may define additional custom fields which are preserved by the atlas loader.
+
+The normal mapping shader reads a `specularPower` value from atlas regions to
+control the Blinn–Phong exponent. Add a line like `specularPower: 32` under a
+region entry to override the default of `16`.
+
+Run `./gradlew tests:copyAssets` whenever the atlas is updated so the test module
+has the latest resources.
+

--- a/docs/shaders.md
+++ b/docs/shaders.md
@@ -75,7 +75,9 @@ additional uniforms:
 
 * `u_lightDir` – normalized direction to the main light source.
 * `u_viewDir` – direction toward the camera.
+* `u_specularPower` – exponent for the specular highlight.
 
-Both values are updated every frame so diffuse and specular terms react to
-camera movement. The specular map supplies the intensity for a Blinn–Phong
-highlight calculation.
+The first two values are updated every frame so diffuse and specular terms react
+to camera movement. The specular map supplies the intensity for a Blinn–Phong
+highlight calculation, while `u_specularPower` controls the falloff. Atlas
+regions may override the default by adding `specularPower: N`.

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/BuildingRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/BuildingRendererTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.*;
 public class BuildingRendererTest {
 
     private static final int VIEW_SIZE = 32;
+    private static final int CUSTOM_POWER = 23;
 
     @Test
     public void rendersBuildingTexture() {
@@ -183,5 +184,41 @@ public class BuildingRendererTest {
 
         verify(normalTex, never()).bind(anyInt());
         verify(specTex, never()).bind(anyInt());
+    }
+
+    @Test
+    public void setsSpecularPowerUniform() {
+        SpriteBatch batch = mock(SpriteBatch.class);
+        ShaderProgram shader = mock(ShaderProgram.class);
+        when(batch.getShader()).thenReturn(shader);
+        ResourceLoader loader = mock(ResourceLoader.class);
+        TextureRegion region = mock(TextureRegion.class);
+        when(loader.findRegion(anyString())).thenReturn(region);
+        when(loader.getSpecularPower(anyString())).thenReturn(CUSTOM_POWER);
+
+        new BaseDefinitionsMod().init();
+
+        CameraProvider camera = mock(CameraProvider.class);
+        OrthographicCamera cam = new OrthographicCamera();
+        ExtendViewport viewport = new ExtendViewport(VIEW_SIZE, VIEW_SIZE, cam);
+        viewport.update(VIEW_SIZE, VIEW_SIZE, true);
+        cam.update();
+        when(camera.getCamera()).thenReturn(cam);
+        when(camera.getViewport()).thenReturn(viewport);
+
+        GraphicsSettings graphics = new GraphicsSettings();
+        BuildingRenderer renderer = new BuildingRenderer(batch, loader, camera, new DefaultAssetResolver(), graphics);
+        reset(loader);
+
+        Array<RenderBuilding> buildings = new Array<>();
+        RenderBuilding building = RenderBuilding.builder().x(0).y(0).buildingType("house").build();
+        buildings.add(building);
+
+        MapRenderData map = new SimpleMapRenderData(new Array<RenderTile>(), buildings,
+                new RenderTile[MapState.DEFAULT_WIDTH][MapState.DEFAULT_HEIGHT]);
+
+        renderer.render(map);
+
+        verify(shader).setUniformf("u_specularPower", (float) CUSTOM_POWER);
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/core/io/ResourceLoaderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/io/ResourceLoaderTest.java
@@ -16,6 +16,8 @@ import static org.junit.Assert.*;
 @RunWith(GdxTestRunner.class)
 public class ResourceLoaderTest {
 
+    private static final int OVERRIDE_POWER = 8;
+
     @Test
     public final void testLoadsResources() throws IOException {
         ResourceLoader resourceLoader = new TextureAtlasResourceLoader();
@@ -37,6 +39,8 @@ public class ResourceLoaderTest {
         assertNotNull(resourceLoader.findSpecularRegion("dirt0"));
         assertNotNull(resourceLoader.findNormalRegion("grass0"));
         assertNotNull(resourceLoader.findSpecularRegion("grass0"));
+        assertEquals(OVERRIDE_POWER, resourceLoader.getSpecularPower("grass0"));
+        assertEquals(ResourceLoader.DEFAULT_SPECULAR_POWER, resourceLoader.getSpecularPower("dirt0"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- support `specularPower` metadata in texture atlas
- provide new uniform to normal-mapping shader
- pass exponent from BuildingRenderer and TileRenderer
- document asset pipeline and shader usage
- test specular power handling

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684f4aeb618c832886c3c1d349caf8ac