### PR TITLE
feat: choose resource to gather

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/systems/SelectionSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/SelectionSystem.java
@@ -36,6 +36,8 @@ public final class SelectionSystem extends BaseSystem {
 
     private TileSelectionHandler tileSelectionHandler;
 
+    private String resourceId = "WOOD";
+
     public SelectionSystem(final GameClient clientToUse, final KeyBindings bindings) {
         this.client = clientToUse;
         this.keyBindings = bindings;
@@ -74,13 +76,25 @@ public final class SelectionSystem extends BaseSystem {
                 }
             }
         }
+        if (Gdx.input.isKeyJustPressed(keyBindings.getKey(KeyAction.SELECT_WOOD))) {
+            resourceId = "WOOD";
+        }
+        if (Gdx.input.isKeyJustPressed(keyBindings.getKey(KeyAction.SELECT_STONE))) {
+            resourceId = "STONE";
+        }
+        if (Gdx.input.isKeyJustPressed(keyBindings.getKey(KeyAction.SELECT_FOOD))) {
+            resourceId = "FOOD";
+        }
         if (map != null && Gdx.input.isKeyJustPressed(keyBindings.getKey(KeyAction.GATHER))) {
             for (int i = 0; i < selectedTiles.size; i++) {
                 var tile = selectedTiles.get(i);
                 TileComponent tc = tileMapper.get(tile);
-                ResourceGatherRequestData msg = new ResourceGatherRequestData(
-                        tc.getX(), tc.getY(), "WOOD");
-                client.sendGatherRequest(msg);
+                ResourceComponent rc = resourceMapper.get(tile);
+                if (rc.getAmount(resourceId) > 0) {
+                    ResourceGatherRequestData msg = new ResourceGatherRequestData(
+                            tc.getX(), tc.getY(), resourceId);
+                    client.sendGatherRequest(msg);
+                }
             }
         }
     }
@@ -101,9 +115,9 @@ public final class SelectionSystem extends BaseSystem {
                 .ifPresent(tile -> {
                     TileComponent tc = tileMapper.get(tile);
                     ResourceComponent rc = resourceMapper.get(tile);
-                    if (rc.getWood() > 0) {
+                    if (rc.getAmount(resourceId) > 0) {
                         ResourceGatherRequestData msg = new ResourceGatherRequestData(
-                                tc.getX(), tc.getY(), "WOOD");
+                                tc.getX(), tc.getY(), resourceId);
                         client.sendGatherRequest(msg);
                     }
                 });

--- a/core/src/main/java/net/lapidist/colony/settings/KeyAction.java
+++ b/core/src/main/java/net/lapidist/colony/settings/KeyAction.java
@@ -13,7 +13,10 @@ public enum KeyAction {
     REMOVE("remove"),
     CHAT("chat"),
     MINIMAP("minimap"),
-    TOGGLE_CAMERA("toggleCamera");
+    TOGGLE_CAMERA("toggleCamera"),
+    SELECT_WOOD("selectWood"),
+    SELECT_STONE("selectStone"),
+    SELECT_FOOD("selectFood");
 
     private final String i18nKey;
 

--- a/core/src/main/java/net/lapidist/colony/settings/KeyBindings.java
+++ b/core/src/main/java/net/lapidist/colony/settings/KeyBindings.java
@@ -11,17 +11,20 @@ import java.util.Map;
 public final class KeyBindings {
     private static final String PREFIX = "key.";
 
-    private static final Map<KeyAction, Integer> DEFAULTS = Map.of(
-            KeyAction.MOVE_UP, Input.Keys.W,
-            KeyAction.MOVE_DOWN, Input.Keys.S,
-            KeyAction.MOVE_LEFT, Input.Keys.A,
-            KeyAction.MOVE_RIGHT, Input.Keys.D,
-            KeyAction.GATHER, Input.Keys.H,
-            KeyAction.BUILD, Input.Keys.B,
-            KeyAction.REMOVE, Input.Keys.R,
-            KeyAction.CHAT, Input.Keys.T,
-            KeyAction.MINIMAP, Input.Keys.M,
-            KeyAction.TOGGLE_CAMERA, Input.Keys.F
+    private static final Map<KeyAction, Integer> DEFAULTS = Map.ofEntries(
+            Map.entry(KeyAction.MOVE_UP, Input.Keys.W),
+            Map.entry(KeyAction.MOVE_DOWN, Input.Keys.S),
+            Map.entry(KeyAction.MOVE_LEFT, Input.Keys.A),
+            Map.entry(KeyAction.MOVE_RIGHT, Input.Keys.D),
+            Map.entry(KeyAction.GATHER, Input.Keys.H),
+            Map.entry(KeyAction.BUILD, Input.Keys.B),
+            Map.entry(KeyAction.REMOVE, Input.Keys.R),
+            Map.entry(KeyAction.CHAT, Input.Keys.T),
+            Map.entry(KeyAction.MINIMAP, Input.Keys.M),
+            Map.entry(KeyAction.TOGGLE_CAMERA, Input.Keys.F),
+            Map.entry(KeyAction.SELECT_WOOD, Input.Keys.NUM_1),
+            Map.entry(KeyAction.SELECT_STONE, Input.Keys.NUM_2),
+            Map.entry(KeyAction.SELECT_FOOD, Input.Keys.NUM_3)
     );
 
     private final EnumMap<KeyAction, Integer> bindings = new EnumMap<>(KeyAction.class);

--- a/tests/src/test/java/net/lapidist/colony/tests/client/systems/SelectionSystemResourceTypeTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/systems/SelectionSystemResourceTypeTest.java
@@ -1,0 +1,110 @@
+package net.lapidist.colony.tests.client.systems;
+
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.client.systems.CameraInputSystem;
+import net.lapidist.colony.client.systems.PlayerCameraSystem;
+import net.lapidist.colony.client.systems.SelectionSystem;
+import net.lapidist.colony.client.systems.network.MapLoadSystem;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.ResourceData;
+import net.lapidist.colony.components.state.ResourceGatherRequestData;
+import net.lapidist.colony.components.state.TileData;
+import net.lapidist.colony.registry.Registries;
+import net.lapidist.colony.settings.KeyAction;
+import net.lapidist.colony.settings.KeyBindings;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+/** Tests resource gathering with {@link SelectionSystem}. */
+@RunWith(GdxTestRunner.class)
+public class SelectionSystemResourceTypeTest {
+
+    @Test
+    public void gatherKeyUsesSelectedStone() {
+        MapState state = new MapState();
+        ResourceData res = new ResourceData(1, 1, 0);
+        state.putTile(TileData.builder()
+                .x(0).y(0).tileType("GRASS").passable(true)
+                .selected(true)
+                .resources(res)
+                .build());
+
+        GameClient client = mock(GameClient.class);
+        KeyBindings keys = new KeyBindings();
+        SelectionSystem system = new SelectionSystem(client, keys);
+        World world = new World(new WorldConfigurationBuilder()
+                .with(new MapLoadSystem(state), new PlayerCameraSystem(),
+                        new CameraInputSystem(keys), system)
+                .build());
+
+        Input input = mock(Input.class);
+        Gdx.input = input;
+        when(input.isKeyJustPressed(keys.getKey(KeyAction.SELECT_WOOD))).thenReturn(false, false);
+        when(input.isKeyJustPressed(keys.getKey(KeyAction.SELECT_STONE))).thenReturn(true, false);
+        when(input.isKeyJustPressed(keys.getKey(KeyAction.SELECT_FOOD))).thenReturn(false, false);
+        when(input.isKeyJustPressed(keys.getKey(KeyAction.GATHER))).thenReturn(false, true);
+
+        world.process();
+        world.process();
+
+        ArgumentCaptor<ResourceGatherRequestData> captor =
+                ArgumentCaptor.forClass(ResourceGatherRequestData.class);
+        verify(client).sendGatherRequest(captor.capture());
+        assertEquals(Registries.resources().get("STONE").id(), captor.getValue().resourceId());
+    }
+
+    @Test
+    public void tapUsesSelectedFood() {
+        MapState state = new MapState();
+        ResourceData res = new ResourceData(0, 0, 2);
+        TileData tile = TileData.builder()
+                .x(0).y(0).tileType("GRASS").passable(true)
+                .resources(res)
+                .build();
+        state.putTile(tile);
+
+        GameClient client = mock(GameClient.class);
+        KeyBindings keys = new KeyBindings();
+        SelectionSystem system = new SelectionSystem(client, keys);
+        World world = new World(new WorldConfigurationBuilder()
+                .with(new MapLoadSystem(state), new PlayerCameraSystem(),
+                        new CameraInputSystem(keys), system)
+                .build());
+        world.process();
+
+        Input input = mock(Input.class);
+        Gdx.input = input;
+        when(input.isKeyJustPressed(keys.getKey(KeyAction.SELECT_WOOD))).thenReturn(false);
+        when(input.isKeyJustPressed(keys.getKey(KeyAction.SELECT_STONE))).thenReturn(false);
+        when(input.isKeyJustPressed(keys.getKey(KeyAction.SELECT_FOOD))).thenReturn(true);
+
+        system.process();
+        when(input.isKeyJustPressed(anyInt())).thenReturn(false);
+
+        PlayerCameraSystem camera = world.getSystem(PlayerCameraSystem.class);
+        ((com.badlogic.gdx.graphics.OrthographicCamera) camera.getCamera()).position.set(
+                net.lapidist.colony.components.GameConstants.TILE_SIZE / 2f,
+                net.lapidist.colony.components.GameConstants.TILE_SIZE / 2f,
+                0
+        );
+        camera.getCamera().update();
+
+        com.badlogic.gdx.math.Vector2 screenCoords = net.lapidist.colony.client.graphics.CameraUtils.worldToScreenCoords(
+                camera.getViewport(), 0, 0);
+        system.tap(screenCoords.x, screenCoords.y);
+
+        ArgumentCaptor<ResourceGatherRequestData> captor =
+                ArgumentCaptor.forClass(ResourceGatherRequestData.class);
+        verify(client).sendGatherRequest(captor.capture());
+        assertEquals(Registries.resources().get("FOOD").id(), captor.getValue().resourceId());
+    }
+}


### PR DESCRIPTION
## Summary
- allow selecting gather resource via new keybinds
- send chosen resource id when gathering
- test selected resource logic for stone and food

## Testing
- `./gradlew spotlessApply`
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_6850284ffcc08328859c128dbe10ed09