### PR TITLE
feat: integrate day-night cycle with lighting plugin

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPlugin.java
+++ b/client/src/main/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPlugin.java
@@ -4,6 +4,8 @@ import box2dLight.RayHandler;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.math.Vector2;
+import net.lapidist.colony.client.systems.CameraProvider;
+import net.lapidist.colony.client.systems.DayNightSystem;
 import com.badlogic.gdx.physics.box2d.World;
 import net.lapidist.colony.client.core.io.FileLocation;
 
@@ -13,6 +15,8 @@ import net.lapidist.colony.client.core.io.FileLocation;
 public final class LightsNormalMapShaderPlugin implements LightingPlugin, UniformUpdater {
 
     private RayHandler rayHandler;
+    private DayNightSystem dayNightSystem;
+    private CameraProvider cameraProvider;
     private final com.badlogic.gdx.math.Vector3 lightDir = new com.badlogic.gdx.math.Vector3(0f, 0f, 1f);
     private final com.badlogic.gdx.math.Vector3 viewDir = new com.badlogic.gdx.math.Vector3(0f, 0f, 1f);
 
@@ -38,6 +42,16 @@ public final class LightsNormalMapShaderPlugin implements LightingPlugin, Unifor
         return rayHandler;
     }
 
+    /** Inject the {@link DayNightSystem} used for lighting calculations. */
+    public void setDayNightSystem(final DayNightSystem system) {
+        this.dayNightSystem = system;
+    }
+
+    /** Inject the {@link CameraProvider} used to derive view direction. */
+    public void setCameraProvider(final CameraProvider provider) {
+        this.cameraProvider = provider;
+    }
+
     @Override
     public String id() {
         return "lights-normalmap";
@@ -58,6 +72,12 @@ public final class LightsNormalMapShaderPlugin implements LightingPlugin, Unifor
 
     @Override
     public void applyUniforms(final ShaderProgram program) {
+        if (dayNightSystem != null) {
+            lightDir.set(dayNightSystem.getSunDirection());
+        }
+        if (cameraProvider != null) {
+            viewDir.set(cameraProvider.getCamera().direction).scl(-1f).nor();
+        }
         program.setUniformf("u_lightDir", lightDir);
         program.setUniformf("u_viewDir", viewDir);
     }

--- a/client/src/main/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRenderer.java
@@ -23,11 +23,12 @@ public final class LoadingSpriteMapRenderer implements MapRenderer, Disposable {
     private final boolean cacheEnabled;
     private final Consumer<Float> progressCallback;
     private final com.badlogic.gdx.graphics.glutils.ShaderProgram shader;
-    private final net.lapidist.colony.client.graphics.ShaderPlugin plugin;
+    private net.lapidist.colony.client.graphics.ShaderPlugin plugin;
     private box2dLight.RayHandler lights;
 
     private MapRenderer delegate;
 
+// CHECKSTYLE:OFF: ParameterNumber
     public LoadingSpriteMapRenderer(
             final World worldContext,
             final SpriteBatch batchToUse,
@@ -35,8 +36,7 @@ public final class LoadingSpriteMapRenderer implements MapRenderer, Disposable {
             final CameraProvider camera,
             final boolean cache,
             final Consumer<Float> callback,
-            final com.badlogic.gdx.graphics.glutils.ShaderProgram shaderProgram,
-            final net.lapidist.colony.client.graphics.ShaderPlugin pluginParam
+            final com.badlogic.gdx.graphics.glutils.ShaderProgram shaderProgram
     ) {
         this.world = worldContext;
         this.spriteBatch = batchToUse;
@@ -45,9 +45,15 @@ public final class LoadingSpriteMapRenderer implements MapRenderer, Disposable {
         this.cacheEnabled = cache;
         this.progressCallback = callback;
         this.shader = shaderProgram;
-        this.plugin = pluginParam;
+        this.plugin = null;
         // ensure mapper initialization for render systems
         worldContext.getMapper(MapComponent.class);
+    }
+// CHECKSTYLE:ON: ParameterNumber
+
+    /** Assign optional shader plugin. */
+    public void setPlugin(final net.lapidist.colony.client.graphics.ShaderPlugin pluginParam) {
+        this.plugin = pluginParam;
     }
 
     /** Assign lighting handler. */
@@ -106,9 +112,11 @@ public final class LoadingSpriteMapRenderer implements MapRenderer, Disposable {
                     buildingRenderer,
                     renderers,
                     cacheEnabled,
-                    shader,
-                    plugin
+                    shader
             );
+            if (delegate instanceof SpriteBatchMapRenderer sb) {
+                sb.setPlugin(plugin);
+            }
             if (lights != null && delegate instanceof SpriteBatchMapRenderer sb) {
                 sb.setLights(lights);
             }

--- a/client/src/main/java/net/lapidist/colony/client/renderers/SpriteBatchMapRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/SpriteBatchMapRenderer.java
@@ -19,13 +19,13 @@ public final class SpriteBatchMapRenderer implements MapRenderer, Disposable {
     private final BuildingRenderer buildingRenderer;
     private final MapEntityRenderers entityRenderers;
     private final ShaderProgram shader;
-    private final net.lapidist.colony.client.graphics.ShaderPlugin plugin;
+    private net.lapidist.colony.client.graphics.ShaderPlugin plugin;
     private final MapTileCache tileCache = new MapTileCache();
     private final AssetResolver resolver = new DefaultAssetResolver();
     private final boolean cacheEnabled;
     private RayHandler lights;
 
-    // CHECKSTYLE:OFF: ParameterNumber
+// CHECKSTYLE:OFF: ParameterNumber
     public SpriteBatchMapRenderer(
             final SpriteBatch spriteBatchToSet,
             final ResourceLoader resourceLoaderToSet,
@@ -33,8 +33,7 @@ public final class SpriteBatchMapRenderer implements MapRenderer, Disposable {
             final BuildingRenderer buildingRendererToSet,
             final MapEntityRenderers entityRenderersToSet,
             final boolean cacheEnabledToSet,
-            final ShaderProgram shaderToSet,
-            final net.lapidist.colony.client.graphics.ShaderPlugin pluginToSet
+            final ShaderProgram shaderToSet
     ) {
         this.spriteBatch = spriteBatchToSet;
         this.resourceLoader = resourceLoaderToSet;
@@ -43,9 +42,14 @@ public final class SpriteBatchMapRenderer implements MapRenderer, Disposable {
         this.entityRenderers = entityRenderersToSet;
         this.cacheEnabled = cacheEnabledToSet;
         this.shader = shaderToSet;
+        this.plugin = null;
+    }
+// CHECKSTYLE:ON: ParameterNumber
+
+    /** Assign optional shader plugin. */
+    public void setPlugin(final net.lapidist.colony.client.graphics.ShaderPlugin pluginToSet) {
         this.plugin = pluginToSet;
     }
-    // CHECKSTYLE:ON: ParameterNumber
 
     /** Invalidate cache segments for the given tile indices. */
     public void invalidateTiles(final com.badlogic.gdx.utils.IntArray indices) {

--- a/client/src/main/java/net/lapidist/colony/client/renderers/SpriteMapRendererFactory.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/SpriteMapRendererFactory.java
@@ -89,9 +89,9 @@ public final class SpriteMapRendererFactory implements MapRendererFactory {
                 cameraSystem,
                 graphics.isSpriteCacheEnabled(),
                 progressCallback,
-                shader,
-                plugin
+                shader
         );
+        renderer.setPlugin(plugin);
         if (lights != null) {
             renderer.setLights(lights);
         }

--- a/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -20,6 +20,7 @@ import net.lapidist.colony.client.systems.MapRenderSystem;
 import net.lapidist.colony.client.systems.LightingSystem;
 import net.lapidist.colony.client.systems.DynamicLightSystem;
 import net.lapidist.colony.client.systems.DayNightSystem;
+import net.lapidist.colony.client.systems.CameraProvider;
 import net.lapidist.colony.client.systems.ParticleSystem;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
 import net.lapidist.colony.client.systems.PlayerMovementSystem;
@@ -236,6 +237,16 @@ public final class MapWorldBuilder {
             MapRenderer renderer = actualFactory.create(world, plugin);
             renderSystem.setMapRenderer(renderer);
             renderSystem.setCameraProvider(world.getSystem(PlayerCameraSystem.class));
+        }
+        if (plugin instanceof net.lapidist.colony.client.graphics.LightsNormalMapShaderPlugin lnmp) {
+            DayNightSystem dns = world.getSystem(DayNightSystem.class);
+            if (dns != null) {
+                lnmp.setDayNightSystem(dns);
+            }
+            CameraProvider cp = world.getSystem(PlayerCameraSystem.class);
+            if (cp != null) {
+                lnmp.setCameraProvider(cp);
+            }
         }
         LightingSystem lightingSystem = world.getSystem(LightingSystem.class);
         if (lightingSystem != null && plugin instanceof net.lapidist.colony.client.graphics.LightingPlugin lp) {

--- a/client/src/main/java/net/lapidist/colony/client/systems/DayNightSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/DayNightSystem.java
@@ -3,6 +3,7 @@ package net.lapidist.colony.client.systems;
 import com.artemis.BaseSystem;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.math.MathUtils;
+import com.badlogic.gdx.math.Vector3;
 import box2dLight.RayHandler;
 import net.lapidist.colony.components.state.EnvironmentState;
 
@@ -15,6 +16,7 @@ public final class DayNightSystem extends BaseSystem {
     private final LightingSystem lightingSystem;
     private final EnvironmentState environment;
     private float timeOfDay;
+    private final Vector3 sunDirection = new Vector3();
 
     private static final float HOURS_PER_DAY = 24f;
     private static final float FULL_ROTATION = 360f;
@@ -43,6 +45,16 @@ public final class DayNightSystem extends BaseSystem {
     /** Set the time of day, values wrap to the 0-24 range. */
     public void setTimeOfDay(final float time) {
         timeOfDay = wrap(time);
+    }
+
+    /**
+     * Returns a normalized direction vector pointing toward the sun based on
+     * the current time of day.
+     */
+    public Vector3 getSunDirection() {
+        float angle = (timeOfDay / HOURS_PER_DAY) * FULL_ROTATION - DAWN_OFFSET;
+        sunDirection.set(MathUtils.cosDeg(angle), 0f, MathUtils.sinDeg(angle)).nor();
+        return sunDirection;
     }
 
     @Override

--- a/tests/src/jmh/java/net/lapidist/colony/tests/benchmarks/SpriteBatchRendererBenchmark.java
+++ b/tests/src/jmh/java/net/lapidist/colony/tests/benchmarks/SpriteBatchRendererBenchmark.java
@@ -70,9 +70,9 @@ public class SpriteBatchRendererBenchmark {
         CelestialRenderer celestialRenderer = mock(CelestialRenderer.class);
         MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer, celestialRenderer);
         cachedRenderer = new SpriteBatchMapRenderer(
-                batch, loader, tileRenderer, buildingRenderer, renderers, true, null, null);
+                batch, loader, tileRenderer, buildingRenderer, renderers, true, null);
         plainRenderer = new SpriteBatchMapRenderer(
-                batch, loader, tileRenderer, buildingRenderer, renderers, false, null, null);
+                batch, loader, tileRenderer, buildingRenderer, renderers, false, null);
         data = createData(MAP_SIZE, MAP_SIZE);
         construction = mockConstruction(SpriteCache.class, (mock, ctx) -> {
             when(mock.getProjectionMatrix()).thenReturn(new Matrix4());

--- a/tests/src/test/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPluginTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPluginTest.java
@@ -1,6 +1,15 @@
 package net.lapidist.colony.client.graphics;
 
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.math.Vector3;
+import net.lapidist.colony.client.systems.ClearScreenSystem;
+import net.lapidist.colony.client.systems.DayNightSystem;
+import net.lapidist.colony.client.systems.LightingSystem;
+import net.lapidist.colony.client.systems.PlayerCameraSystem;
+import net.lapidist.colony.components.state.EnvironmentState;
+import org.mockito.ArgumentCaptor;
+import static org.mockito.Mockito.*;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -10,6 +19,10 @@ import static org.junit.Assert.*;
 /** Basic checks for {@link LightsNormalMapShaderPlugin}. */
 @RunWith(GdxTestRunner.class)
 public class LightsNormalMapShaderPluginTest {
+
+    private static final float START_TIME = 6f;
+    private static final float END_TIME = 12f;
+    private static final float EPSILON = 0.001f;
 
     @Test
     public void createInitializesShaderAndLights() {
@@ -24,5 +37,31 @@ public class LightsNormalMapShaderPluginTest {
             assertNull(plugin.getRayHandler());
         }
         assertEquals("lights-normalmap", plugin.id());
+    }
+
+    @Test
+    public void updatesLightDirectionWhenTimeChanges() {
+        LightsNormalMapShaderPlugin plugin = new LightsNormalMapShaderPlugin();
+        DayNightSystem dns = new DayNightSystem(
+                new ClearScreenSystem(new Color()),
+                new LightingSystem(),
+                new EnvironmentState()
+        );
+        PlayerCameraSystem camera = new PlayerCameraSystem();
+        plugin.setDayNightSystem(dns);
+        plugin.setCameraProvider(camera);
+
+        ShaderProgram program = mock(ShaderProgram.class);
+        ArgumentCaptor<Vector3> captor = ArgumentCaptor.forClass(Vector3.class);
+        dns.setTimeOfDay(START_TIME);
+        plugin.applyUniforms(program);
+        verify(program).setUniformf(eq("u_lightDir"), captor.capture());
+        Vector3 first = new Vector3(captor.getValue());
+        reset(program);
+        dns.setTimeOfDay(END_TIME);
+        plugin.applyUniforms(program);
+        verify(program).setUniformf(eq("u_lightDir"), captor.capture());
+        Vector3 second = captor.getValue();
+        assertNotEquals(first.x, second.x, EPSILON);
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRendererTest.java
@@ -32,7 +32,7 @@ public class LoadingSpriteMapRendererTest {
         try (MockedConstruction<SpriteBatchMapRenderer> cons =
                 mockConstruction(SpriteBatchMapRenderer.class)) {
             LoadingSpriteMapRenderer renderer = new LoadingSpriteMapRenderer(
-                    world, batch, loader, camera, false, null, null, null);
+                    world, batch, loader, camera, false, null, null);
             renderer.setLights(lights);
 
             renderer.render(mock(net.lapidist.colony.client.render.MapRenderData.class), null);

--- a/tests/src/test/java/net/lapidist/colony/client/renderers/SpriteBatchMapRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/renderers/SpriteBatchMapRendererTest.java
@@ -32,7 +32,7 @@ public class SpriteBatchMapRendererTest {
         MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer, celestialRenderer);
 
         SpriteBatchMapRenderer renderer = new SpriteBatchMapRenderer(
-                batch, loader, tileRenderer, buildingRenderer, renderers, true, null, null);
+                batch, loader, tileRenderer, buildingRenderer, renderers, true, null);
 
         Field cacheField = SpriteBatchMapRenderer.class.getDeclaredField("tileCache");
         cacheField.setAccessible(true);
@@ -57,7 +57,7 @@ public class SpriteBatchMapRendererTest {
         MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer, celestialRenderer);
 
         SpriteBatchMapRenderer renderer = new SpriteBatchMapRenderer(
-                batch, loader, tileRenderer, buildingRenderer, renderers, false, null, null);
+                batch, loader, tileRenderer, buildingRenderer, renderers, false, null);
 
         Field cacheField = SpriteBatchMapRenderer.class.getDeclaredField("tileCache");
         cacheField.setAccessible(true);
@@ -82,7 +82,7 @@ public class SpriteBatchMapRendererTest {
         MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer, celestialRenderer);
 
         SpriteBatchMapRenderer renderer = new SpriteBatchMapRenderer(
-                batch, loader, tileRenderer, buildingRenderer, renderers, false, shader, null);
+                batch, loader, tileRenderer, buildingRenderer, renderers, false, shader);
 
         MapRenderData map = mock(MapRenderData.class);
         CameraProvider camera = new CameraProvider() {
@@ -128,7 +128,7 @@ public class SpriteBatchMapRendererTest {
         MapEntityRenderers renderers = new MapEntityRenderers(resourceRenderer, playerRenderer, celestialRenderer);
 
         SpriteBatchMapRenderer renderer = new SpriteBatchMapRenderer(
-                batch, loader, tileRenderer, buildingRenderer, renderers, false, null, null);
+                batch, loader, tileRenderer, buildingRenderer, renderers, false, null);
 
         MapRenderData map = mock(MapRenderData.class);
         CameraProvider camera = new CameraProvider() {
@@ -169,7 +169,7 @@ public class SpriteBatchMapRendererTest {
         box2dLight.RayHandler lights = mock(box2dLight.RayHandler.class);
 
         SpriteBatchMapRenderer renderer = new SpriteBatchMapRenderer(
-                batch, loader, tileRenderer, buildingRenderer, renderers, false, null, null);
+                batch, loader, tileRenderer, buildingRenderer, renderers, false, null);
         renderer.setLights(lights);
 
         MapRenderData map = mock(MapRenderData.class);


### PR DESCRIPTION
## Summary
- compute normalized sun direction in `DayNightSystem`
- update `LightsNormalMapShaderPlugin` with current sun and view directions
- wire `LightsNormalMapShaderPlugin` to `DayNightSystem` when creating the map world
- pass shader plugin into renderers through setters
- adapt tests for new API and behaviour

## Testing
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_684f47d85dc88328a0a82c689be5f6a1