### PR TITLE
feat: add light rays graphics setting

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -158,7 +158,8 @@ public final class MapWorldBuilder {
 
         ClearScreenSystem clear = new ClearScreenSystem(Color.BLACK);
         LightingSystem lighting = new LightingSystem();
-        DynamicLightSystem dynamicLights = new DynamicLightSystem(lighting);
+        int rays = graphics != null ? graphics.getLightRays() : DynamicLightSystem.DEFAULT_RAYS;
+        DynamicLightSystem dynamicLights = new DynamicLightSystem(lighting, rays);
         WorldConfigurationBuilder builder = new WorldConfigurationBuilder()
                 .with(
                         new EventSystem(),

--- a/client/src/main/java/net/lapidist/colony/client/systems/DynamicLightSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/DynamicLightSystem.java
@@ -21,7 +21,9 @@ public final class DynamicLightSystem extends BaseSystem implements Disposable {
         PointLight create(RayHandler handler, PointLightComponent comp);
     }
 
-    private static final int DEFAULT_RAYS = 16;
+    public static final int DEFAULT_RAYS = 16;
+
+    private final int rays;
 
     private final LightingSystem lightingSystem;
     private final LightFactory factory;
@@ -30,12 +32,26 @@ public final class DynamicLightSystem extends BaseSystem implements Disposable {
     private final IntMap<PointLight> lights = new IntMap<>();
 
     public DynamicLightSystem(final LightingSystem lighting) {
-        this(lighting, (h, c) -> new PointLight(h, DEFAULT_RAYS, c.getColor(), c.getRadius(), 0f, 0f));
+        this(lighting, DEFAULT_RAYS);
+    }
+
+    public DynamicLightSystem(final LightingSystem lighting, final int rayCount) {
+        this(lighting, (h, c) -> new PointLight(h, rayCount, c.getColor(), c.getRadius(), 0f, 0f), rayCount);
     }
 
     public DynamicLightSystem(final LightingSystem lighting, final LightFactory factoryParam) {
+        this(lighting, factoryParam, DEFAULT_RAYS);
+    }
+
+    /** Number of rays used when creating each light. */
+    public int getRayCount() {
+        return rays;
+    }
+
+    private DynamicLightSystem(final LightingSystem lighting, final LightFactory factoryParam, final int rayCount) {
         this.lightingSystem = lighting;
         this.factory = factoryParam;
+        this.rays = rayCount;
     }
 
     /** Number of active lights. */

--- a/core/src/main/java/net/lapidist/colony/settings/GraphicsSettings.java
+++ b/core/src/main/java/net/lapidist/colony/settings/GraphicsSettings.java
@@ -17,6 +17,9 @@ public final class GraphicsSettings {
     private static final String NORMAL_KEY = PREFIX + "normalmaps";
     private static final String SPECULAR_KEY = PREFIX + "specularmaps";
     private static final String DAY_NIGHT_KEY = PREFIX + "dayNightCycle";
+    private static final String RAYS_KEY = PREFIX + "lightRays";
+
+    private static final int DEFAULT_RAYS = 16;
 
     private boolean antialiasingEnabled = true;
     private boolean mipMapsEnabled = true;
@@ -28,6 +31,7 @@ public final class GraphicsSettings {
     private boolean normalMapsEnabled;
     private boolean specularMapsEnabled;
     private boolean dayNightCycleEnabled = true;
+    private int lightRays = DEFAULT_RAYS;
 
     public boolean isAntialiasingEnabled() {
         return antialiasingEnabled;
@@ -109,6 +113,14 @@ public final class GraphicsSettings {
         this.dayNightCycleEnabled = enabled;
     }
 
+    public int getLightRays() {
+        return lightRays;
+    }
+
+    public void setLightRays(final int rays) {
+        this.lightRays = rays;
+    }
+
     /** Load graphics settings from the given properties. */
     public static GraphicsSettings load(final Properties props) {
         GraphicsSettings gs = new GraphicsSettings();
@@ -122,6 +134,7 @@ public final class GraphicsSettings {
         gs.normalMapsEnabled = Boolean.parseBoolean(props.getProperty(NORMAL_KEY, "false"));
         gs.specularMapsEnabled = Boolean.parseBoolean(props.getProperty(SPECULAR_KEY, "false"));
         gs.dayNightCycleEnabled = Boolean.parseBoolean(props.getProperty(DAY_NIGHT_KEY, "true"));
+        gs.lightRays = Integer.parseInt(props.getProperty(RAYS_KEY, Integer.toString(DEFAULT_RAYS)));
         return gs;
     }
 
@@ -137,5 +150,6 @@ public final class GraphicsSettings {
         props.setProperty(NORMAL_KEY, Boolean.toString(normalMapsEnabled));
         props.setProperty(SPECULAR_KEY, Boolean.toString(specularMapsEnabled));
         props.setProperty(DAY_NIGHT_KEY, Boolean.toString(dayNightCycleEnabled));
+        props.setProperty(RAYS_KEY, Integer.toString(lightRays));
     }
 }

--- a/core/src/main/java/net/lapidist/colony/settings/Settings.java
+++ b/core/src/main/java/net/lapidist/colony/settings/Settings.java
@@ -70,6 +70,7 @@ public final class Settings {
             settings.graphicsSettings.setNormalMapsEnabled(gLoaded.isNormalMapsEnabled());
             settings.graphicsSettings.setSpecularMapsEnabled(gLoaded.isSpecularMapsEnabled());
             settings.graphicsSettings.setDayNightCycleEnabled(gLoaded.isDayNightCycleEnabled());
+            settings.graphicsSettings.setLightRays(gLoaded.getLightRays());
         } catch (IOException e) {
             // ignore and use defaults
         }

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -64,6 +64,7 @@ graphics.renderer=Renderer
 graphics.spritecache=Sprite Cache
 graphics.lighting=Lighting
 graphics.dayNightCycle=Day/Night Cycle
+graphics.lightRays=Light Rays
 common.save=Save
 ui.saving=Saving...
 modSelect.title=Mods

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -63,6 +63,7 @@ graphics.renderer=Renderer
 graphics.spritecache=Sprite-Cache
 graphics.lighting=Beleuchtung
 graphics.dayNightCycle=Tag-/Nachtzyklus
+graphics.lightRays=Lichtstrahlen
 common.save=Speichern
 ui.saving=Speichern...
 modSelect.title=Mods

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -63,6 +63,7 @@ graphics.renderer=Renderizador
 graphics.spritecache=Cache de Sprites
 graphics.lighting=Iluminaci\u00f3n
 graphics.dayNightCycle=Ciclo d\u00eda/noche
+graphics.lightRays=Rayos de luz
 common.save=Guardar
 ui.saving=Guardando...
 modSelect.title=Mods

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -63,6 +63,7 @@ graphics.renderer=Moteur de rendu
 graphics.spritecache=Cache de Sprites
 graphics.lighting=\u00c9clairage
 graphics.dayNightCycle=Cycle jour/nuit
+graphics.lightRays=Rayons lumineux
 common.save=Sauvegarder
 ui.saving=Sauvegarde...
 modSelect.title=Mods

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,3 +76,7 @@ graphics.shaderPlugin=lights-normalmap
 Lighting can be disabled independently with `graphics.lighting=false` if the
 additional frame buffer passes are too costly on low end GPUs.
 
+The number of rays per dynamic light can be tuned with `graphics.lightRays`.
+Higher values produce smoother shadows but reduce performance. The default is
+`16`.
+

--- a/tests/src/test/java/net/lapidist/colony/tests/client/systems/DynamicLightSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/systems/DynamicLightSystemTest.java
@@ -54,4 +54,12 @@ public class DynamicLightSystemTest {
         world.dispose();
         handler.dispose();
     }
+
+    @Test
+    public void usesConfiguredRayCount() {
+        LightingSystem lighting = new LightingSystem();
+        final int rays = 24;
+        DynamicLightSystem system = new DynamicLightSystem(lighting, rays);
+        assertEquals(rays, system.getRayCount());
+    }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/core/settings/GraphicsSettingsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/settings/GraphicsSettingsTest.java
@@ -16,6 +16,7 @@ public class GraphicsSettingsTest {
         Properties props = new Properties();
 
         GraphicsSettings gs = new GraphicsSettings();
+        final int rays = 32;
         gs.setAntialiasingEnabled(true);
         gs.setMipMapsEnabled(true);
         gs.setAnisotropicFilteringEnabled(true);
@@ -26,6 +27,7 @@ public class GraphicsSettingsTest {
         gs.setNormalMapsEnabled(true);
         gs.setSpecularMapsEnabled(true);
         gs.setDayNightCycleEnabled(false);
+        gs.setLightRays(rays);
         gs.save(props);
 
         GraphicsSettings loaded = GraphicsSettings.load(props);
@@ -39,6 +41,7 @@ public class GraphicsSettingsTest {
         assertTrue(loaded.isNormalMapsEnabled());
         assertTrue(loaded.isSpecularMapsEnabled());
         assertFalse(loaded.isDayNightCycleEnabled());
+        assertEquals(rays, loaded.getLightRays());
     }
 
     @Test
@@ -56,5 +59,6 @@ public class GraphicsSettingsTest {
         assertFalse(loaded.isNormalMapsEnabled());
         assertFalse(loaded.isSpecularMapsEnabled());
         assertTrue(loaded.isDayNightCycleEnabled());
+        assertEquals(GraphicsSettings.load(new Properties()).getLightRays(), loaded.getLightRays());
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/core/settings/SettingsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/settings/SettingsTest.java
@@ -78,6 +78,8 @@ public class SettingsTest {
         graphics.setNormalMapsEnabled(true);
         graphics.setSpecularMapsEnabled(true);
         graphics.setDayNightCycleEnabled(false);
+        final int rays = 20;
+        graphics.setLightRays(rays);
         settings.save(paths);
 
         Settings loaded = Settings.load(paths);
@@ -91,5 +93,6 @@ public class SettingsTest {
         assertEquals(true, loaded.getGraphicsSettings().isNormalMapsEnabled());
         assertEquals(true, loaded.getGraphicsSettings().isSpecularMapsEnabled());
         assertEquals(false, loaded.getGraphicsSettings().isDayNightCycleEnabled());
+        assertEquals(rays, loaded.getGraphicsSettings().getLightRays());
     }
 }


### PR DESCRIPTION
## Summary
- allow configuring `graphics.lightRays`
- pass the configured ray count to `DynamicLightSystem`
- document the new option in configuration docs
- add missing translations
- test loading and using the new field

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_684fcf8ac51c8328a5f16fd9756da216