### PR TITLE
fix(graphics): soften normal and specular effects

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/core/io/ResourceLoader.java
+++ b/client/src/main/java/net/lapidist/colony/client/core/io/ResourceLoader.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 public interface ResourceLoader extends Disposable {
 
     /** Default specular exponent applied when metadata is missing. */
-    int DEFAULT_SPECULAR_POWER = 16;
+    int DEFAULT_SPECULAR_POWER = 8;
 
     /**
      * Load texture regions from the given atlas.

--- a/core/src/main/java/net/lapidist/colony/settings/GraphicsSettings.java
+++ b/core/src/main/java/net/lapidist/colony/settings/GraphicsSettings.java
@@ -20,6 +20,7 @@ public final class GraphicsSettings {
     private static final String RAYS_KEY = PREFIX + "lightRays";
 
     private static final int DEFAULT_RAYS = 16;
+    private static final float DEFAULT_NORMAL_STRENGTH = 0.5f;
 
     private boolean antialiasingEnabled = true;
     private boolean mipMapsEnabled = true;
@@ -29,7 +30,7 @@ public final class GraphicsSettings {
     private boolean lightingEnabled = true;
     private boolean normalMapsEnabled;
     private boolean specularMapsEnabled;
-    private float normalMapStrength = 1f;
+    private float normalMapStrength = DEFAULT_NORMAL_STRENGTH;
     private boolean dayNightCycleEnabled = true;
     private int lightRays = DEFAULT_RAYS;
 
@@ -133,7 +134,10 @@ public final class GraphicsSettings {
         gs.lightingEnabled = Boolean.parseBoolean(props.getProperty(LIGHT_KEY, "true"));
         gs.normalMapsEnabled = Boolean.parseBoolean(props.getProperty(NORMAL_KEY, "false"));
         gs.specularMapsEnabled = Boolean.parseBoolean(props.getProperty(SPECULAR_KEY, "false"));
-        gs.normalMapStrength = Float.parseFloat(props.getProperty(NORMAL_STRENGTH_KEY, "1"));
+        gs.normalMapStrength = Float.parseFloat(props.getProperty(
+                NORMAL_STRENGTH_KEY,
+                Float.toString(DEFAULT_NORMAL_STRENGTH)
+        ));
         gs.dayNightCycleEnabled = Boolean.parseBoolean(props.getProperty(DAY_NIGHT_KEY, "true"));
         gs.lightRays = Integer.parseInt(props.getProperty(RAYS_KEY, Integer.toString(DEFAULT_RAYS)));
         return gs;

--- a/docs/asset_pipeline.md
+++ b/docs/asset_pipeline.md
@@ -5,7 +5,7 @@ region may define additional custom fields which are preserved by the atlas load
 
 The normal mapping shader reads a `specularPower` value from atlas regions to
 control the Blinn–Phong exponent. Add a line like `specularPower: 32` under a
-region entry to override the default of `16`.
+region entry to override the default of `8`.
 
 Run `./gradlew tests:copyAssets` whenever the atlas is updated so the test module
 has the latest resources.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,5 +81,5 @@ Higher values produce smoother shadows but reduce performance. The default is
 `16`.
 
 `graphics.normalStrength` controls how strongly normal maps affect lighting. The
-value ranges from `0` (disabled) to `1` (full effect) and defaults to `1`.
+value ranges from `0` (disabled) to `1` (full effect) and defaults to `0.5`.
 


### PR DESCRIPTION
## Summary
- tone down default specular highlight
- reduce normal map strength
- document new defaults

## Testing
- `./gradlew spotlessApply`
- `./scripts/check.sh`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_6852f8e7132c83289e14c60fd70f510d