### PR TITLE
feat(core): add scheduled service base

### DIFF
--- a/core/src/main/java/net/lapidist/colony/mod/ScheduledService.java
+++ b/core/src/main/java/net/lapidist/colony/mod/ScheduledService.java
@@ -1,0 +1,44 @@
+package net.lapidist.colony.mod;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Base class for services that run periodically on a single daemon thread.
+ */
+public abstract class ScheduledService implements GameSystem {
+
+    private final long interval;
+    private ScheduledExecutorService executor;
+
+    protected ScheduledService(final long intervalMs) {
+        this.interval = intervalMs;
+    }
+
+    /**
+     * Starts a daemon thread that invokes {@link #runTask()} at the configured interval.
+     */
+    @Override
+    public void start() {
+        executor = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r);
+            t.setDaemon(true);
+            return t;
+        });
+        executor.scheduleAtFixedRate(this::runTask, interval, interval, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Stops the scheduler. Subclasses overriding this method must call {@code super.stop()}.
+     */
+    @Override
+    public void stop() {
+        if (executor != null) {
+            executor.shutdownNow();
+        }
+    }
+
+    /** Task executed on each interval. */
+    protected abstract void runTask();
+}


### PR DESCRIPTION
## Summary
- add `ScheduledService` for periodic tasks
- refactor autosave, season cycle and resource production services to extend the base class

## Testing
- `./scripts/check.sh`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_685202f61ec8832893b40abd39d8369d