### PR TITLE
docs: add second client launcher

### DIFF
--- a/.idea/runConfigurations/LauncherMacSecond.xml
+++ b/.idea/runConfigurations/LauncherMacSecond.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="LauncherMacSecond" type="Application" factoryName="Application">
+    <option name="MAIN_CLASS_NAME" value="net.lapidist.colony.client.ClientLauncher" />
+    <module name="colony.client.main" />
+    <option name="VM_PARAMETERS" value="-XstartOnFirstThread" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/client/src/main/resources/assets" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.idea/runConfigurations/LauncherWindowsSecond.xml
+++ b/.idea/runConfigurations/LauncherWindowsSecond.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="LauncherWindowsSecond" type="Application" factoryName="Application">
+    <option name="MAIN_CLASS_NAME" value="net.lapidist.colony.client.ClientLauncher" />
+    <module name="colony.client.main" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/client/src/main/resources/assets" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ For more details on the developer workflow, see [docs/developer_workflow.md](doc
 Both the client and dedicated server can be started directly from Gradle:
 
 - `./gradlew :client:run` – launches the game client.
+- `./scripts/second_client.sh` – launches a second client instance.
 - `./gradlew :server:run` – starts a headless server.
 
 ### Docker

--- a/scripts/second_client.sh
+++ b/scripts/second_client.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+./gradlew :client:run


### PR DESCRIPTION
## Summary
- add IntelliJ run configs for a second client instance
- provide helper script for launching another client
- document the new script in README

## Testing
- `./scripts/check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6851deaea0708328898e8d471655a292