### PR TITLE
feat(core): add map select translations

### DIFF
--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -22,6 +22,7 @@ map.build=Build
 map.remove=Remove
 map.map=Map
 map.minimap=Minimap
+map.select=Select
 generator.generatedMap=Generated map
 language.en=English
 language.fr=Français

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -21,6 +21,7 @@ map.build=Bauen
 map.remove=Entfernen
 map.map=Karte
 map.minimap=Minikarte
+map.select=Auswählen
 generator.generatedMap=Generierte Karte
 language.en=Englisch
 language.fr=Französisch

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -21,6 +21,7 @@ map.build=Construir
 map.remove=Eliminar
 map.map=Mapa
 map.minimap=Minimapa
+map.select=Seleccionar
 generator.generatedMap=Mapa generado
 language.en=Inglés
 language.fr=Francés

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -21,6 +21,7 @@ map.build=Construire
 map.remove=Supprimer
 map.map=Carte
 map.minimap=Mini-carte
+map.select=Sélectionner
 generator.generatedMap=Carte générée
 language.en=Anglais
 language.fr=Français


### PR DESCRIPTION
## Summary
- add `map.select` entry to i18n bundles
- provide translations for English, French, Spanish and German

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_6852702271488328af37f66e93475044