### PR TITLE
feat(server): expose lifecycle methods in mod API

### DIFF
--- a/core/src/main/java/net/lapidist/colony/mod/GameServer.java
+++ b/core/src/main/java/net/lapidist/colony/mod/GameServer.java
@@ -16,4 +16,48 @@ public interface GameServer {
     default void registerSystem(GameSystem system) {
         // no-op for non-server implementations
     }
+
+    /**
+     * Start the server and all registered services.
+     *
+     * <p>Client implementations may ignore this call.</p>
+     */
+    default void start() throws java.io.IOException, InterruptedException {
+        // no-op for non-server implementations
+    }
+
+    /** Stop the server and release resources. */
+    default void stop() {
+        // no-op for non-server implementations
+    }
+
+    /** Send a message to all connected clients. */
+    default void broadcast(Object message) {
+        // no-op for non-server implementations
+    }
+
+    /** Override the factory for creating the map service. */
+    default void setMapServiceFactory(java.util.function.Supplier<?> factory) {
+        // no-op for non-server implementations
+    }
+
+    /** Override the factory for creating the network service. */
+    default void setNetworkServiceFactory(java.util.function.Supplier<?> factory) {
+        // no-op for non-server implementations
+    }
+
+    /** Override the factory for creating the autosave service. */
+    default void setAutosaveServiceFactory(java.util.function.Supplier<?> factory) {
+        // no-op for non-server implementations
+    }
+
+    /** Override the factory for creating the resource production service. */
+    default void setResourceProductionServiceFactory(java.util.function.Supplier<?> factory) {
+        // no-op for non-server implementations
+    }
+
+    /** Override the factory for creating the command bus. */
+    default void setCommandBusFactory(java.util.function.Supplier<?> factory) {
+        // no-op for non-server implementations
+    }
 }

--- a/docs/mods.md
+++ b/docs/mods.md
@@ -96,6 +96,13 @@ public final class ExtraMod implements GameMod {
 }
 ```
 
+`GameServer` also exposes convenience methods for lifecycle management and
+service customization. Mods may call `start`, `stop` or `broadcast` on the
+provided instance. Core services can be replaced via the corresponding factory
+setters: `setMapServiceFactory`, `setNetworkServiceFactory`,
+`setAutosaveServiceFactory`, `setResourceProductionServiceFactory` and
+`setCommandBusFactory`.
+
 ## Registries
 
 Core game data is looked up from string keyed registries. Four registries are

--- a/server/src/main/java/net/lapidist/colony/base/BaseAutosaveMod.java
+++ b/server/src/main/java/net/lapidist/colony/base/BaseAutosaveMod.java
@@ -9,7 +9,7 @@ public final class BaseAutosaveMod implements GameMod {
     @Override
     public void registerServices(final GameServer srv) {
         net.lapidist.colony.server.GameServer s = (net.lapidist.colony.server.GameServer) srv;
-        s.setAutosaveServiceFactory(() -> new AutosaveService(
+        srv.setAutosaveServiceFactory(() -> new AutosaveService(
                 s.getAutosaveInterval(),
                 s.getSaveName(),
                 s::getMapState,

--- a/server/src/main/java/net/lapidist/colony/base/BaseCommandBusMod.java
+++ b/server/src/main/java/net/lapidist/colony/base/BaseCommandBusMod.java
@@ -9,6 +9,6 @@ public final class BaseCommandBusMod implements GameMod {
     @Override
     public void registerServices(final GameServer srv) {
         net.lapidist.colony.server.GameServer s = (net.lapidist.colony.server.GameServer) srv;
-        s.setCommandBusFactory(CommandBus::new);
+        srv.setCommandBusFactory(CommandBus::new);
     }
 }

--- a/server/src/main/java/net/lapidist/colony/base/BaseMapServiceMod.java
+++ b/server/src/main/java/net/lapidist/colony/base/BaseMapServiceMod.java
@@ -9,7 +9,7 @@ public final class BaseMapServiceMod implements GameMod {
     @Override
     public void registerServices(final GameServer srv) {
         net.lapidist.colony.server.GameServer s = (net.lapidist.colony.server.GameServer) srv;
-        s.setMapServiceFactory(() -> new MapService(
+        srv.setMapServiceFactory(() -> new MapService(
                 s.getMapGenerator(),
                 s.getSaveName(),
                 s.getMapWidth(),

--- a/server/src/main/java/net/lapidist/colony/base/BaseNetworkMod.java
+++ b/server/src/main/java/net/lapidist/colony/base/BaseNetworkMod.java
@@ -10,7 +10,7 @@ public final class BaseNetworkMod implements GameMod {
     @Override
     public void registerServices(final GameServer srv) {
         net.lapidist.colony.server.GameServer s = (net.lapidist.colony.server.GameServer) srv;
-        s.setNetworkServiceFactory(() -> new NetworkService(
+        srv.setNetworkServiceFactory(() -> new NetworkService(
                 s.getServer(),
                 NetworkConfig.getTcpPort(),
                 NetworkConfig.getUdpPort()

--- a/server/src/main/java/net/lapidist/colony/base/BaseResourceProductionMod.java
+++ b/server/src/main/java/net/lapidist/colony/base/BaseResourceProductionMod.java
@@ -9,7 +9,7 @@ public final class BaseResourceProductionMod implements GameMod {
     @Override
     public void registerServices(final GameServer srv) {
         net.lapidist.colony.server.GameServer s = (net.lapidist.colony.server.GameServer) srv;
-        s.setResourceProductionServiceFactory(() -> new ResourceProductionService(
+        srv.setResourceProductionServiceFactory(() -> new ResourceProductionService(
                 s.getAutosaveInterval(),
                 s::getMapState,
                 s::setMapState,

--- a/server/src/main/java/net/lapidist/colony/server/GameServer.java
+++ b/server/src/main/java/net/lapidist/colony/server/GameServer.java
@@ -338,8 +338,10 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
      * Override the factory for creating {@link MapService} instances.
      * Modifications must occur before calling {@link #start()}.
      */
-    public void setMapServiceFactory(final java.util.function.Supplier<MapService> factory) {
-        this.mapServiceFactory = factory;
+    @Override
+    public void setMapServiceFactory(final java.util.function.Supplier<?> factory) {
+        //noinspection unchecked
+        this.mapServiceFactory = (java.util.function.Supplier<MapService>) factory;
     }
 
     /**
@@ -353,9 +355,11 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
      * Override the factory for creating {@link NetworkService} instances.
      * Modifications must occur before calling {@link #start()}.
      */
+    @Override
     public void setNetworkServiceFactory(
-            final java.util.function.Supplier<NetworkService> factory) {
-        this.networkServiceFactory = factory;
+            final java.util.function.Supplier<?> factory) {
+        //noinspection unchecked
+        this.networkServiceFactory = (java.util.function.Supplier<NetworkService>) factory;
     }
 
     /**
@@ -369,9 +373,11 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
      * Override the factory for creating {@link AutosaveService} instances.
      * Modifications must occur before calling {@link #start()}.
      */
+    @Override
     public void setAutosaveServiceFactory(
-            final java.util.function.Supplier<AutosaveService> factory) {
-        this.autosaveServiceFactory = factory;
+            final java.util.function.Supplier<?> factory) {
+        //noinspection unchecked
+        this.autosaveServiceFactory = (java.util.function.Supplier<AutosaveService>) factory;
     }
 
     /**
@@ -385,9 +391,11 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
      * Override the factory for creating {@link ResourceProductionService} instances.
      * Modifications must occur before calling {@link #start()}.
      */
+    @Override
     public void setResourceProductionServiceFactory(
-            final java.util.function.Supplier<ResourceProductionService> factory) {
-        this.resourceProductionServiceFactory = factory;
+            final java.util.function.Supplier<?> factory) {
+        //noinspection unchecked
+        this.resourceProductionServiceFactory = (java.util.function.Supplier<ResourceProductionService>) factory;
     }
 
     /**
@@ -401,9 +409,11 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
      * Override the factory for creating {@link CommandBus} instances.
      * Modifications must occur before calling {@link #start()}.
      */
+    @Override
     public void setCommandBusFactory(
-            final java.util.function.Supplier<CommandBus> factory) {
-        this.commandBusFactory = factory;
+            final java.util.function.Supplier<?> factory) {
+        //noinspection unchecked
+        this.commandBusFactory = (java.util.function.Supplier<CommandBus>) factory;
     }
 
     /**
@@ -435,6 +445,7 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
      *
      * @param message message to send
      */
+    @Override
     public void broadcast(final Object message) {
         networkService.broadcast(message);
     }

--- a/tests/src/test/java/net/lapidist/colony/mod/test/ResourceStubMod.java
+++ b/tests/src/test/java/net/lapidist/colony/mod/test/ResourceStubMod.java
@@ -24,8 +24,7 @@ public final class ResourceStubMod implements GameMod {
             START_CALLS.incrementAndGet();
             return null;
         }).when(service).start();
-        ((net.lapidist.colony.server.GameServer) server)
-                .setResourceProductionServiceFactory(() -> service);
+        server.setResourceProductionServiceFactory(() -> service);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- expand `GameServer` interface with start/stop/broadcast and service factory setters
- implement the new API in `GameServer`
- call these methods directly in built-in mods and tests
- document the available server APIs for mods

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851ce8997bc83289ac5cbee164b4632