### PR TITLE
feat: tune normal map strength

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
@@ -104,6 +104,7 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
                             "u_specularPower",
                             power != null ? (float) power : ResourceLoader.DEFAULT_SPECULAR_POWER
                     );
+                    shader.setUniformf("u_normalStrength", graphicsSettings.getNormalMapStrength());
                     com.badlogic.gdx.Gdx.gl.glActiveTexture(com.badlogic.gdx.graphics.GL20.GL_TEXTURE0);
                 }
                 spriteBatch.draw(region, worldCoords.x, worldCoords.y);

--- a/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
@@ -135,6 +135,7 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
                                 "u_specularPower",
                                 power != null ? (float) power : ResourceLoader.DEFAULT_SPECULAR_POWER
                         );
+                        shader.setUniformf("u_normalStrength", graphicsSettings.getNormalMapStrength());
                         com.badlogic.gdx.Gdx.gl.glActiveTexture(com.badlogic.gdx.graphics.GL20.GL_TEXTURE0);
                     }
                         String upper = type.toUpperCase(java.util.Locale.ROOT);

--- a/client/src/main/resources/assets/shaders/normal.frag
+++ b/client/src/main/resources/assets/shaders/normal.frag
@@ -11,10 +11,12 @@ uniform sampler2D u_specular;
 uniform vec3 u_lightDir;
 uniform vec3 u_viewDir;
 uniform float u_specularPower;
+uniform float u_normalStrength;
 
 void main() {
     vec4 diffuse = texture2D(u_texture, v_texCoords);
-    vec3 normal = texture2D(u_normal, v_texCoords).xyz * 2.0 - 1.0;
+    vec3 map = texture2D(u_normal, v_texCoords).xyz * 2.0 - 1.0;
+    vec3 normal = normalize(mix(vec3(0.0, 0.0, 1.0), map, u_normalStrength));
     vec3 lightDir = normalize(u_lightDir);
     vec3 viewDir = normalize(u_viewDir);
     float diff = max(dot(normal, lightDir), 0.0);

--- a/core/src/main/java/net/lapidist/colony/settings/GraphicsSettings.java
+++ b/core/src/main/java/net/lapidist/colony/settings/GraphicsSettings.java
@@ -15,6 +15,7 @@ public final class GraphicsSettings {
     private static final String LIGHT_KEY = PREFIX + "lighting";
     private static final String NORMAL_KEY = PREFIX + "normalmaps";
     private static final String SPECULAR_KEY = PREFIX + "specularmaps";
+    private static final String NORMAL_STRENGTH_KEY = PREFIX + "normalStrength";
     private static final String DAY_NIGHT_KEY = PREFIX + "dayNightCycle";
     private static final String RAYS_KEY = PREFIX + "lightRays";
 
@@ -28,6 +29,7 @@ public final class GraphicsSettings {
     private boolean lightingEnabled = true;
     private boolean normalMapsEnabled;
     private boolean specularMapsEnabled;
+    private float normalMapStrength = 1f;
     private boolean dayNightCycleEnabled = true;
     private int lightRays = DEFAULT_RAYS;
 
@@ -96,6 +98,14 @@ public final class GraphicsSettings {
         this.specularMapsEnabled = enabled;
     }
 
+    public float getNormalMapStrength() {
+        return normalMapStrength;
+    }
+
+    public void setNormalMapStrength(final float strength) {
+        this.normalMapStrength = strength;
+    }
+
     public boolean isDayNightCycleEnabled() {
         return dayNightCycleEnabled;
     }
@@ -123,6 +133,7 @@ public final class GraphicsSettings {
         gs.lightingEnabled = Boolean.parseBoolean(props.getProperty(LIGHT_KEY, "true"));
         gs.normalMapsEnabled = Boolean.parseBoolean(props.getProperty(NORMAL_KEY, "false"));
         gs.specularMapsEnabled = Boolean.parseBoolean(props.getProperty(SPECULAR_KEY, "false"));
+        gs.normalMapStrength = Float.parseFloat(props.getProperty(NORMAL_STRENGTH_KEY, "1"));
         gs.dayNightCycleEnabled = Boolean.parseBoolean(props.getProperty(DAY_NIGHT_KEY, "true"));
         gs.lightRays = Integer.parseInt(props.getProperty(RAYS_KEY, Integer.toString(DEFAULT_RAYS)));
         return gs;
@@ -138,6 +149,7 @@ public final class GraphicsSettings {
         props.setProperty(LIGHT_KEY, Boolean.toString(lightingEnabled));
         props.setProperty(NORMAL_KEY, Boolean.toString(normalMapsEnabled));
         props.setProperty(SPECULAR_KEY, Boolean.toString(specularMapsEnabled));
+        props.setProperty(NORMAL_STRENGTH_KEY, Float.toString(normalMapStrength));
         props.setProperty(DAY_NIGHT_KEY, Boolean.toString(dayNightCycleEnabled));
         props.setProperty(RAYS_KEY, Integer.toString(lightRays));
     }

--- a/core/src/main/java/net/lapidist/colony/settings/Settings.java
+++ b/core/src/main/java/net/lapidist/colony/settings/Settings.java
@@ -68,6 +68,7 @@ public final class Settings {
             settings.graphicsSettings.setLightingEnabled(gLoaded.isLightingEnabled());
             settings.graphicsSettings.setNormalMapsEnabled(gLoaded.isNormalMapsEnabled());
             settings.graphicsSettings.setSpecularMapsEnabled(gLoaded.isSpecularMapsEnabled());
+            settings.graphicsSettings.setNormalMapStrength(gLoaded.getNormalMapStrength());
             settings.graphicsSettings.setDayNightCycleEnabled(gLoaded.isDayNightCycleEnabled());
             settings.graphicsSettings.setLightRays(gLoaded.getLightRays());
         } catch (IOException e) {

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -59,6 +59,7 @@ graphics.mipmaps=Mip Maps
 graphics.anisotropic=Anisotropic Filtering
 graphics.normalmaps=Normal Maps
 graphics.specularmaps=Specular Maps
+graphics.normalStrength=Normal Strength
 graphics.renderer=Renderer
 graphics.spritecache=Sprite Cache
 graphics.lighting=Lighting

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -58,6 +58,7 @@ graphics.mipmaps=MipMaps
 graphics.anisotropic=Anisotropes Filtern
 graphics.normalmaps=Normalmaps
 graphics.specularmaps=Spekularmaps
+graphics.normalStrength=Normalstärke
 graphics.renderer=Renderer
 graphics.spritecache=Sprite-Cache
 graphics.lighting=Beleuchtung

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -58,6 +58,7 @@ graphics.mipmaps=Mip Maps
 graphics.anisotropic=Filtrado Anisotrópico
 graphics.normalmaps=Mapas Normales
 graphics.specularmaps=Mapas Especulares
+graphics.normalStrength=Intensidad de Normal
 graphics.renderer=Renderizador
 graphics.spritecache=Cache de Sprites
 graphics.lighting=Iluminaci\u00f3n

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -58,6 +58,7 @@ graphics.mipmaps=Mip Maps
 graphics.anisotropic=Filtrage Anisotrope
 graphics.normalmaps=Cartes de Normales
 graphics.specularmaps=Cartes de Sp\u00e9culaire
+graphics.normalStrength=Intensit\u00e9 des Normales
 graphics.renderer=Moteur de rendu
 graphics.spritecache=Cache de Sprites
 graphics.lighting=\u00c9clairage

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,3 +80,6 @@ The number of rays per dynamic light can be tuned with `graphics.lightRays`.
 Higher values produce smoother shadows but reduce performance. The default is
 `16`.
 
+`graphics.normalStrength` controls how strongly normal maps affect lighting. The
+value ranges from `0` (disabled) to `1` (full effect) and defaults to `1`.
+

--- a/docs/shaders.md
+++ b/docs/shaders.md
@@ -72,8 +72,11 @@ additional uniforms:
 * `u_lightDir` – normalized direction to the main light source.
 * `u_viewDir` – direction toward the camera.
 * `u_specularPower` – exponent for the specular highlight.
+* `u_normalStrength` – blend factor for normal maps.
 
 The first two values are updated every frame so diffuse and specular terms react
 to camera movement. The specular map supplies the intensity for a Blinn–Phong
 highlight calculation, while `u_specularPower` controls the falloff. Atlas
 regions may override the default by adding `specularPower: N`.
+`u_normalStrength` mixes between a flat surface and the stored normal values so
+lower numbers soften the bump effect.

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/BuildingRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/BuildingRendererTest.java
@@ -31,6 +31,7 @@ public class BuildingRendererTest {
 
     private static final int VIEW_SIZE = 32;
     private static final int CUSTOM_POWER = 23;
+    private static final float CUSTOM_STRENGTH = 0.4f;
 
     @Test
     public void rendersBuildingTexture() {
@@ -220,5 +221,40 @@ public class BuildingRendererTest {
         renderer.render(map);
 
         verify(shader).setUniformf("u_specularPower", (float) CUSTOM_POWER);
+    }
+
+    @Test
+    public void setsNormalStrengthUniform() {
+        SpriteBatch batch = mock(SpriteBatch.class);
+        ShaderProgram shader = mock(ShaderProgram.class);
+        when(batch.getShader()).thenReturn(shader);
+        ResourceLoader loader = mock(ResourceLoader.class);
+        TextureRegion region = mock(TextureRegion.class);
+        when(loader.findRegion(anyString())).thenReturn(region);
+
+        new BaseDefinitionsMod().init();
+
+        CameraProvider camera = mock(CameraProvider.class);
+        OrthographicCamera cam = new OrthographicCamera();
+        ExtendViewport viewport = new ExtendViewport(VIEW_SIZE, VIEW_SIZE, cam);
+        viewport.update(VIEW_SIZE, VIEW_SIZE, true);
+        cam.update();
+        when(camera.getCamera()).thenReturn(cam);
+        when(camera.getViewport()).thenReturn(viewport);
+
+        GraphicsSettings graphics = new GraphicsSettings();
+        graphics.setNormalMapStrength(CUSTOM_STRENGTH);
+        BuildingRenderer renderer = new BuildingRenderer(batch, loader, camera, new DefaultAssetResolver(), graphics);
+
+        Array<RenderBuilding> buildings = new Array<>();
+        RenderBuilding building = RenderBuilding.builder().x(0).y(0).buildingType("house").build();
+        buildings.add(building);
+
+        MapRenderData map = new SimpleMapRenderData(new Array<RenderTile>(), buildings,
+                new RenderTile[MapState.DEFAULT_WIDTH][MapState.DEFAULT_HEIGHT]);
+
+        renderer.render(map);
+
+        verify(shader).setUniformf("u_normalStrength", CUSTOM_STRENGTH);
     }
 }


### PR DESCRIPTION
## Summary
- allow adjusting normal map intensity through `GraphicsSettings`
- control shader with new `u_normalStrength` uniform
- document the setting
- support translations and tests

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851df62ff7883289724955dc507e7e6