### PR TITLE
Improve day/night lighting

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/entities/PlayerFactory.java
+++ b/client/src/main/java/net/lapidist/colony/client/entities/PlayerFactory.java
@@ -18,6 +18,8 @@ import net.lapidist.colony.components.state.ResourceData;
 public final class PlayerFactory {
     private static final float DEFAULT_LIGHT_RADIUS = 3f;
     private static final float DEFAULT_LIGHT_INTENSITY = 0.6f;
+    private static final com.badlogic.gdx.graphics.Color DEFAULT_LIGHT_COLOR =
+            new com.badlogic.gdx.graphics.Color(1f, 0.6f, 0.2f, 1f);
 
     private PlayerFactory() {
     }
@@ -55,6 +57,7 @@ public final class PlayerFactory {
         PointLightComponent light = new PointLightComponent();
         light.setRadius(DEFAULT_LIGHT_RADIUS);
         light.setIntensity(DEFAULT_LIGHT_INTENSITY);
+        light.setColor(DEFAULT_LIGHT_COLOR);
         player.edit().add(pr).add(pc).add(light);
         return player;
     }

--- a/client/src/main/java/net/lapidist/colony/client/systems/LightingSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/LightingSystem.java
@@ -37,15 +37,13 @@ public final class LightingSystem extends BaseSystem implements Disposable {
     private ComponentMapper<PlayerComponent> playerMapper;
 
     private static final float HOURS_PER_DAY = 24f;
-    private static final float FULL_ROTATION = 360f;
-    private static final float DAWN_OFFSET = 90f;
     private static final float SUNRISE_TIME = 6f;
     private static final float NOON_TIME = 12f;
     private static final float SUNSET_TIME = 18f;
     private static final Color NIGHT_COLOR = new Color(0f, 0f, 0f, 1f);
     private static final Color SUNRISE_COLOR = new Color(0.6f, 0.5f, 0.4f, 1f);
     private static final Color DAY_COLOR = new Color(0.6f, 0.7f, 1f, 1f);
-    private static final float NIGHT_AMBIENT_SCALE = 0.5f;
+    private static final float NIGHT_AMBIENT_SCALE = 0.1f;
 
     public LightingSystem(final ClearScreenSystem clearSystem) {
         this(clearSystem, DEFAULT_RAYS);
@@ -97,8 +95,8 @@ public final class LightingSystem extends BaseSystem implements Disposable {
 
     /** Calculate the direction of the sun for the current time of day. */
     public Vector3 getSunDirection(final Vector3 out) {
-        float angle = (timeOfDay / HOURS_PER_DAY) * FULL_ROTATION - DAWN_OFFSET;
-        return out.set(MathUtils.cosDeg(angle), MathUtils.sinDeg(angle), 1f).nor();
+        float angle = (timeOfDay / HOURS_PER_DAY) * MathUtils.PI2 - MathUtils.HALF_PI;
+        return out.set(0f, MathUtils.cos(angle), MathUtils.sin(angle)).nor();
     }
 
     @Override

--- a/tests/src/test/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPluginTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPluginTest.java
@@ -58,7 +58,7 @@ public class LightsNormalMapShaderPluginTest {
         verify(shader).setUniformf(eq("u_lightDir"), secondCap.capture());
         Vector3 second = new Vector3(secondCap.getValue());
 
-        assertNotEquals(first.x, second.x);
+        assertNotEquals(first.z, second.z);
     }
 
     @Test

--- a/tests/src/test/java/net/lapidist/colony/tests/client/systems/LightingCycleSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/systems/LightingCycleSystemTest.java
@@ -20,7 +20,7 @@ public class LightingCycleSystemTest {
 
     private static final float DAY_RED = 0.6f;
     private static final float NIGHT_RED = 0f;
-    private static final float NIGHT_AMBIENT = 0.5f;
+    private static final float NIGHT_AMBIENT = 0.1f;
     private static final float TOLERANCE = 0.01f;
 
     @Test

--- a/tests/src/test/java/net/lapidist/colony/tests/client/systems/LightingSunDirectionTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/systems/LightingSunDirectionTest.java
@@ -1,0 +1,34 @@
+package net.lapidist.colony.tests.client.systems;
+
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.math.Vector3;
+import net.lapidist.colony.client.systems.ClearScreenSystem;
+import net.lapidist.colony.client.systems.LightingSystem;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/** Verifies sun direction flips below the horizon at night. */
+@RunWith(GdxTestRunner.class)
+public class LightingSunDirectionTest {
+
+    private static final float NOON = 12f;
+
+    @Test
+    public void midnightBelowHorizon() {
+        LightingSystem lighting = new LightingSystem(new ClearScreenSystem(new Color()));
+        lighting.setTimeOfDay(0f);
+        Vector3 dir = lighting.getSunDirection(new Vector3());
+        assertTrue(dir.z < 0f);
+    }
+
+    @Test
+    public void noonAboveHorizon() {
+        LightingSystem lighting = new LightingSystem(new ClearScreenSystem(new Color()));
+        lighting.setTimeOfDay(NOON);
+        Vector3 dir = lighting.getSunDirection(new Vector3());
+        assertTrue(dir.z > 0f);
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/PlayerFactoryTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/PlayerFactoryTest.java
@@ -18,6 +18,8 @@ public class PlayerFactoryTest {
 
     private static final float EXPECTED_RADIUS = 3f;
     private static final float EXPECTED_INTENSITY = 0.6f;
+    private static final com.badlogic.gdx.graphics.Color EXPECTED_COLOR =
+            new com.badlogic.gdx.graphics.Color(1f, 0.6f, 0.2f, 1f);
 
     @Test
     public void addsLightToPlayer() {
@@ -38,5 +40,8 @@ public class PlayerFactoryTest {
         assertNotNull(light);
         assertEquals(EXPECTED_RADIUS, light.getRadius(), 0f);
         assertEquals(EXPECTED_INTENSITY, light.getIntensity(), 0f);
+        assertEquals(EXPECTED_COLOR.r, light.getColor().r, 0f);
+        assertEquals(EXPECTED_COLOR.g, light.getColor().g, 0f);
+        assertEquals(EXPECTED_COLOR.b, light.getColor().b, 0f);
     }
 }


### PR DESCRIPTION
## Summary
- darken nights via lower ambient light and update sun direction
- give the player an orange personal light
- fix shader plugin test to match new sun vector
- add unit test for sun direction
- update existing lighting tests for new ambient level

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851de4e75908328abd6c88b254fa440