### PR TITLE
fix: player movement initializes correctly

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/systems/PlayerMovementSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/PlayerMovementSystem.java
@@ -52,8 +52,21 @@ public final class PlayerMovementSystem extends BaseSystem {
 
     @Override
     protected void processSystem() {
-        if (!cameraSystem.isPlayerMode() || player == null) {
+        if (!cameraSystem.isPlayerMode()) {
             return;
+        }
+        if (player == null) {
+            var players = world.getAspectSubscriptionManager()
+                    .get(com.artemis.Aspect.all(PlayerComponent.class))
+                    .getEntities();
+            if (players.size() > 0) {
+                player = world.getEntity(players.get(0));
+                PlayerComponent pc = playerMapper.get(player);
+                lastTileX = Math.floorDiv((int) pc.getX(), GameConstants.TILE_SIZE);
+                lastTileY = Math.floorDiv((int) pc.getY(), GameConstants.TILE_SIZE);
+            } else {
+                return;
+            }
         }
         PlayerComponent pc = playerMapper.get(player);
         float move = SPEED * world.getDelta();


### PR DESCRIPTION
## Summary
- ensure PlayerMovementSystem detects the player entity if created after world init

## Testing
- `./gradlew spotlessApply`
- `./gradlew tests:copyAssets`
- `./gradlew test` *(fails: 38 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6851d6e9f4008328b2eabfe05d88df44