### PR TITLE
feat(server): add day-night cycle persistence

### DIFF
--- a/server/src/main/java/net/lapidist/colony/base/BaseDayCycleMod.java
+++ b/server/src/main/java/net/lapidist/colony/base/BaseDayCycleMod.java
@@ -1,0 +1,23 @@
+package net.lapidist.colony.base;
+
+import net.lapidist.colony.mod.GameMod;
+import net.lapidist.colony.mod.GameServer;
+import net.lapidist.colony.server.services.DayNightCycleService;
+
+/** Built-in mod registering the day/night cycle service. */
+public final class BaseDayCycleMod implements GameMod {
+    private static final long TICK_PERIOD_MS = 1000L;
+    private static final float DAY_LENGTH_SECONDS = 24f;
+
+    @Override
+    public void registerSystems(final GameServer srv) {
+        net.lapidist.colony.server.GameServer s = (net.lapidist.colony.server.GameServer) srv;
+        srv.registerSystem(new DayNightCycleService(
+                TICK_PERIOD_MS,
+                DAY_LENGTH_SECONDS,
+                s::getMapState,
+                s::setMapState,
+                s.getStateLock()
+        ));
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/server/services/DayNightCycleService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/DayNightCycleService.java
@@ -1,0 +1,64 @@
+package net.lapidist.colony.server.services;
+
+import net.lapidist.colony.components.state.EnvironmentState;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.mod.ScheduledService;
+
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Periodically advances the time of day stored in the map state.
+ */
+public final class DayNightCycleService extends ScheduledService {
+    private static final float HOURS_PER_DAY = 24f;
+    private static final float MS_TO_SECONDS = 1000f;
+    private final long interval;
+    private final float dayLength;
+    private final Supplier<MapState> supplier;
+    private final Consumer<MapState> consumer;
+    private final ReentrantLock lock;
+
+    public DayNightCycleService(
+            final long periodMs,
+            final float dayLengthInSeconds,
+            final Supplier<MapState> stateSupplier,
+            final Consumer<MapState> stateConsumer,
+            final ReentrantLock stateLock) {
+        super(periodMs);
+        this.interval = periodMs;
+        this.dayLength = dayLengthInSeconds;
+        this.supplier = stateSupplier;
+        this.consumer = stateConsumer;
+        this.lock = stateLock;
+    }
+
+    @Override
+    protected void runTask() {
+        lock.lock();
+        try {
+            MapState state = supplier.get();
+            EnvironmentState env = state.environment();
+            float increment = (getIntervalSeconds() * HOURS_PER_DAY) / dayLength;
+            float time = wrap(env.timeOfDay() + increment);
+            consumer.accept(state.toBuilder()
+                    .environment(new EnvironmentState(time, env.season(), env.moonPhase()))
+                    .build());
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private float getIntervalSeconds() {
+        return interval / MS_TO_SECONDS;
+    }
+
+    private static float wrap(final float time) {
+        float t = time % HOURS_PER_DAY;
+        if (t < 0f) {
+            t += HOURS_PER_DAY;
+        }
+        return t;
+    }
+}

--- a/server/src/main/resources/META-INF/services/net.lapidist.colony.mod.GameMod
+++ b/server/src/main/resources/META-INF/services/net.lapidist.colony.mod.GameMod
@@ -12,3 +12,4 @@ net.lapidist.colony.base.BaseItemsMod
 
 net.lapidist.colony.base.BaseGameplaySystemsMod
 net.lapidist.colony.base.BaseSeasonCycleMod
+net.lapidist.colony.base.BaseDayCycleMod

--- a/tests/src/test/java/net/lapidist/colony/tests/server/DayNightCycleServiceTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/DayNightCycleServiceTest.java
@@ -1,0 +1,35 @@
+package net.lapidist.colony.tests.server;
+
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.server.services.DayNightCycleService;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.junit.Assert.assertTrue;
+
+public class DayNightCycleServiceTest {
+    private static final int INTERVAL = 10;
+    private static final int WAIT_MS = 30;
+    private static final float DAY_LENGTH = 0.02f;
+
+    @Test
+    public void advancesTimeOfDay() throws Exception {
+        MapState state = new MapState();
+        AtomicReference<MapState> ref = new AtomicReference<>(state);
+        DayNightCycleService service = new DayNightCycleService(
+                INTERVAL,
+                DAY_LENGTH,
+                ref::get,
+                ref::set,
+                new ReentrantLock()
+        );
+
+        service.start();
+        Thread.sleep(WAIT_MS);
+        service.stop();
+
+        assertTrue(ref.get().environment().timeOfDay() > 0f);
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerBaseSystemsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerBaseSystemsTest.java
@@ -4,6 +4,7 @@ import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.server.GameServerConfig;
 import net.lapidist.colony.server.services.ResourceProductionService;
 import net.lapidist.colony.server.services.SeasonCycleService;
+import net.lapidist.colony.server.services.DayNightCycleService;
 import net.lapidist.colony.io.Paths;
 import org.junit.Test;
 
@@ -41,6 +42,17 @@ public class GameServerBaseSystemsTest {
         server.start();
 
         assertTrue(systems(server).stream().anyMatch(s -> s instanceof SeasonCycleService));
+        server.stop();
+    }
+
+    @Test
+    public void dayNightCycleSystemRegistered() throws Exception {
+        String name = "day-cycle";
+        Paths.get().deleteAutosave(name);
+        GameServer server = new GameServer(GameServerConfig.builder().saveName(name).build());
+        server.start();
+
+        assertTrue(systems(server).stream().anyMatch(s -> s instanceof DayNightCycleService));
         server.stop();
     }
 }


### PR DESCRIPTION
## Summary
- add `DayNightCycleService` to advance environment time
- register new service via `BaseDayCycleMod`
- include mod in service loader list
- ensure server initializes day/night cycle by default
- test service and registration logic

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852fe64f92c8328a50b3930600a0279