### PR TITLE
feat(client): cycle languages via single settings button

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/SettingsScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/SettingsScreen.java
@@ -17,48 +17,35 @@ import java.util.Locale;
  */
 public final class SettingsScreen extends BaseScreen {
     private final Colony colony;
+    private static final Locale[] SUPPORTED_LOCALES = new Locale[] {
+            Locale.ENGLISH,
+            Locale.FRENCH,
+            new Locale("es"),
+            Locale.GERMAN
+    };
+    private int localeIndex;
+    private final TextButton language;
 
     public SettingsScreen(final Colony game) {
         this.colony = game;
-
-        TextButton en = new TextButton(I18n.get("language.en"), getSkin());
-        TextButton fr = new TextButton(I18n.get("language.fr"), getSkin());
-        TextButton es = new TextButton(I18n.get("language.es"), getSkin());
-        TextButton de = new TextButton(I18n.get("language.de"), getSkin());
+        localeIndex = findLocaleIndex(colony.getSettings().getLocale());
+        language = new TextButton(getLanguageText(SUPPORTED_LOCALES[localeIndex]), getSkin());
         TextButton keybinds = new TextButton(I18n.get("settings.keybinds"), getSkin());
         TextButton graphics = new TextButton(I18n.get("settings.graphics"), getSkin());
         TextButton back = new TextButton(I18n.get("common.back"), getSkin());
 
-        getRoot().add(en).row();
-        getRoot().add(fr).row();
-        getRoot().add(es).row();
-        getRoot().add(de).row();
+        getRoot().add(language).row();
         getRoot().add(keybinds).row();
         getRoot().add(graphics).row();
         getRoot().add(back).row();
 
-        en.addListener(new ChangeListener() {
+        language.addListener(new ChangeListener() {
             @Override
             public void changed(final ChangeEvent event, final Actor actor) {
-                switchLocale(Locale.ENGLISH);
-            }
-        });
-        fr.addListener(new ChangeListener() {
-            @Override
-            public void changed(final ChangeEvent event, final Actor actor) {
-                switchLocale(Locale.FRENCH);
-            }
-        });
-        es.addListener(new ChangeListener() {
-            @Override
-            public void changed(final ChangeEvent event, final Actor actor) {
-                switchLocale(new Locale("es"));
-            }
-        });
-        de.addListener(new ChangeListener() {
-            @Override
-            public void changed(final ChangeEvent event, final Actor actor) {
-                switchLocale(Locale.GERMAN);
+                localeIndex = (localeIndex + 1) % SUPPORTED_LOCALES.length;
+                Locale next = SUPPORTED_LOCALES[localeIndex];
+                switchLocale(next);
+                language.setText(getLanguageText(next));
             }
         });
         keybinds.addListener(new ChangeListener() {
@@ -91,6 +78,19 @@ public final class SettingsScreen extends BaseScreen {
                 return false;
             }
         });
+    }
+
+    private static int findLocaleIndex(final Locale locale) {
+        for (int i = 0; i < SUPPORTED_LOCALES.length; i++) {
+            if (SUPPORTED_LOCALES[i].getLanguage().equals(locale.getLanguage())) {
+                return i;
+            }
+        }
+        return 0;
+    }
+
+    private static String getLanguageText(final Locale locale) {
+        return I18n.get("language." + locale.getLanguage());
     }
 
     private void switchLocale(final Locale locale) {

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MainMenuScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MainMenuScreenTest.java
@@ -9,6 +9,7 @@ import net.lapidist.colony.client.screens.LoadGameScreen;
 import net.lapidist.colony.client.screens.MainMenuScreen;
 import net.lapidist.colony.client.screens.ModSelectionScreen;
 import net.lapidist.colony.client.screens.SettingsScreen;
+import net.lapidist.colony.settings.Settings;
 import org.mockito.MockedConstruction;
 import static org.mockito.Mockito.mockConstruction;
 import net.lapidist.colony.tests.GdxTestRunner;
@@ -59,6 +60,7 @@ public class MainMenuScreenTest {
     @Test
     public void clickingSettingsOpensSettingsScreen() throws Exception {
         Colony colony = mock(Colony.class);
+        when(colony.getSettings()).thenReturn(new Settings());
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
             MainMenuScreen screen = new MainMenuScreen(colony);
             TextButton settings = (TextButton) getRoot(screen).getChildren().get(SETTINGS_INDEX);

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/SettingsScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/SettingsScreenTest.java
@@ -25,9 +25,9 @@ import static org.mockito.Mockito.*;
 @RunWith(GdxTestRunner.class)
 public class SettingsScreenTest {
 
-    private static final int KEYBINDS_INDEX = 4;
-    private static final int GRAPHICS_INDEX = 5;
-    private static final int BACK_BUTTON_INDEX = 6;
+    private static final int KEYBINDS_INDEX = 1;
+    private static final int GRAPHICS_INDEX = 2;
+    private static final int BACK_BUTTON_INDEX = 3;
 
     private static Table getRoot(final SettingsScreen screen) throws Exception {
         Field f = screen.getClass().getSuperclass().getDeclaredField("root");


### PR DESCRIPTION
## Summary
- compress settings language options into one button
- adapt tests for new button layout
- fix MainMenuScreen test to provide settings

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851ff1f43788328a0ab5470e9494ad6