### PR TITLE
Fix tile shading when sprite cache enabled

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/renderers/SpriteBatchMapRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/SpriteBatchMapRenderer.java
@@ -76,10 +76,8 @@ public final class SpriteBatchMapRenderer implements MapRenderer, Disposable {
 
         if (cacheEnabled) {
             tileCache.draw(spriteBatch, camera);
-            tileRenderer.setOverlayOnly(true);
-        } else {
-            tileRenderer.setOverlayOnly(false);
         }
+        tileRenderer.setOverlayOnly(false);
 
         tileRenderer.render(map);
         buildingRenderer.render(map);


### PR DESCRIPTION
## Summary
- draw base tiles through TileRenderer even when SpriteCache is used

## Testing
- `./gradlew spotlessApply`
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew :tests:jmh -Djmh.include=SpriteBatchRendererBenchmark`

------
https://chatgpt.com/codex/tasks/task_e_6851e1c4012c83288316186369fd7f99