### PR TITLE
feat: add light occlusion system

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPlugin.java
+++ b/client/src/main/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPlugin.java
@@ -50,6 +50,11 @@ public final class LightsNormalMapShaderPlugin implements LightingPlugin, Unifor
         return rayHandler;
     }
 
+    /** Current Box2D world used for occlusion bodies. */
+    public World getWorld() {
+        return world;
+    }
+
     @Override
     public String id() {
         return "lights-normalmap";

--- a/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -29,6 +29,7 @@ import net.lapidist.colony.client.systems.network.ResourceUpdateSystem;
 import net.lapidist.colony.client.systems.CelestialSystem;
 import net.lapidist.colony.client.systems.MapInitSystem;
 import net.lapidist.colony.client.systems.MapRenderDataSystem;
+import net.lapidist.colony.client.systems.LightOcclusionSystem;
 import net.lapidist.colony.components.entities.CelestialBodyComponent;
 import net.lapidist.colony.components.state.CameraPosition;
 import net.lapidist.colony.components.state.MutableEnvironmentState;
@@ -229,6 +230,9 @@ public final class MapWorldBuilder {
         builder.with(new PlayerCameraSystem());
 
         ShaderPlugin plugin = new net.lapidist.colony.client.graphics.LightsNormalMapShaderPlugin();
+        if (plugin instanceof net.lapidist.colony.client.graphics.LightsNormalMapShaderPlugin ln) {
+            builder.with(new net.lapidist.colony.client.systems.LightOcclusionSystem(ln.getWorld()));
+        }
 
         World world = new World(builder.build());
         MapRenderSystem renderSystem = world.getSystem(MapRenderSystem.class);
@@ -236,6 +240,12 @@ public final class MapWorldBuilder {
             MapRenderer renderer = actualFactory.create(world, plugin);
             renderSystem.setMapRenderer(renderer);
             renderSystem.setCameraProvider(world.getSystem(PlayerCameraSystem.class));
+            if (plugin instanceof net.lapidist.colony.client.graphics.LightsNormalMapShaderPlugin ln) {
+                LightOcclusionSystem los = world.getSystem(LightOcclusionSystem.class);
+                if (los != null) {
+                    los.setWorld(ln.getWorld());
+                }
+            }
         }
         LightingSystem lightingSystem = world.getSystem(LightingSystem.class);
         if (plugin instanceof net.lapidist.colony.client.graphics.LightsNormalMapShaderPlugin ln

--- a/client/src/main/java/net/lapidist/colony/client/systems/LightOcclusionSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/LightOcclusionSystem.java
@@ -1,0 +1,134 @@
+package net.lapidist.colony.client.systems;
+
+import com.artemis.Aspect;
+import com.artemis.BaseSystem;
+import com.artemis.ComponentMapper;
+import com.artemis.Entity;
+import com.artemis.utils.IntBag;
+import com.badlogic.gdx.physics.box2d.Body;
+import com.badlogic.gdx.physics.box2d.BodyDef;
+import com.badlogic.gdx.physics.box2d.PolygonShape;
+import com.badlogic.gdx.physics.box2d.World;
+import com.badlogic.gdx.utils.Disposable;
+import com.badlogic.gdx.utils.IntMap;
+import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.components.entities.BuildingComponent;
+import net.lapidist.colony.components.entities.PlayerComponent;
+
+/**
+ * Maintains Box2D bodies representing occluders for lights.
+ */
+public final class LightOcclusionSystem extends BaseSystem implements Disposable {
+
+    private final IntMap<Body> buildingBodies = new IntMap<>();
+    private Body playerBody;
+    private World physicsWorld;
+
+    private ComponentMapper<BuildingComponent> buildingMapper;
+    private ComponentMapper<PlayerComponent> playerMapper;
+
+    public LightOcclusionSystem(final World world) {
+        this.physicsWorld = world;
+    }
+
+    /** Update the Box2D world used for bodies. */
+    public void setWorld(final World world) {
+        this.physicsWorld = world;
+    }
+
+    @Override
+    protected void processSystem() {
+        if (physicsWorld == null) {
+            return;
+        }
+        updateBuildings();
+        updatePlayer();
+    }
+
+    private void updateBuildings() {
+        IntBag ids = world.getAspectSubscriptionManager()
+                .get(Aspect.all(BuildingComponent.class))
+                .getEntities();
+        int[] data = ids.getData();
+        for (int i = 0, s = ids.size(); i < s; i++) {
+            int id = data[i];
+            if (!buildingBodies.containsKey(id)) {
+                Entity e = world.getEntity(id);
+                BuildingComponent bc = buildingMapper.get(e);
+                buildingBodies.put(id, createBuildingBody(bc));
+            }
+        }
+        IntMap.Keys keys = buildingBodies.keys();
+        while (keys.hasNext) {
+            int id = keys.next();
+            if (!contains(ids, id)) {
+                Body body = buildingBodies.remove(id);
+                if (body != null) {
+                    physicsWorld.destroyBody(body);
+                }
+            }
+        }
+    }
+
+    private void updatePlayer() {
+        IntBag players = world.getAspectSubscriptionManager()
+                .get(Aspect.all(PlayerComponent.class))
+                .getEntities();
+        if (players.isEmpty()) {
+            return;
+        }
+        Entity player = world.getEntity(players.get(0));
+        PlayerComponent pc = playerMapper.get(player);
+        if (playerBody == null) {
+            BodyDef def = new BodyDef();
+            def.type = BodyDef.BodyType.DynamicBody;
+            playerBody = physicsWorld.createBody(def);
+            PolygonShape shape = new PolygonShape();
+            float half = GameConstants.TILE_SIZE / 2f;
+            shape.setAsBox(half, half);
+            playerBody.createFixture(shape, 0f);
+            shape.dispose();
+        }
+        playerBody.setTransform(pc.getX(), pc.getY(), 0f);
+    }
+
+    private Body createBuildingBody(final BuildingComponent bc) {
+        BodyDef def = new BodyDef();
+        def.type = BodyDef.BodyType.StaticBody;
+        float half = GameConstants.TILE_SIZE / 2f;
+        def.position.set(bc.getX() * GameConstants.TILE_SIZE + half,
+                bc.getY() * GameConstants.TILE_SIZE + half);
+        Body body = physicsWorld.createBody(def);
+        PolygonShape shape = new PolygonShape();
+        shape.setAsBox(half, half);
+        body.createFixture(shape, 0f);
+        shape.dispose();
+        return body;
+    }
+
+    private static boolean contains(final IntBag bag, final int value) {
+        int[] arr = bag.getData();
+        for (int i = 0, s = bag.size(); i < s; i++) {
+            if (arr[i] == value) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void dispose() {
+        if (physicsWorld == null) {
+            return;
+        }
+        IntMap.Values<Body> bodies = buildingBodies.values();
+        while (bodies.hasNext()) {
+            physicsWorld.destroyBody(bodies.next());
+        }
+        buildingBodies.clear();
+        if (playerBody != null) {
+            physicsWorld.destroyBody(playerBody);
+            playerBody = null;
+        }
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/client/systems/LightOcclusionSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/systems/LightOcclusionSystemTest.java
@@ -1,0 +1,71 @@
+package net.lapidist.colony.tests.client.systems;
+
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import com.badlogic.gdx.math.Vector2;
+import net.lapidist.colony.client.systems.LightOcclusionSystem;
+import net.lapidist.colony.components.entities.BuildingComponent;
+import net.lapidist.colony.components.entities.PlayerComponent;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link LightOcclusionSystem}. */
+@RunWith(GdxTestRunner.class)
+public class LightOcclusionSystemTest {
+
+    @Test
+    public void createsAndRemovesBodies() {
+        com.badlogic.gdx.physics.box2d.World box =
+                new com.badlogic.gdx.physics.box2d.World(new Vector2(), false);
+        LightOcclusionSystem system = new LightOcclusionSystem(box);
+        World world = new World(new WorldConfigurationBuilder().with(system).build());
+
+        var building = world.createEntity();
+        BuildingComponent bc = new BuildingComponent();
+        bc.setX(0);
+        bc.setY(0);
+        building.edit().add(bc);
+
+        var player = world.createEntity();
+        PlayerComponent pc = new PlayerComponent();
+        pc.setX(1f);
+        pc.setY(2f);
+        player.edit().add(pc);
+
+        world.process();
+        assertEquals(2, box.getBodyCount());
+
+        building.deleteFromWorld();
+        world.process();
+        assertEquals(1, box.getBodyCount());
+        world.dispose();
+        box.dispose();
+    }
+
+    @Test
+    public void updatesPlayerBodyPosition() {
+        com.badlogic.gdx.physics.box2d.World box =
+                new com.badlogic.gdx.physics.box2d.World(new Vector2(), false);
+        LightOcclusionSystem system = new LightOcclusionSystem(box);
+        World world = new World(new WorldConfigurationBuilder().with(system).build());
+
+        var player = world.createEntity();
+        PlayerComponent pc = new PlayerComponent();
+        pc.setX(3f);
+        pc.setY(4f);
+        player.edit().add(pc);
+
+        world.process();
+        com.badlogic.gdx.utils.Array<com.badlogic.gdx.physics.box2d.Body> bodies =
+                new com.badlogic.gdx.utils.Array<>();
+        box.getBodies(bodies);
+        com.badlogic.gdx.physics.box2d.Body body = bodies.get(0);
+        assertEquals(3f, body.getPosition().x, 0.001f);
+        assertEquals(4f, body.getPosition().y, 0.001f);
+        world.dispose();
+        box.dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- expose Box2D world from `LightsNormalMapShaderPlugin`
- add `LightOcclusionSystem` to create bodies for player and buildings
- register light occlusion system in `MapWorldBuilder`
- test occlusion body creation and removal

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`

------
https://chatgpt.com/codex/tasks/task_e_6852febbe61c8328b9776e1fcc34d893