### PR TITLE
fix: adjust day-night lighting levels

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/systems/DayNightSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/DayNightSystem.java
@@ -23,9 +23,9 @@ public final class DayNightSystem extends BaseSystem {
     private static final float SUNRISE_TIME = 6f;
     private static final float NOON_TIME = 12f;
     private static final float SUNSET_TIME = 18f;
-    private static final Color NIGHT_COLOR = new Color(0.01f, 0.01f, 0.025f, 1f);
+    private static final Color NIGHT_COLOR = new Color(0f, 0f, 0f, 1f);
     private static final Color SUNRISE_COLOR = new Color(0.6f, 0.5f, 0.4f, 1f);
-    private static final Color DAY_COLOR = new Color(0.8f, 0.85f, 0.9f, 1f);
+    private static final Color DAY_COLOR = new Color(1f, 1f, 1f, 1f);
     private static final Color MOON_COLOR = new Color(0.2f, 0.2f, 0.25f, 1f);
 
     public DayNightSystem(final ClearScreenSystem clearSystem,
@@ -77,8 +77,9 @@ public final class DayNightSystem extends BaseSystem {
     }
 
     private static float calculateBrightness(final float time) {
-        float angle = (time / HOURS_PER_DAY) * FULL_ROTATION - DAWN_OFFSET;
-        return (MathUtils.sinDeg(angle) + 1f) / 2f;
+        float t = wrap(time);
+        float dayProgress = MathUtils.clamp((t - SUNRISE_TIME) / (SUNSET_TIME - SUNRISE_TIME), 0f, 1f);
+        return MathUtils.sin(dayProgress * MathUtils.PI);
     }
 
     private static void calculateColor(final float time, final float moonPhase, final Color out) {

--- a/tests/src/test/java/net/lapidist/colony/tests/client/systems/DayNightSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/systems/DayNightSystemTest.java
@@ -22,9 +22,9 @@ import static org.mockito.Mockito.*;
 @SuppressWarnings("checkstyle:magicnumber")
 public class DayNightSystemTest {
 
-    private static final float DAY_RED = 0.8f;
-    private static final float DAY_GREEN = 0.85f;
-    private static final float DAY_BLUE = 0.9f;
+    private static final float DAY_RED = 1f;
+    private static final float DAY_GREEN = 1f;
+    private static final float DAY_BLUE = 1f;
     private static final float NIGHT_RED = 0f;
     private static final float NIGHT_BLUE = 0f;
     private static final float MOON_RED = 0.2f;


### PR DESCRIPTION
## Summary
- tune ambient lighting values so night is darker and daytime isn't tinted
- update DayNightSystem tests for new values

## Testing
- `./gradlew clean test --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_685068d4d8dc83288da3ea179398425c