### PR TITLE
feat: lazily populate tile resources

### DIFF
--- a/core/src/main/java/net/lapidist/colony/map/ChunkedMapGenerator.java
+++ b/core/src/main/java/net/lapidist/colony/map/ChunkedMapGenerator.java
@@ -3,12 +3,9 @@ package net.lapidist.colony.map;
 import net.lapidist.colony.components.state.BuildingData;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.ResourceData;
-import net.lapidist.colony.components.state.TileData;
-import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.components.state.ChunkPos;
 import net.lapidist.colony.util.I18n;
 
-import java.util.Map;
 import java.util.Random;
 
 /**
@@ -18,9 +15,6 @@ import java.util.Random;
 public final class ChunkedMapGenerator implements MapGenerator {
 
     private static final int NAME_RANGE = 100000;
-    private static final int DEFAULT_WOOD = 10;
-    private static final int DEFAULT_STONE = 5;
-    private static final int DEFAULT_FOOD = 3;
 
     @Override
     public MapState generate(final int width, final int height) {
@@ -45,27 +39,6 @@ public final class ChunkedMapGenerator implements MapGenerator {
         // generate a starting building in the middle
         BuildingData building = new BuildingData(width / 2, height / 2, "house");
         state.buildings().add(building);
-
-        // prepopulate resources when tiles are first accessed
-        for (int x = 0; x < width; x++) {
-            for (int y = 0; y < height; y++) {
-                TileData td = state.getTile(x, y);
-                TileData updated = td.toBuilder()
-                        .resources(new ResourceData(new java.util.HashMap<>(Map.of(
-                                "WOOD", DEFAULT_WOOD,
-                                "STONE", DEFAULT_STONE,
-                                "FOOD", DEFAULT_FOOD
-                        ))))
-                        .build();
-                int chunkX = Math.floorDiv(x, MapChunkData.CHUNK_SIZE);
-                int chunkY = Math.floorDiv(y, MapChunkData.CHUNK_SIZE);
-                int localX = Math.floorMod(x, MapChunkData.CHUNK_SIZE);
-                int localY = Math.floorMod(y, MapChunkData.CHUNK_SIZE);
-                state.getOrCreateChunk(chunkX, chunkY)
-                        .getTiles()
-                        .put(new TilePos(localX, localY), updated);
-            }
-        }
 
         state = state.toBuilder()
                 .playerResources(new ResourceData())

--- a/core/src/main/java/net/lapidist/colony/map/MapChunkData.java
+++ b/core/src/main/java/net/lapidist/colony/map/MapChunkData.java
@@ -16,6 +16,9 @@ import java.util.Random;
 public final class MapChunkData {
     public static final int CHUNK_SIZE = 32;
     private static final double NOISE_SCALE = 0.1;
+    private static final int DEFAULT_WOOD = 10;
+    private static final int DEFAULT_STONE = 5;
+    private static final int DEFAULT_FOOD = 3;
 
     private final Map<TilePos, TileData> tiles = new ConcurrentHashMap<>();
     private final long seed;
@@ -71,6 +74,8 @@ public final class MapChunkData {
                 .y(worldY)
                 .tileType(type)
                 .passable(true)
+                .resources(new net.lapidist.colony.components.state.ResourceData(
+                        DEFAULT_WOOD, DEFAULT_STONE, DEFAULT_FOOD))
                 .build();
     }
 

--- a/tests/src/test/java/net/lapidist/colony/tests/map/ChunkedMapGeneratorTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/map/ChunkedMapGeneratorTest.java
@@ -1,13 +1,17 @@
 package net.lapidist.colony.tests.map;
 
 import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.ChunkPos;
 import net.lapidist.colony.map.ChunkedMapGenerator;
+import net.lapidist.colony.map.MapChunkData;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class ChunkedMapGeneratorTest {
+
+    private static final int DEFAULT_WOOD = 10;
 
     @Test
     public void generatesExpectedTileCount() {
@@ -45,5 +49,16 @@ public class ChunkedMapGeneratorTest {
         }
         assertTrue(grass > 0);
         assertTrue(dirt > 0);
+    }
+
+    @Test
+    public void resourcesGeneratedOnDemand() {
+        ChunkedMapGenerator generator = new ChunkedMapGenerator();
+        MapState state = generator.generate(2, 2);
+        MapChunkData chunk = state.chunks().get(new ChunkPos(0, 0));
+        assertTrue(chunk.getTiles().isEmpty());
+
+        var tile = state.getTile(0, 0);
+        assertEquals(DEFAULT_WOOD, tile.resources().wood());
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/map/MapChunkDataTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/map/MapChunkDataTest.java
@@ -13,6 +13,9 @@ public class MapChunkDataTest {
     private static final long SEED_TWO = 123L;
     private static final int SAMPLE_X = 5;
     private static final int SAMPLE_Y = 5;
+    private static final int DEFAULT_WOOD = 10;
+    private static final int DEFAULT_STONE = 5;
+    private static final int DEFAULT_FOOD = 3;
 
     @Test
     public void generatesTilesLazily() {
@@ -45,5 +48,14 @@ public class MapChunkDataTest {
         assertSame(tile, chunk.getTiles().get(new TilePos(1, 2)));
         assertFalse(chunk.isGenerated());
         assertEquals(1, chunk.getTiles().size());
+    }
+
+    @Test
+    public void tilesHaveDefaultResources() {
+        MapChunkData chunk = new MapChunkData(SEED_ONE);
+        TileData tile = chunk.getTile(0, 0);
+        assertEquals(DEFAULT_WOOD, tile.resources().wood());
+        assertEquals(DEFAULT_STONE, tile.resources().stone());
+        assertEquals(DEFAULT_FOOD, tile.resources().food());
     }
 }


### PR DESCRIPTION
## Summary
- remove resource loops from `ChunkedMapGenerator`
- add default resources in `MapChunkData.createTile`
- test lazy resource generation

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew codeCoverageReport`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_6850237869248328a6712dd8ed9e6024