### PR TITLE
fix(client): start GLFW on Mac main thread

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -16,6 +16,10 @@ dependencies {
 
 application {
     mainClass = 'net.lapidist.colony.client.ClientLauncher'
+    // macOS requires starting on the first thread when using GLFW
+    if (System.getProperty('os.name').toLowerCase().contains('mac')) {
+        applicationDefaultJvmArgs = ['-XstartOnFirstThread']
+    }
 }
 
 eclipse.project.name = "$appName-client"


### PR DESCRIPTION
## Summary
- detect macOS in the client build file
- start the LWJGL application on the first thread to satisfy GLFW

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851e0afdee4832891856aaad8863c25