### PR TITLE
fix(client): clear stencil buffer

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/systems/ClearScreenSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/ClearScreenSystem.java
@@ -21,7 +21,6 @@ public final class ClearScreenSystem extends BaseSystem {
     @Override
     protected void processSystem() {
         Gdx.gl.glClearColor(color.r, color.g, color.b, color.a);
-        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
-        Gdx.gl.glClear(GL20.GL_ALPHA_BITS);
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT | GL20.GL_STENCIL_BUFFER_BIT);
     }
 }


### PR DESCRIPTION
## Summary
- clean up ClearScreenSystem
- remove invalid alpha clear and clear stencil instead

## Testing
- `./scripts/check.sh`


------
https://chatgpt.com/codex/tasks/task_e_684fcf7dd7f88328ad4f7a3dd0f3f9ab