### PR TITLE
feat: link shader to day-night cycle

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPlugin.java
+++ b/client/src/main/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPlugin.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.physics.box2d.World;
+import net.lapidist.colony.client.systems.DayNightSystem;
 import net.lapidist.colony.client.core.io.FileLocation;
 
 /**
@@ -13,8 +14,14 @@ import net.lapidist.colony.client.core.io.FileLocation;
 public final class LightsNormalMapShaderPlugin implements LightingPlugin, UniformUpdater {
 
     private RayHandler rayHandler;
+    private DayNightSystem dayNightSystem;
     private final com.badlogic.gdx.math.Vector3 lightDir = new com.badlogic.gdx.math.Vector3(0f, 0f, 1f);
     private final com.badlogic.gdx.math.Vector3 viewDir = new com.badlogic.gdx.math.Vector3(0f, 0f, 1f);
+
+    /** Assign the system providing the sun direction. */
+    public void setDayNightSystem(final DayNightSystem system) {
+        this.dayNightSystem = system;
+    }
 
     @Override
     public ShaderProgram create(final ShaderManager manager) {
@@ -58,6 +65,10 @@ public final class LightsNormalMapShaderPlugin implements LightingPlugin, Unifor
 
     @Override
     public void applyUniforms(final ShaderProgram program) {
+        if (dayNightSystem != null) {
+            dayNightSystem.getSunDirection(lightDir);
+        }
+        viewDir.set(0f, 0f, 1f);
         program.setUniformf("u_lightDir", lightDir);
         program.setUniformf("u_viewDir", viewDir);
     }

--- a/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -237,6 +237,11 @@ public final class MapWorldBuilder {
             renderSystem.setMapRenderer(renderer);
             renderSystem.setCameraProvider(world.getSystem(PlayerCameraSystem.class));
         }
+        DayNightSystem dayNightSystem = world.getSystem(DayNightSystem.class);
+        if (plugin instanceof net.lapidist.colony.client.graphics.LightsNormalMapShaderPlugin ln
+                && dayNightSystem != null) {
+            ln.setDayNightSystem(dayNightSystem);
+        }
         LightingSystem lightingSystem = world.getSystem(LightingSystem.class);
         if (lightingSystem != null && plugin instanceof net.lapidist.colony.client.graphics.LightingPlugin lp) {
             if (settings == null || settings.getGraphicsSettings().isLightingEnabled()) {

--- a/client/src/main/java/net/lapidist/colony/client/systems/DayNightSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/DayNightSystem.java
@@ -3,6 +3,7 @@ package net.lapidist.colony.client.systems;
 import com.artemis.BaseSystem;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.math.MathUtils;
+import com.badlogic.gdx.math.Vector3;
 import box2dLight.RayHandler;
 import net.lapidist.colony.components.state.EnvironmentState;
 
@@ -43,6 +44,17 @@ public final class DayNightSystem extends BaseSystem {
     /** Set the time of day, values wrap to the 0-24 range. */
     public void setTimeOfDay(final float time) {
         timeOfDay = wrap(time);
+    }
+
+    /**
+     * Calculate the direction of the sun for the current time of day.
+     *
+     * @param out vector to store the result
+     * @return normalized sun direction
+     */
+    public Vector3 getSunDirection(final Vector3 out) {
+        float angle = (timeOfDay / HOURS_PER_DAY) * FULL_ROTATION - DAWN_OFFSET;
+        return out.set(MathUtils.cosDeg(angle), MathUtils.sinDeg(angle), 1f).nor();
     }
 
     @Override

--- a/tests/src/test/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPluginTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPluginTest.java
@@ -1,6 +1,15 @@
 package net.lapidist.colony.client.graphics;
 
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import com.badlogic.gdx.graphics.Color;
+import net.lapidist.colony.client.systems.ClearScreenSystem;
+import net.lapidist.colony.client.systems.DayNightSystem;
+import net.lapidist.colony.client.systems.LightingSystem;
+import net.lapidist.colony.components.state.EnvironmentState;
+import net.lapidist.colony.components.state.Season;
+import com.badlogic.gdx.math.Vector3;
+import org.mockito.ArgumentCaptor;
+import static org.mockito.Mockito.*;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,5 +33,34 @@ public class LightsNormalMapShaderPluginTest {
             assertNull(plugin.getRayHandler());
         }
         assertEquals("lights-normalmap", plugin.id());
+    }
+
+    @Test
+    @SuppressWarnings("checkstyle:magicnumber")
+    public void updatesLightDirectionWhenTimeChanges() {
+        LightsNormalMapShaderPlugin plugin = new LightsNormalMapShaderPlugin();
+        DayNightSystem system = new DayNightSystem(
+                new ClearScreenSystem(new Color()),
+                new LightingSystem(),
+                new EnvironmentState(0f, Season.SPRING, 0f)
+        );
+        plugin.setDayNightSystem(system);
+        ShaderProgram shader = mock(ShaderProgram.class);
+
+        system.setTimeOfDay(0f);
+        plugin.applyUniforms(shader);
+        ArgumentCaptor<Vector3> firstCap = ArgumentCaptor.forClass(Vector3.class);
+        verify(shader).setUniformf(eq("u_lightDir"), firstCap.capture());
+        Vector3 first = new Vector3(firstCap.getValue());
+        reset(shader);
+
+        final float newTime = 6f;
+        system.setTimeOfDay(newTime);
+        plugin.applyUniforms(shader);
+        ArgumentCaptor<Vector3> secondCap = ArgumentCaptor.forClass(Vector3.class);
+        verify(shader).setUniformf(eq("u_lightDir"), secondCap.capture());
+        Vector3 second = new Vector3(secondCap.getValue());
+
+        assertNotEquals(first.x, second.x);
     }
 }


### PR DESCRIPTION
## Summary
- expose DayNightSystem.getSunDirection() to compute normalized sunlight vector
- have LightsNormalMapShaderPlugin update uniforms using DayNightSystem
- wire plugin to DayNightSystem in MapWorldBuilder
- extend shader plugin test to verify u_lightDir changes over time

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684f4eceaca083289c036a279925ab90