### PR TITLE
feat(server): route network requests through command bus

### DIFF
--- a/server/src/main/java/net/lapidist/colony/server/handlers/BuildingPlacementRequestHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/handlers/BuildingPlacementRequestHandler.java
@@ -3,27 +3,22 @@ package net.lapidist.colony.server.handlers;
 import net.lapidist.colony.components.state.BuildingPlacementData;
 import net.lapidist.colony.server.commands.BuildCommand;
 import net.lapidist.colony.server.commands.CommandBus;
-import net.lapidist.colony.network.AbstractMessageHandler;
+import net.lapidist.colony.server.commands.ServerCommand;
 
 /**
  * Converts incoming {@link BuildingPlacementData} messages into {@link BuildCommand} instances.
  *
  * Client system: {@code net.lapidist.colony.client.systems.network.BuildingUpdateSystem}
  */
-public final class BuildingPlacementRequestHandler extends AbstractMessageHandler<BuildingPlacementData> {
-    private final CommandBus commandBus;
+public final class BuildingPlacementRequestHandler
+        extends CommandBusMessageHandler<BuildingPlacementData> {
 
     public BuildingPlacementRequestHandler(final CommandBus bus) {
-        super(BuildingPlacementData.class);
-        this.commandBus = bus;
+        super(BuildingPlacementData.class, bus);
     }
 
     @Override
-    public void handle(final BuildingPlacementData data) {
-        commandBus.dispatch(new BuildCommand(
-                data.x(),
-                data.y(),
-                data.buildingId()
-        ));
+    protected ServerCommand convert(final BuildingPlacementData data) {
+        return new BuildCommand(data.x(), data.y(), data.buildingId());
     }
 }

--- a/server/src/main/java/net/lapidist/colony/server/handlers/BuildingRemovalRequestHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/handlers/BuildingRemovalRequestHandler.java
@@ -3,23 +3,22 @@ package net.lapidist.colony.server.handlers;
 import net.lapidist.colony.components.state.BuildingRemovalData;
 import net.lapidist.colony.server.commands.CommandBus;
 import net.lapidist.colony.server.commands.RemoveBuildingCommand;
-import net.lapidist.colony.network.AbstractMessageHandler;
+import net.lapidist.colony.server.commands.ServerCommand;
 
 /**
  * Converts incoming {@link BuildingRemovalData} messages into {@link RemoveBuildingCommand} instances.
  *
  * Client system: {@code net.lapidist.colony.client.systems.network.BuildingUpdateSystem}
  */
-public final class BuildingRemovalRequestHandler extends AbstractMessageHandler<BuildingRemovalData> {
-    private final CommandBus commandBus;
+public final class BuildingRemovalRequestHandler
+        extends CommandBusMessageHandler<BuildingRemovalData> {
 
     public BuildingRemovalRequestHandler(final CommandBus bus) {
-        super(BuildingRemovalData.class);
-        this.commandBus = bus;
+        super(BuildingRemovalData.class, bus);
     }
 
     @Override
-    public void handle(final BuildingRemovalData data) {
-        commandBus.dispatch(new RemoveBuildingCommand(data.x(), data.y()));
+    protected ServerCommand convert(final BuildingRemovalData data) {
+        return new RemoveBuildingCommand(data.x(), data.y());
     }
 }

--- a/server/src/main/java/net/lapidist/colony/server/handlers/CommandBusMessageHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/handlers/CommandBusMessageHandler.java
@@ -1,0 +1,29 @@
+package net.lapidist.colony.server.handlers;
+
+import net.lapidist.colony.network.AbstractMessageHandler;
+import net.lapidist.colony.server.commands.CommandBus;
+import net.lapidist.colony.server.commands.ServerCommand;
+
+/**
+ * Base class for handlers that translate network messages into
+ * {@link ServerCommand} instances dispatched on the {@link CommandBus}.
+ *
+ * @param <T> the message type handled
+ */
+public abstract class CommandBusMessageHandler<T> extends AbstractMessageHandler<T> {
+
+    private final CommandBus commandBus;
+
+    protected CommandBusMessageHandler(final Class<T> type, final CommandBus bus) {
+        super(type);
+        this.commandBus = bus;
+    }
+
+    /** Convert the incoming message into a command for dispatch. */
+    protected abstract ServerCommand convert(T data);
+
+    @Override
+    public final void handle(final T data) {
+        commandBus.dispatch(convert(data));
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/server/handlers/PlayerPositionUpdateHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/handlers/PlayerPositionUpdateHandler.java
@@ -1,21 +1,20 @@
 package net.lapidist.colony.server.handlers;
 
 import net.lapidist.colony.components.state.PlayerPositionUpdate;
-import net.lapidist.colony.network.AbstractMessageHandler;
 import net.lapidist.colony.server.commands.CommandBus;
 import net.lapidist.colony.server.commands.PlayerPositionCommand;
+import net.lapidist.colony.server.commands.ServerCommand;
 
 /** Converts incoming {@link PlayerPositionUpdate} into {@link PlayerPositionCommand}. */
-public final class PlayerPositionUpdateHandler extends AbstractMessageHandler<PlayerPositionUpdate> {
-    private final CommandBus commandBus;
+public final class PlayerPositionUpdateHandler
+        extends CommandBusMessageHandler<PlayerPositionUpdate> {
 
     public PlayerPositionUpdateHandler(final CommandBus bus) {
-        super(PlayerPositionUpdate.class);
-        this.commandBus = bus;
+        super(PlayerPositionUpdate.class, bus);
     }
 
     @Override
-    public void handle(final PlayerPositionUpdate message) {
-        commandBus.dispatch(new PlayerPositionCommand(message.x(), message.y()));
+    protected ServerCommand convert(final PlayerPositionUpdate message) {
+        return new PlayerPositionCommand(message.x(), message.y());
     }
 }

--- a/server/src/main/java/net/lapidist/colony/server/handlers/ResourceGatherRequestHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/handlers/ResourceGatherRequestHandler.java
@@ -3,23 +3,22 @@ package net.lapidist.colony.server.handlers;
 import net.lapidist.colony.components.state.ResourceGatherRequestData;
 import net.lapidist.colony.server.commands.CommandBus;
 import net.lapidist.colony.server.commands.GatherCommand;
-import net.lapidist.colony.network.AbstractMessageHandler;
+import net.lapidist.colony.server.commands.ServerCommand;
 
 /**
  * Converts incoming {@link ResourceGatherRequestData} into {@link GatherCommand}.
  *
  * Client system: {@code net.lapidist.colony.client.systems.network.ResourceUpdateSystem}
  */
-public final class ResourceGatherRequestHandler extends AbstractMessageHandler<ResourceGatherRequestData> {
-    private final CommandBus commandBus;
+public final class ResourceGatherRequestHandler
+        extends CommandBusMessageHandler<ResourceGatherRequestData> {
 
     public ResourceGatherRequestHandler(final CommandBus bus) {
-        super(ResourceGatherRequestData.class);
-        this.commandBus = bus;
+        super(ResourceGatherRequestData.class, bus);
     }
 
     @Override
-    public void handle(final ResourceGatherRequestData data) {
-        commandBus.dispatch(new GatherCommand(data.x(), data.y(), data.resourceId()));
+    protected ServerCommand convert(final ResourceGatherRequestData data) {
+        return new GatherCommand(data.x(), data.y(), data.resourceId());
     }
 }

--- a/server/src/main/java/net/lapidist/colony/server/handlers/TileSelectionRequestHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/handlers/TileSelectionRequestHandler.java
@@ -3,7 +3,7 @@ package net.lapidist.colony.server.handlers;
 import net.lapidist.colony.server.commands.CommandBus;
 import net.lapidist.colony.server.commands.TileSelectionCommand;
 import net.lapidist.colony.components.state.TileSelectionData;
-import net.lapidist.colony.network.AbstractMessageHandler;
+import net.lapidist.colony.server.commands.ServerCommand;
 
 /**
  * Converts incoming {@link TileSelectionData} messages into
@@ -11,16 +11,15 @@ import net.lapidist.colony.network.AbstractMessageHandler;
  *
  * Client system: {@code net.lapidist.colony.client.systems.network.TileUpdateSystem}
  */
-public final class TileSelectionRequestHandler extends AbstractMessageHandler<TileSelectionData> {
-    private final CommandBus commandBus;
+public final class TileSelectionRequestHandler
+        extends CommandBusMessageHandler<TileSelectionData> {
 
     public TileSelectionRequestHandler(final CommandBus bus) {
-        super(TileSelectionData.class);
-        this.commandBus = bus;
+        super(TileSelectionData.class, bus);
     }
 
     @Override
-    public void handle(final TileSelectionData data) {
-        commandBus.dispatch(new TileSelectionCommand(data.x(), data.y(), data.selected()));
+    protected ServerCommand convert(final TileSelectionData data) {
+        return new TileSelectionCommand(data.x(), data.y(), data.selected());
     }
 }


### PR DESCRIPTION
## Summary
- add `CommandBusMessageHandler` to unify request handling
- route tile selection, build, remove, gather and player position messages through the new base class

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852031672ec8328adba3f25c1afa949