### PR TITLE
fix: clean up world on shader init failure

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPlugin.java
+++ b/client/src/main/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPlugin.java
@@ -36,6 +36,10 @@ public final class LightsNormalMapShaderPlugin implements LightingPlugin, Unifor
             return manager.load(FileLocation.INTERNAL,
                     "shaders/normal.vert", "shaders/normal.frag");
         } catch (Exception ex) {
+            if (world != null) {
+                world.dispose();
+                world = null;
+            }
             rayHandler = null;
             return null;
         }

--- a/tests/src/test/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPluginTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPluginTest.java
@@ -89,4 +89,25 @@ public class LightsNormalMapShaderPluginTest {
         assertNull(worldField.get(plugin));
         assertNull(handlerField.get(plugin));
     }
+
+    @Test
+    public void failedCreationCleansUpWorld() throws Exception {
+        LightsNormalMapShaderPlugin plugin = new LightsNormalMapShaderPlugin();
+
+        java.lang.reflect.Field worldField = LightsNormalMapShaderPlugin.class.getDeclaredField("world");
+        worldField.setAccessible(true);
+        java.lang.reflect.Field handlerField = LightsNormalMapShaderPlugin.class.getDeclaredField("rayHandler");
+        handlerField.setAccessible(true);
+
+        ShaderProgram program = mock(ShaderProgram.class);
+        when(program.isCompiled()).thenReturn(false);
+        when(program.getLog()).thenReturn("err");
+
+        ShaderManager manager = new ShaderManager((v, f) -> program);
+
+        assertNull(plugin.create(manager));
+
+        assertNull(worldField.get(plugin));
+        assertNull(handlerField.get(plugin));
+    }
 }


### PR DESCRIPTION
## Summary
- dispose Box2D world when LightsNormalMapShaderPlugin fails to create
- avoid world reuse after failure
- test cleanup behaviour when shader creation fails

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684fcf8784dc8328b58bbd68a47f8fec