### PR TITLE
feat: add season cycle system

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
+++ b/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
@@ -148,7 +148,8 @@ public final class GameClient extends AbstractMessageEndpoint implements AutoClo
                             .buildings(new java.util.ArrayList<>(meta.buildings()))
                             .playerResources(meta.playerResources())
                             .playerPos(meta.playerPos())
-                            .cameraPos(meta.cameraPos());
+                            .cameraPos(meta.cameraPos())
+                            .environment(meta.environment());
                     tileBuffer = new java.util.HashMap<>();
                     expectedChunks = meta.chunkCount();
                     mapWidth = meta.width();

--- a/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -34,9 +34,11 @@ import net.lapidist.colony.client.systems.MapInitSystem;
 import net.lapidist.colony.client.systems.MapRenderDataSystem;
 import net.lapidist.colony.client.systems.PlayerInitSystem;
 import net.lapidist.colony.components.entities.CelestialBodyComponent;
+import net.lapidist.colony.components.state.MutableEnvironmentState;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.ResourceData;
 import net.lapidist.colony.components.state.PlayerPosition;
+import net.lapidist.colony.client.systems.SeasonCycleSystem;
 import net.lapidist.colony.map.MapStateProvider;
 import net.lapidist.colony.map.ProvidedMapStateProvider;
 import net.lapidist.colony.events.Events;
@@ -149,6 +151,8 @@ public final class MapWorldBuilder {
         ResourceData playerResources = state.playerResources();
         PlayerPosition playerPos = state.playerPos();
         net.lapidist.colony.components.state.CameraPosition cameraPos = state.cameraPos();
+        net.lapidist.colony.components.state.MutableEnvironmentState environment =
+                new net.lapidist.colony.components.state.MutableEnvironmentState(state.environment());
         CameraInputSystem cameraInputSystem = new CameraInputSystem(client, keyBindings);
         cameraInputSystem.addProcessor(stage);
         SelectionSystem selectionSystem = new SelectionSystem(client, keyBindings);
@@ -174,7 +178,7 @@ public final class MapWorldBuilder {
                         new ResourceUpdateSystem(client),
                         new ChunkLoadSystem(client),
                         new ChunkRequestQueueSystem(client),
-                        new CelestialSystem(client, state.environment()),
+                        new CelestialSystem(client, environment),
                         new MapRenderSystem(),
                         particleSystem,
                         lighting,
@@ -186,7 +190,10 @@ public final class MapWorldBuilder {
         }
 
         if (graphics == null || (graphics.isLightingEnabled() && graphics.isDayNightCycleEnabled())) {
-            builder.with(new DayNightSystem(clear, lighting, state.environment()));
+            builder.with(
+                    new DayNightSystem(clear, lighting, environment),
+                    new SeasonCycleSystem(environment)
+            );
         }
 
         if (provider != null) {

--- a/client/src/main/java/net/lapidist/colony/client/systems/CelestialSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/CelestialSystem.java
@@ -7,13 +7,13 @@ import com.artemis.Entity;
 import com.badlogic.gdx.math.MathUtils;
 import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.components.entities.CelestialBodyComponent;
-import net.lapidist.colony.components.state.EnvironmentState;
+import net.lapidist.colony.components.state.MutableEnvironmentState;
 import net.lapidist.colony.components.state.MapState;
 
 /** Updates celestial body positions based on the current environment. */
 public final class CelestialSystem extends BaseSystem {
     private final net.lapidist.colony.client.network.GameClient client;
-    private final EnvironmentState environment;
+    private final MutableEnvironmentState environment;
     private ComponentMapper<CelestialBodyComponent> bodyMapper;
 
     private static final float HOURS_PER_DAY = 24f;
@@ -21,7 +21,7 @@ public final class CelestialSystem extends BaseSystem {
     private static final float DAWN_OFFSET = 90f;
 
     public CelestialSystem(final net.lapidist.colony.client.network.GameClient clientToUse,
-                           final EnvironmentState env) {
+                           final MutableEnvironmentState env) {
         this.client = clientToUse;
         this.environment = env;
     }
@@ -46,7 +46,7 @@ public final class CelestialSystem extends BaseSystem {
             float radius = body.getOrbitRadius() > 0
                     ? body.getOrbitRadius()
                     : Math.max(width, height) * GameConstants.TILE_SIZE;
-            float angle = (environment.timeOfDay() / HOURS_PER_DAY) * FULL_ROTATION - DAWN_OFFSET
+            float angle = (environment.getTimeOfDay() / HOURS_PER_DAY) * FULL_ROTATION - DAWN_OFFSET
                     + body.getOrbitOffset();
             body.setX(centerX + MathUtils.cosDeg(angle) * radius);
             body.setY(centerY + MathUtils.sinDeg(angle) * radius);

--- a/client/src/main/java/net/lapidist/colony/client/systems/DayNightSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/DayNightSystem.java
@@ -5,7 +5,7 @@ import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Vector3;
 import box2dLight.RayHandler;
-import net.lapidist.colony.components.state.EnvironmentState;
+import net.lapidist.colony.components.state.MutableEnvironmentState;
 
 /**
  * System that updates ambient lighting and clear color based on the time of day.
@@ -14,7 +14,7 @@ public final class DayNightSystem extends BaseSystem {
 
     private final ClearScreenSystem clearScreenSystem;
     private final LightingSystem lightingSystem;
-    private final EnvironmentState environment;
+    private final MutableEnvironmentState environment;
     private float timeOfDay;
 
     private static final float HOURS_PER_DAY = 24f;
@@ -30,7 +30,7 @@ public final class DayNightSystem extends BaseSystem {
 
     public DayNightSystem(final ClearScreenSystem clearSystem,
                           final LightingSystem lighting,
-                          final EnvironmentState env) {
+                          final MutableEnvironmentState env) {
         this.clearScreenSystem = clearSystem;
         this.lightingSystem = lighting;
         this.environment = env;
@@ -61,7 +61,7 @@ public final class DayNightSystem extends BaseSystem {
     protected void processSystem() {
         timeOfDay = wrap(timeOfDay + world.getDelta());
         Color c = clearScreenSystem.getColor();
-        calculateColor(timeOfDay, environment.moonPhase(), c);
+        calculateColor(timeOfDay, environment.getMoonPhase(), c);
         RayHandler handler = lightingSystem.getRayHandler();
         if (handler != null) {
             handler.setAmbientLight(c.r, c.g, c.b, 1f);

--- a/client/src/main/java/net/lapidist/colony/client/systems/SeasonCycleSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/SeasonCycleSystem.java
@@ -1,0 +1,37 @@
+package net.lapidist.colony.client.systems;
+
+import com.artemis.BaseSystem;
+import net.lapidist.colony.components.state.MutableEnvironmentState;
+import net.lapidist.colony.components.state.Season;
+
+/**
+ * Cycles the game season after a fixed interval of real time.
+ */
+public final class SeasonCycleSystem extends BaseSystem {
+    private final MutableEnvironmentState environment;
+    private final float seasonLength;
+    private float elapsed;
+
+    /**
+     * @param env          environment to update
+     * @param lengthInSecs duration of a season in seconds
+     */
+    public SeasonCycleSystem(final MutableEnvironmentState env, final float lengthInSecs) {
+        this.environment = env;
+        this.seasonLength = lengthInSecs;
+    }
+
+    /** Default constructor using 60 seconds per season. */
+    public SeasonCycleSystem(final MutableEnvironmentState env) {
+        this(env, 60f);
+    }
+
+    @Override
+    protected void processSystem() {
+        elapsed += world.getDelta();
+        if (elapsed >= seasonLength) {
+            elapsed -= seasonLength;
+            environment.setSeason(environment.getSeason().next());
+        }
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/components/state/MapMetadata.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/MapMetadata.java
@@ -18,6 +18,7 @@ public record MapMetadata(
         ResourceData playerResources,
         PlayerPosition playerPos,
         CameraPosition cameraPos,
+        EnvironmentState environment,
         int width,
         int height,
         int chunkCount

--- a/core/src/main/java/net/lapidist/colony/components/state/MutableEnvironmentState.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/MutableEnvironmentState.java
@@ -1,0 +1,49 @@
+package net.lapidist.colony.components.state;
+
+/**
+ * Mutable runtime representation of {@link EnvironmentState}.
+ */
+public final class MutableEnvironmentState {
+    private float timeOfDay;
+    private Season season;
+    private float moonPhase;
+
+    public MutableEnvironmentState() {
+        this(new EnvironmentState());
+    }
+
+    public MutableEnvironmentState(final EnvironmentState state) {
+        this.timeOfDay = state.timeOfDay();
+        this.season = state.season();
+        this.moonPhase = state.moonPhase();
+    }
+
+    public float getTimeOfDay() {
+        return timeOfDay;
+    }
+
+    public void setTimeOfDay(final float time) {
+        this.timeOfDay = time;
+    }
+
+    public Season getSeason() {
+        return season;
+    }
+
+    public void setSeason(final Season s) {
+        this.season = s;
+    }
+
+    public float getMoonPhase() {
+        return moonPhase;
+    }
+
+    public void setMoonPhase(final float phase) {
+        this.moonPhase = phase;
+    }
+
+    /** Convert back to the immutable record type. */
+    public EnvironmentState toImmutable() {
+        return new EnvironmentState(timeOfDay, season, moonPhase);
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/components/state/Season.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/Season.java
@@ -8,5 +8,11 @@ public enum Season {
     SPRING,
     SUMMER,
     AUTUMN,
-    WINTER
+    WINTER;
+
+    /** Next season in the cycle. */
+    public Season next() {
+        Season[] values = values();
+        return values[(ordinal() + 1) % values.length];
+    }
 }

--- a/server/src/main/java/net/lapidist/colony/base/BaseSeasonCycleMod.java
+++ b/server/src/main/java/net/lapidist/colony/base/BaseSeasonCycleMod.java
@@ -1,0 +1,20 @@
+package net.lapidist.colony.base;
+
+import net.lapidist.colony.mod.GameMod;
+import net.lapidist.colony.mod.GameServer;
+import net.lapidist.colony.server.services.SeasonCycleService;
+
+/** Built-in mod registering the season cycle service. */
+public final class BaseSeasonCycleMod implements GameMod {
+    @Override
+    public void registerSystems(final GameServer srv) {
+        net.lapidist.colony.server.GameServer s = (net.lapidist.colony.server.GameServer) srv;
+        srv.registerSystem(new SeasonCycleService(
+                1000,
+                60f,
+                s::getMapState,
+                s::setMapState,
+                s.getStateLock()
+        ));
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/server/services/NetworkService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/NetworkService.java
@@ -90,6 +90,7 @@ public final class NetworkService {
                 state.playerResources(),
                 state.playerPos(),
                 state.cameraPos(),
+                state.environment(),
                 state.width(),
                 state.height(),
                 chunkCount

--- a/server/src/main/java/net/lapidist/colony/server/services/SeasonCycleService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/SeasonCycleService.java
@@ -1,0 +1,72 @@
+package net.lapidist.colony.server.services;
+
+import net.lapidist.colony.components.state.EnvironmentState;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.Season;
+import net.lapidist.colony.mod.GameSystem;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/** Service that periodically advances the world season. */
+public final class SeasonCycleService implements GameSystem {
+    private final long period;
+    private final float seasonLength;
+    private final Supplier<MapState> supplier;
+    private final Consumer<MapState> consumer;
+    private final ReentrantLock lock;
+    private ScheduledExecutorService executor;
+    private float elapsed;
+
+    public SeasonCycleService(final long periodMs,
+                              final float lengthInSeconds,
+                              final Supplier<MapState> stateSupplier,
+                              final Consumer<MapState> stateConsumer,
+                              final ReentrantLock stateLock) {
+        this.period = periodMs;
+        this.seasonLength = lengthInSeconds;
+        this.supplier = stateSupplier;
+        this.consumer = stateConsumer;
+        this.lock = stateLock;
+    }
+
+    @Override
+    public void start() {
+        executor = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r);
+            t.setDaemon(true);
+            return t;
+        });
+        executor.scheduleAtFixedRate(this::tick, period, period, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void stop() {
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+    }
+
+    private void tick() {
+        lock.lock();
+        try {
+            elapsed += period / 1000f;
+            if (elapsed < seasonLength) {
+                return;
+            }
+            elapsed -= seasonLength;
+            MapState state = supplier.get();
+            EnvironmentState env = state.environment();
+            Season next = env.season().next();
+            consumer.accept(state.toBuilder()
+                    .environment(new EnvironmentState(env.timeOfDay(), next, env.moonPhase()))
+                    .build());
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/server/src/main/resources/META-INF/services/net.lapidist.colony.mod.GameMod
+++ b/server/src/main/resources/META-INF/services/net.lapidist.colony.mod.GameMod
@@ -11,3 +11,4 @@ net.lapidist.colony.base.BaseResourcesMod
 net.lapidist.colony.base.BaseItemsMod
 
 net.lapidist.colony.base.BaseGameplaySystemsMod
+net.lapidist.colony.base.BaseSeasonCycleMod

--- a/tests/src/test/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPluginTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPluginTest.java
@@ -6,6 +6,7 @@ import net.lapidist.colony.client.systems.ClearScreenSystem;
 import net.lapidist.colony.client.systems.DayNightSystem;
 import net.lapidist.colony.client.systems.LightingSystem;
 import net.lapidist.colony.components.state.EnvironmentState;
+import net.lapidist.colony.components.state.MutableEnvironmentState;
 import net.lapidist.colony.components.state.Season;
 import com.badlogic.gdx.math.Vector3;
 import org.mockito.ArgumentCaptor;
@@ -44,7 +45,7 @@ public class LightsNormalMapShaderPluginTest {
         DayNightSystem system = new DayNightSystem(
                 new ClearScreenSystem(new Color()),
                 new LightingSystem(),
-                new EnvironmentState(0f, Season.SPRING, 0f)
+                new MutableEnvironmentState(new EnvironmentState(0f, Season.SPRING, 0f))
         );
         plugin.setDayNightSystem(system);
         ShaderProgram shader = mock(ShaderProgram.class);

--- a/tests/src/test/java/net/lapidist/colony/tests/client/systems/CelestialSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/systems/CelestialSystemTest.java
@@ -5,6 +5,7 @@ import com.artemis.WorldConfigurationBuilder;
 import net.lapidist.colony.client.systems.CelestialSystem;
 import net.lapidist.colony.components.entities.CelestialBodyComponent;
 import net.lapidist.colony.components.state.EnvironmentState;
+import net.lapidist.colony.components.state.MutableEnvironmentState;
 import net.lapidist.colony.components.state.Season;
 import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.components.state.MapState;
@@ -21,7 +22,7 @@ public class CelestialSystemTest {
     private static final float EPSILON = 0.01f;
     @Test
     public void updatesBodyPosition() {
-        EnvironmentState env = new EnvironmentState(TIME, Season.SPRING, 0f);
+        MutableEnvironmentState env = new MutableEnvironmentState(new EnvironmentState(TIME, Season.SPRING, 0f));
         CelestialSystem system = new CelestialSystem(null, env);
         World world = new World(new WorldConfigurationBuilder().with(system).build());
         var e = world.createEntity();

--- a/tests/src/test/java/net/lapidist/colony/tests/client/systems/DayNightSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/systems/DayNightSystemTest.java
@@ -6,6 +6,7 @@ import com.artemis.WorldConfigurationBuilder;
 import com.badlogic.gdx.graphics.Color;
 import net.lapidist.colony.client.systems.ClearScreenSystem;
 import net.lapidist.colony.client.systems.DayNightSystem;
+import net.lapidist.colony.components.state.MutableEnvironmentState;
 import net.lapidist.colony.components.state.EnvironmentState;
 import net.lapidist.colony.components.state.Season;
 import net.lapidist.colony.client.systems.LightingSystem;
@@ -35,7 +36,7 @@ public class DayNightSystemTest {
         LightingSystem lighting = new LightingSystem();
         RayHandler handler = mock(RayHandler.class);
         lighting.setRayHandler(handler);
-        EnvironmentState env = new EnvironmentState(0f, Season.SPRING, 0f);
+        MutableEnvironmentState env = new MutableEnvironmentState(new EnvironmentState(0f, Season.SPRING, 0f));
         DayNightSystem system = new DayNightSystem(clear, lighting, env);
         final float noon = 12f;
         system.setTimeOfDay(noon);
@@ -59,7 +60,7 @@ public class DayNightSystemTest {
     public void wrapsTimeOfDay() {
         ClearScreenSystem clear = new ClearScreenSystem(new Color());
         LightingSystem lighting = new LightingSystem();
-        EnvironmentState env = new EnvironmentState(0f, Season.SPRING, 0f);
+        MutableEnvironmentState env = new MutableEnvironmentState(new EnvironmentState(0f, Season.SPRING, 0f));
         DayNightSystem system = new DayNightSystem(clear, lighting, env);
         final float wrapValue = 25f;
         system.setTimeOfDay(wrapValue);
@@ -79,7 +80,7 @@ public class DayNightSystemTest {
         LightingSystem lighting = new LightingSystem();
         RayHandler handler = mock(RayHandler.class);
         lighting.setRayHandler(handler);
-        EnvironmentState env = new EnvironmentState(0f, Season.SPRING, 1f);
+        MutableEnvironmentState env = new MutableEnvironmentState(new EnvironmentState(0f, Season.SPRING, 1f));
         DayNightSystem system = new DayNightSystem(clear, lighting, env);
         World world = new World(new WorldConfigurationBuilder()
                 .with(clear, lighting, system)

--- a/tests/src/test/java/net/lapidist/colony/tests/client/systems/SeasonCycleSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/systems/SeasonCycleSystemTest.java
@@ -1,0 +1,28 @@
+package net.lapidist.colony.tests.client.systems;
+
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import net.lapidist.colony.client.systems.SeasonCycleSystem;
+import net.lapidist.colony.components.state.MutableEnvironmentState;
+import net.lapidist.colony.components.state.EnvironmentState;
+import net.lapidist.colony.components.state.Season;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/** Tests for {@link SeasonCycleSystem}. */
+@RunWith(GdxTestRunner.class)
+public class SeasonCycleSystemTest {
+    @Test
+    public void advancesSeasonAfterInterval() {
+        MutableEnvironmentState env = new MutableEnvironmentState(new EnvironmentState());
+        SeasonCycleSystem system = new SeasonCycleSystem(env, 1f);
+        World world = new World(new WorldConfigurationBuilder().with(system).build());
+        world.setDelta(1f);
+        world.process();
+        assertEquals(Season.SUMMER, env.getSeason());
+        world.dispose();
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MapWorldBuilderConfigurationTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MapWorldBuilderConfigurationTest.java
@@ -18,6 +18,7 @@ import net.lapidist.colony.client.systems.PlayerInitSystem;
 import net.lapidist.colony.client.systems.MapRenderSystem;
 import net.lapidist.colony.client.systems.MapRenderDataSystem;
 import net.lapidist.colony.client.systems.DayNightSystem;
+import net.lapidist.colony.client.systems.SeasonCycleSystem;
 import net.lapidist.colony.components.resources.PlayerResourceComponent;
 import net.lapidist.colony.components.entities.PlayerComponent;
 import net.lapidist.colony.components.state.MapState;
@@ -70,6 +71,7 @@ public class MapWorldBuilderConfigurationTest {
             assertNull(world.getSystem(MapRenderDataSystem.class));
             assertNotNull(world.getSystem(DayNightSystem.class));
             assertNotNull(world.getSystem(net.lapidist.colony.client.systems.CelestialSystem.class));
+            assertNotNull(world.getSystem(SeasonCycleSystem.class));
 
             world.dispose();
         }
@@ -108,6 +110,7 @@ public class MapWorldBuilderConfigurationTest {
             assertNotNull(world.getSystem(PlayerMovementSystem.class));
             assertNotNull(world.getSystem(MapRenderDataSystem.class));
             assertNotNull(world.getSystem(net.lapidist.colony.client.systems.CelestialSystem.class));
+            assertNotNull(world.getSystem(SeasonCycleSystem.class));
             assertEquals(1, world.getAspectSubscriptionManager()
                     .get(Aspect.all(PlayerResourceComponent.class))
                     .getEntities().size());

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerBaseSystemsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerBaseSystemsTest.java
@@ -3,6 +3,7 @@ package net.lapidist.colony.tests.server;
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.server.GameServerConfig;
 import net.lapidist.colony.server.services.ResourceProductionService;
+import net.lapidist.colony.server.services.SeasonCycleService;
 import net.lapidist.colony.io.Paths;
 import org.junit.Test;
 
@@ -29,6 +30,17 @@ public class GameServerBaseSystemsTest {
         server.start();
 
         assertTrue(systems(server).stream().anyMatch(s -> s instanceof ResourceProductionService));
+        server.stop();
+    }
+
+    @Test
+    public void seasonCycleSystemRegistered() throws Exception {
+        String name = "season-systems";
+        Paths.get().deleteAutosave(name);
+        GameServer server = new GameServer(GameServerConfig.builder().saveName(name).build());
+        server.start();
+
+        assertTrue(systems(server).stream().anyMatch(s -> s instanceof SeasonCycleService));
         server.stop();
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/server/NetworkServiceTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/NetworkServiceTest.java
@@ -41,6 +41,7 @@ public class NetworkServiceTest {
         MapMetadata meta = metaCaptor.getValue();
         assertEquals(MapState.DEFAULT_WIDTH, meta.width());
         assertEquals(MapState.DEFAULT_HEIGHT, meta.height());
+        assertEquals(MapState.builder().build().environment().season(), meta.environment().season());
         assertEquals(1, meta.chunkCount());
         verify(connection, atLeastOnce()).sendTCP(isA(MapChunkBytes.class));
     }

--- a/tests/src/test/java/net/lapidist/colony/tests/server/SeasonCycleServiceTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/SeasonCycleServiceTest.java
@@ -1,0 +1,36 @@
+package net.lapidist.colony.tests.server;
+
+import net.lapidist.colony.components.state.EnvironmentState;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.Season;
+import net.lapidist.colony.server.services.SeasonCycleService;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.junit.Assert.*;
+
+public class SeasonCycleServiceTest {
+    private static final int INTERVAL = 10;
+    private static final int WAIT_MS = 30;
+
+    @Test
+    public void advancesSeason() throws Exception {
+        MapState state = new MapState();
+        AtomicReference<MapState> ref = new AtomicReference<>(state);
+        SeasonCycleService service = new SeasonCycleService(
+                INTERVAL,
+                0.02f,
+                ref::get,
+                ref::set,
+                new ReentrantLock()
+        );
+
+        service.start();
+        Thread.sleep(WAIT_MS);
+        service.stop();
+
+        assertEquals(Season.SUMMER, ref.get().environment().season());
+    }
+}


### PR DESCRIPTION
## Summary
- add mutable environment representation and season progression
- implement SeasonCycleSystem and integrate in MapWorldBuilder
- send environment state via MapMetadata
- add SeasonCycleService on the server and register through BaseSeasonCycleMod
- update client/server logic and tests for the new season cycle

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`

------
https://chatgpt.com/codex/tasks/task_e_68502381bca883289964410ba7cd281a