### PR TITLE
feat: add select key action

### DIFF
--- a/core/src/main/java/net/lapidist/colony/settings/KeyAction.java
+++ b/core/src/main/java/net/lapidist/colony/settings/KeyAction.java
@@ -14,6 +14,7 @@ public enum KeyAction {
     CHAT("chat"),
     MINIMAP("minimap"),
     TOGGLE_CAMERA("toggleCamera"),
+    SELECT("select"),
     SELECT_WOOD("selectWood"),
     SELECT_STONE("selectStone"),
     SELECT_FOOD("selectFood");

--- a/core/src/main/java/net/lapidist/colony/settings/KeyBindings.java
+++ b/core/src/main/java/net/lapidist/colony/settings/KeyBindings.java
@@ -22,6 +22,7 @@ public final class KeyBindings {
             Map.entry(KeyAction.CHAT, Input.Keys.T),
             Map.entry(KeyAction.MINIMAP, Input.Keys.M),
             Map.entry(KeyAction.TOGGLE_CAMERA, Input.Keys.F),
+            Map.entry(KeyAction.SELECT, Input.Keys.ENTER),
             Map.entry(KeyAction.SELECT_WOOD, Input.Keys.NUM_1),
             Map.entry(KeyAction.SELECT_STONE, Input.Keys.NUM_2),
             Map.entry(KeyAction.SELECT_FOOD, Input.Keys.NUM_3)

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -43,6 +43,7 @@ keybind.remove=Remove
 keybind.chat=Chat
 keybind.minimap=Minimap
 keybind.toggleCamera=Toggle Camera
+keybind.select=Select
 common.reset=Reset
 ui.resources=Resources
 building.house=House

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -42,6 +42,7 @@ keybind.remove=Entfernen
 keybind.chat=Chat
 keybind.minimap=Minikarte
 keybind.toggleCamera=Kamera Umschalten
+keybind.select=Auswählen
 common.reset=Zurücksetzen
 ui.resources=Rohstoffe
 building.house=Haus

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -42,6 +42,7 @@ keybind.remove=Eliminar
 keybind.chat=Chat
 keybind.minimap=Minimapa
 keybind.toggleCamera=Cambiar Cámara
+keybind.select=Seleccionar
 common.reset=Restablecer
 ui.resources=Recursos
 building.house=Casa

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -42,6 +42,7 @@ keybind.remove=Supprimer
 keybind.chat=Chat
 keybind.minimap=Mini-carte
 keybind.toggleCamera=Basculer Caméra
+keybind.select=Sélectionner
 common.reset=Réinitialiser
 ui.resources=Ressources
 building.house=Maison


### PR DESCRIPTION
## Summary
- add `SELECT` to KeyAction
- map new action to `ENTER` in KeyBindings
- provide `keybind.select` translations

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`

------
https://chatgpt.com/codex/tasks/task_e_68526db3217c8328842c300518a82947