### PR TITLE
feat(client): dispose light worlds

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/graphics/Box2dLightsPlugin.java
+++ b/client/src/main/java/net/lapidist/colony/client/graphics/Box2dLightsPlugin.java
@@ -13,6 +13,7 @@ import com.badlogic.gdx.physics.box2d.World;
 public final class Box2dLightsPlugin implements LightingPlugin {
 
     private RayHandler rayHandler;
+    private World world;
 
     @Override
     public ShaderProgram create(final ShaderManager manager) {
@@ -20,7 +21,7 @@ public final class Box2dLightsPlugin implements LightingPlugin {
             return null;
         }
         try {
-            World world = new World(new Vector2(), false);
+            world = new World(new Vector2(), false);
             rayHandler = new RayHandler(world);
             rayHandler.setAmbientLight(1f, 1f, 1f, 1f);
         } catch (Exception ex) {
@@ -50,6 +51,10 @@ public final class Box2dLightsPlugin implements LightingPlugin {
 
     @Override
     public void dispose() {
+        if (world != null) {
+            world.dispose();
+            world = null;
+        }
         if (rayHandler != null) {
             rayHandler.dispose();
             rayHandler = null;

--- a/client/src/main/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPlugin.java
+++ b/client/src/main/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPlugin.java
@@ -14,6 +14,7 @@ import net.lapidist.colony.client.core.io.FileLocation;
 public final class LightsNormalMapShaderPlugin implements LightingPlugin, UniformUpdater {
 
     private RayHandler rayHandler;
+    private World world;
     private DayNightSystem dayNightSystem;
     private final com.badlogic.gdx.math.Vector3 lightDir = new com.badlogic.gdx.math.Vector3(0f, 0f, 1f);
     private final com.badlogic.gdx.math.Vector3 viewDir = new com.badlogic.gdx.math.Vector3(0f, 0f, 1f);
@@ -29,7 +30,7 @@ public final class LightsNormalMapShaderPlugin implements LightingPlugin, Unifor
             return null;
         }
         try {
-            World world = new World(new Vector2(), false);
+            world = new World(new Vector2(), false);
             rayHandler = new RayHandler(world);
             rayHandler.setAmbientLight(1f, 1f, 1f, 1f);
             return manager.load(FileLocation.INTERNAL,
@@ -57,6 +58,10 @@ public final class LightsNormalMapShaderPlugin implements LightingPlugin, Unifor
 
     @Override
     public void dispose() {
+        if (world != null) {
+            world.dispose();
+            world = null;
+        }
         if (rayHandler != null) {
             rayHandler.dispose();
             rayHandler = null;

--- a/tests/src/test/java/net/lapidist/colony/client/graphics/Box2dLightsPluginTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/graphics/Box2dLightsPluginTest.java
@@ -5,6 +5,9 @@ import com.badlogic.gdx.graphics.Color;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+
+import static org.mockito.Mockito.*;
 
 import static org.junit.Assert.*;
 
@@ -35,5 +38,29 @@ public class Box2dLightsPluginTest {
         }
         assertEquals("box2dlights", plugin.id());
         assertEquals("Box2DLights", plugin.displayName());
+    }
+
+    @Test
+    public void disposeCleansUpResources() throws Exception {
+        Box2dLightsPlugin plugin = new Box2dLightsPlugin();
+
+        java.lang.reflect.Field worldField = Box2dLightsPlugin.class.getDeclaredField("world");
+        worldField.setAccessible(true);
+        java.lang.reflect.Field handlerField = Box2dLightsPlugin.class.getDeclaredField("rayHandler");
+        handlerField.setAccessible(true);
+
+        com.badlogic.gdx.physics.box2d.World world = mock(com.badlogic.gdx.physics.box2d.World.class);
+        RayHandler handler = mock(RayHandler.class);
+        worldField.set(plugin, world);
+        handlerField.set(plugin, handler);
+
+        plugin.dispose();
+
+        InOrder order = inOrder(world, handler);
+        order.verify(world).dispose();
+        order.verify(handler).dispose();
+
+        assertNull(worldField.get(plugin));
+        assertNull(handlerField.get(plugin));
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPluginTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPluginTest.java
@@ -9,6 +9,8 @@ import net.lapidist.colony.components.state.EnvironmentState;
 import net.lapidist.colony.components.state.Season;
 import com.badlogic.gdx.math.Vector3;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import box2dLight.RayHandler;
 import static org.mockito.Mockito.*;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
@@ -62,5 +64,29 @@ public class LightsNormalMapShaderPluginTest {
         Vector3 second = new Vector3(secondCap.getValue());
 
         assertNotEquals(first.x, second.x);
+    }
+
+    @Test
+    public void disposeCleansUpResources() throws Exception {
+        LightsNormalMapShaderPlugin plugin = new LightsNormalMapShaderPlugin();
+
+        java.lang.reflect.Field worldField = LightsNormalMapShaderPlugin.class.getDeclaredField("world");
+        worldField.setAccessible(true);
+        java.lang.reflect.Field handlerField = LightsNormalMapShaderPlugin.class.getDeclaredField("rayHandler");
+        handlerField.setAccessible(true);
+
+        com.badlogic.gdx.physics.box2d.World world = mock(com.badlogic.gdx.physics.box2d.World.class);
+        RayHandler handler = mock(RayHandler.class);
+        worldField.set(plugin, world);
+        handlerField.set(plugin, handler);
+
+        plugin.dispose();
+
+        InOrder order = inOrder(world, handler);
+        order.verify(world).dispose();
+        order.verify(handler).dispose();
+
+        assertNull(worldField.get(plugin));
+        assertNull(handlerField.get(plugin));
     }
 }


### PR DESCRIPTION
## Summary
- add `World` fields to lighting shader plugins
- dispose Box2DLights `World` before its `RayHandler`
- dispose normal map lights `World` before its `RayHandler`
- verify cleanup in unit tests

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684fc7b37848832880af0d5af29fa41a