### PR TITLE
fix: copy client assets to resources root

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -1,5 +1,10 @@
 apply plugin: 'application'
 
+processResources {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    exclude 'assets/**'
+    from('src/main/resources/assets') { into '' }
+}
 dependencies {
     implementation project(":core")
     implementation project(":server")


### PR DESCRIPTION
## Summary
- include assets directly in the `client` resources output so runtime paths like `skin/default.json` resolve correctly

## Testing
- `./scripts/check.sh`
- `./scripts/second_client.sh` *(fails: GLFW platform unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6851e2211ff483289141c7bf7ad31cf1