### PR TITLE
feat: persist server inventory

### DIFF
--- a/core/src/main/java/net/lapidist/colony/components/state/MapState.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/MapState.java
@@ -21,6 +21,7 @@ public record MapState(
         Map<ChunkPos, MapChunkData> chunks,
         List<BuildingData> buildings,
         ResourceData playerResources,
+        Map<String, Integer> inventory,
         PlayerPosition playerPos,
         CameraPosition cameraPos,
         EnvironmentState environment,
@@ -41,6 +42,7 @@ public record MapState(
                 new ConcurrentHashMap<>(),
                 new ArrayList<>(),
                 new ResourceData(),
+                new java.util.HashMap<>(),
                 new PlayerPosition(DEFAULT_WIDTH / 2, DEFAULT_HEIGHT / 2),
                 new CameraPosition(DEFAULT_WIDTH / 2f, DEFAULT_HEIGHT / 2f),
                 new EnvironmentState(),
@@ -129,6 +131,7 @@ public record MapState(
         private Map<ChunkPos, MapChunkData> chunks;
         private List<BuildingData> buildings;
         private ResourceData playerResources;
+        private Map<String, Integer> inventory;
         private PlayerPosition playerPos;
         private CameraPosition cameraPos;
         private EnvironmentState environment;
@@ -148,6 +151,7 @@ public record MapState(
             this.chunks = state.chunks;
             this.buildings = state.buildings;
             this.playerResources = state.playerResources;
+            this.inventory = state.inventory;
             this.playerPos = state.playerPos;
             this.cameraPos = state.cameraPos;
             this.environment = state.environment;
@@ -195,6 +199,11 @@ public record MapState(
             return this;
         }
 
+        public Builder inventory(final Map<String, Integer> newInventory) {
+            this.inventory = newInventory;
+            return this;
+        }
+
         public Builder playerPos(final PlayerPosition newPos) {
             this.playerPos = newPos;
             return this;
@@ -230,6 +239,7 @@ public record MapState(
                     chunks,
                     buildings,
                     playerResources,
+                    inventory,
                     playerPos,
                     cameraPos,
                     environment,

--- a/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveMigrator.java
@@ -48,6 +48,7 @@ public final class SaveMigrator {
         register(new V32ToV33Migration());
         register(new V33ToV34Migration());
         register(new V34ToV35Migration());
+        register(new V35ToV36Migration());
     }
 
     private SaveMigrator() {

--- a/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
+++ b/core/src/main/java/net/lapidist/colony/save/SaveVersion.java
@@ -38,9 +38,10 @@ public enum SaveVersion {
     V32(32),
     V33(33),
     V34(34),
-    V35(35);
+    V35(35),
+    V36(36);
 
-    public static final SaveVersion CURRENT = V35;
+    public static final SaveVersion CURRENT = V36;
 
     private final int number;
 

--- a/core/src/main/java/net/lapidist/colony/save/V35ToV36Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V35ToV36Migration.java
@@ -1,0 +1,24 @@
+package net.lapidist.colony.save;
+
+import net.lapidist.colony.components.state.MapState;
+
+/** Migration from save version 35 to 36 adding inventory storage. */
+public final class V35ToV36Migration implements MapStateMigration {
+    @Override
+    public int fromVersion() {
+        return SaveVersion.V35.number();
+    }
+
+    @Override
+    public int toVersion() {
+        return SaveVersion.V36.number();
+    }
+
+    @Override
+    public MapState apply(final MapState state) {
+        return state.toBuilder()
+                .inventory(new java.util.HashMap<>())
+                .version(toVersion())
+                .build();
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/server/GameServer.java
+++ b/server/src/main/java/net/lapidist/colony/server/GameServer.java
@@ -224,8 +224,16 @@ public final class GameServer extends AbstractMessageEndpoint implements AutoClo
             commandHandlers = java.util.List.of(
                     new TileSelectionCommandHandler(() -> mapState, networkService, stateLock),
                     new BuildCommandHandler(() -> mapState, s -> mapState = s, networkService, stateLock),
-                    new GatherCommandHandler(() -> mapState, s -> mapState = s,
-                            networkService, new net.lapidist.colony.server.services.InventoryService(), stateLock),
+                    new GatherCommandHandler(
+                            () -> mapState,
+                            s -> mapState = s,
+                            networkService,
+                            new net.lapidist.colony.server.services.InventoryService(
+                                    () -> mapState,
+                                    ns -> mapState = ns,
+                                    stateLock
+                            ),
+                            stateLock),
                     new RemoveBuildingCommandHandler(() -> mapState, s -> mapState = s, networkService, stateLock),
                     new PlayerPositionCommandHandler(() -> mapState, s -> mapState = s, stateLock)
             );

--- a/server/src/main/java/net/lapidist/colony/server/commands/GatherCommandHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/GatherCommandHandler.java
@@ -68,6 +68,7 @@ public final class GatherCommandHandler implements CommandHandler<GatherCommand>
             java.util.Map<String, Integer> playerAmounts = new java.util.HashMap<>(player.amounts());
             playerAmounts.merge(command.resourceId(), current - updatedValue, Integer::sum);
             inventoryService.addItem(command.resourceId().toLowerCase(Locale.ROOT), current - updatedValue);
+            state = stateSupplier.get();
             ResourceData newPlayer = new ResourceData(new java.util.HashMap<>(playerAmounts));
             MapState updatedState = state.toBuilder()
                     .playerResources(newPlayer)

--- a/server/src/main/java/net/lapidist/colony/server/services/InventoryService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/InventoryService.java
@@ -1,13 +1,27 @@
 package net.lapidist.colony.server.services;
 
+import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.registry.Registries;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
-/** Simple service tracking collected item amounts. */
+/** Simple service tracking collected item amounts persisted in {@link MapState}. */
 public final class InventoryService {
-    private final Map<String, Integer> amounts = new HashMap<>();
+    private final Supplier<MapState> supplier;
+    private final Consumer<MapState> consumer;
+    private final ReentrantLock lock;
+
+    public InventoryService(final Supplier<MapState> stateSupplier,
+                            final Consumer<MapState> stateConsumer,
+                            final ReentrantLock lockToUse) {
+        this.supplier = stateSupplier;
+        this.consumer = stateConsumer;
+        this.lock = lockToUse;
+    }
 
     /**
      * Add the specified amount of an item to the inventory if the item exists in the registry.
@@ -19,20 +33,38 @@ public final class InventoryService {
         if (itemId == null || amount == 0 || Registries.items().get(itemId) == null) {
             return;
         }
-        amounts.merge(itemId, amount, Integer::sum);
+        lock.lock();
+        try {
+            MapState state = supplier.get();
+            Map<String, Integer> inv = new HashMap<>(state.inventory());
+            inv.merge(itemId, amount, Integer::sum);
+            consumer.accept(state.toBuilder().inventory(inv).build());
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**
      * Current amount stored for the given item id.
      */
     public int getAmount(final String itemId) {
-        return amounts.getOrDefault(itemId, 0);
+        lock.lock();
+        try {
+            return supplier.get().inventory().getOrDefault(itemId, 0);
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**
      * @return copy of all stored item amounts
      */
     public Map<String, Integer> getItems() {
-        return new HashMap<>(amounts);
+        lock.lock();
+        try {
+            return new HashMap<>(supplier.get().inventory());
+        } finally {
+            lock.unlock();
+        }
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV35Test.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameStateIOMigrationV35Test.java
@@ -1,0 +1,42 @@
+package net.lapidist.colony.tests.server;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Output;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.serialization.KryoRegistry;
+import net.lapidist.colony.save.SaveData;
+import net.lapidist.colony.save.SaveVersion;
+import net.lapidist.colony.serialization.SerializationRegistrar;
+import net.lapidist.colony.save.io.GameStateIO;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.*;
+
+public class GameStateIOMigrationV35Test {
+
+    @Test
+    public void migratesV35ToCurrent() throws Exception {
+        Path file = Files.createTempFile("state", ".dat");
+        MapState state = MapState.builder()
+                .version(SaveVersion.V35.number())
+                .build();
+        Kryo kryo = new Kryo();
+        KryoRegistry.register(kryo);
+        try (Output output = new Output(Files.newOutputStream(file))) {
+            SaveData data = new SaveData(
+                    SaveVersion.V35.number(),
+                    SerializationRegistrar.registrationHash(),
+                    state
+            );
+            kryo.writeObject(output, data);
+        }
+
+        MapState loaded = GameStateIO.load(file);
+        Files.deleteIfExists(file);
+        assertEquals(SaveVersion.CURRENT.number(), loaded.version());
+        assertNotNull(loaded.inventory());
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GatherCommandHandlerTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GatherCommandHandlerTest.java
@@ -14,6 +14,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -29,13 +30,15 @@ public class GatherCommandHandlerTest {
     @Test
     public void ignoresUnknownResource() {
         MapState state = new MapState();
-        InventoryService inv = new InventoryService();
+        AtomicReference<MapState> ref = new AtomicReference<>(state);
+        ReentrantLock lock = new ReentrantLock();
+        InventoryService inv = new InventoryService(ref::get, ref::set, lock);
         GatherCommandHandler handler = new GatherCommandHandler(
-                () -> state,
-                s -> { },
+                ref::get,
+                ref::set,
                 mock(NetworkService.class),
                 inv,
-                new ReentrantLock()
+                lock
         );
 
         handler.handle(new GatherCommand(0, 0, "missing"));
@@ -51,15 +54,15 @@ public class GatherCommandHandlerTest {
                 .x(0).y(0).tileType("GRASS").passable(true)
                 .resources(res)
                 .build());
-        java.util.concurrent.atomic.AtomicReference<MapState> ref =
-                new java.util.concurrent.atomic.AtomicReference<>(state);
-        InventoryService inv = new InventoryService();
+        AtomicReference<MapState> ref = new AtomicReference<>(state);
+        ReentrantLock lock = new ReentrantLock();
+        InventoryService inv = new InventoryService(ref::get, ref::set, lock);
         GatherCommandHandler handler = new GatherCommandHandler(
                 ref::get,
                 ref::set,
                 mock(NetworkService.class),
                 inv,
-                new ReentrantLock()
+                lock
         );
 
         handler.handle(new GatherCommand(0, 0, Registries.resources().get("STONE").id()));

--- a/tests/src/test/java/net/lapidist/colony/tests/server/InventoryServiceTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/InventoryServiceTest.java
@@ -2,6 +2,9 @@ package net.lapidist.colony.tests.server;
 
 import net.lapidist.colony.base.BaseItemsMod;
 import net.lapidist.colony.server.services.InventoryService;
+import net.lapidist.colony.components.state.MapState;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -17,7 +20,10 @@ public class InventoryServiceTest {
 
     @Test
     public void addsItemsOnlyWhenRegistered() {
-        InventoryService inv = new InventoryService();
+        MapState state = new MapState();
+        AtomicReference<MapState> ref = new AtomicReference<>(state);
+        ReentrantLock lock = new ReentrantLock();
+        InventoryService inv = new InventoryService(ref::get, ref::set, lock);
         inv.addItem("stone", 2);
         final int unknownAmount = 5;
         inv.addItem("unknown", unknownAmount);


### PR DESCRIPTION
## Summary
- track inventory within MapState
- save/load inventory via new save version 36
- update GatherCommandHandler to retain inventory changes
- persist items across restarts with InventoryService
- migrate v35 saves and extend tests

## Testing
- `./gradlew tests:copyAssets spotlessApply`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_6851da6dfdbc8328bc5d400b9c56143d