### PR TITLE
fix: remove unused disposal

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/renderers/CelestialRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/CelestialRenderer.java
@@ -6,13 +6,12 @@ import com.artemis.Entity;
 import com.artemis.World;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
-import com.badlogic.gdx.utils.Disposable;
 import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.client.render.MapRenderData;
 import net.lapidist.colony.components.entities.CelestialBodyComponent;
 
 /** Draws celestial bodies like the sun and moon. */
-public final class CelestialRenderer implements EntityRenderer<Void>, Disposable {
+public final class CelestialRenderer implements EntityRenderer<Void> {
     private final SpriteBatch spriteBatch;
     private final ResourceLoader resourceLoader;
     private final World world;
@@ -42,8 +41,5 @@ public final class CelestialRenderer implements EntityRenderer<Void>, Disposable
         }
     }
 
-    @Override
-    public void dispose() {
-        // no-op
-    }
+    // CelestialRenderer does not own disposable resources
 }

--- a/client/src/main/java/net/lapidist/colony/client/renderers/PlayerRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/PlayerRenderer.java
@@ -6,12 +6,11 @@ import com.artemis.Entity;
 import com.artemis.World;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
-import com.badlogic.gdx.utils.Disposable;
 import net.lapidist.colony.client.core.io.ResourceLoader;
 import net.lapidist.colony.components.entities.PlayerComponent;
 
 /** Draws the player sprite at the player component position. */
-public final class PlayerRenderer implements EntityRenderer<Void>, Disposable {
+public final class PlayerRenderer implements EntityRenderer<Void> {
     private final SpriteBatch spriteBatch;
     private final ComponentMapper<PlayerComponent> playerMapper;
     private final World world;
@@ -47,8 +46,5 @@ public final class PlayerRenderer implements EntityRenderer<Void>, Disposable {
         spriteBatch.draw(region, pc.getX(), pc.getY());
     }
 
-    @Override
-    public void dispose() {
-        // no-op
-    }
+    // PlayerRenderer does not own disposable resources
 }

--- a/client/src/main/java/net/lapidist/colony/client/renderers/SpriteBatchMapRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/SpriteBatchMapRenderer.java
@@ -101,8 +101,6 @@ public final class SpriteBatchMapRenderer implements MapRenderer, Disposable {
     public void dispose() {
         resourceLoader.dispose();
         entityRenderers.resourceRenderer().dispose();
-        entityRenderers.playerRenderer().dispose();
-        entityRenderers.celestialRenderer().dispose();
         spriteBatch.dispose();
         if (shader != null) {
             shader.dispose();


### PR DESCRIPTION
## Summary
- drop Disposable from `PlayerRenderer` and `CelestialRenderer`
- stop disposing non-owned renderers in `SpriteBatchMapRenderer`

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew clean test`

------
https://chatgpt.com/codex/tasks/task_e_6851ce8cc03483288bfd98720d444d1a