### PR TITLE
fix: reset tile selections when choosing new tile

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/systems/input/TileSelectionHandler.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/input/TileSelectionHandler.java
@@ -49,6 +49,25 @@ public final class TileSelectionHandler {
         return MapUtils.findTile(map, (int) tileCoords.x, (int) tileCoords.y)
                 .map(tile -> {
                     TileComponent tileComponent = tileMapper.get(tile);
+
+                    if (!tileComponent.isSelected()) {
+                        for (int i = 0; i < selectedTiles.size; i++) {
+                            Entity selected = selectedTiles.get(i);
+                            TileComponent comp = tileMapper.get(selected);
+                            if (comp.isSelected()) {
+                                TileSelectionData deselectMsg = new TileSelectionData(
+                                        comp.getX(),
+                                        comp.getY(),
+                                        false
+                                );
+                                client.sendTileSelectionRequest(deselectMsg);
+                                comp.setSelected(false);
+                                map.incrementVersion();
+                            }
+                        }
+                        selectedTiles.clear();
+                    }
+
                     boolean newState = !tileComponent.isSelected();
 
                     TileSelectionData msg = new TileSelectionData(
@@ -59,10 +78,9 @@ public final class TileSelectionHandler {
                     client.sendTileSelectionRequest(msg);
                     tileComponent.setSelected(newState);
                     map.incrementVersion();
+
                     if (newState) {
-                        if (!selectedTiles.contains(tile, true)) {
-                            selectedTiles.add(tile);
-                        }
+                        selectedTiles.add(tile);
                     } else {
                         selectedTiles.removeValue(tile, true);
                     }


### PR DESCRIPTION
## Summary
- deselect previously selected tiles in `TileSelectionHandler`
- ensure deselection messages are sent before storing new selection

## Testing
- `./scripts/check.sh`
- `./gradlew spotlessCheck`

------
https://chatgpt.com/codex/tasks/task_e_685274ec77708328a7c9d73c83efea2f