### PR TITLE
fix: preserve world time in saves

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -164,7 +164,7 @@ public final class MapWorldBuilder {
                 || (graphics.isLightingEnabled() && graphics.isDayNightCycleEnabled());
         LightingSystem lighting = null;
         if (lightingEnabled || dayNightEnabled) {
-            lighting = new LightingSystem(clear, rays);
+            lighting = new LightingSystem(clear, rays, environment);
         }
         WorldConfigurationBuilder builder = new WorldConfigurationBuilder()
                 .with(

--- a/tests/src/test/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPluginTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/graphics/LightsNormalMapShaderPluginTest.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.graphics.Color;
 import net.lapidist.colony.client.systems.ClearScreenSystem;
 import net.lapidist.colony.client.systems.LightingSystem;
+import net.lapidist.colony.components.state.MutableEnvironmentState;
 import com.badlogic.gdx.math.Vector3;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
@@ -38,13 +39,15 @@ public class LightsNormalMapShaderPluginTest {
     @SuppressWarnings("checkstyle:magicnumber")
     public void updatesLightDirectionWhenTimeChanges() {
         LightsNormalMapShaderPlugin plugin = new LightsNormalMapShaderPlugin();
+        MutableEnvironmentState env = new MutableEnvironmentState();
         LightingSystem system = new LightingSystem(
-                new ClearScreenSystem(new Color())
+                new ClearScreenSystem(new Color()),
+                env
         );
         plugin.setLightingSystem(system);
         ShaderProgram shader = mock(ShaderProgram.class);
 
-        system.setTimeOfDay(0f);
+        env.setTimeOfDay(0f);
         plugin.applyUniforms(shader);
         ArgumentCaptor<Vector3> firstCap = ArgumentCaptor.forClass(Vector3.class);
         verify(shader).setUniformf(eq("u_lightDir"), firstCap.capture());
@@ -52,7 +55,7 @@ public class LightsNormalMapShaderPluginTest {
         reset(shader);
 
         final float newTime = 6f;
-        system.setTimeOfDay(newTime);
+        env.setTimeOfDay(newTime);
         plugin.applyUniforms(shader);
         ArgumentCaptor<Vector3> secondCap = ArgumentCaptor.forClass(Vector3.class);
         verify(shader).setUniformf(eq("u_lightDir"), secondCap.capture());

--- a/tests/src/test/java/net/lapidist/colony/tests/client/systems/LightingCycleSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/systems/LightingCycleSystemTest.java
@@ -7,6 +7,7 @@ import com.badlogic.gdx.graphics.Color;
 import net.lapidist.colony.client.systems.ClearScreenSystem;
 import net.lapidist.colony.client.systems.LightingSystem;
 import net.lapidist.colony.tests.GdxTestRunner;
+import net.lapidist.colony.components.state.MutableEnvironmentState;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -26,11 +27,12 @@ public class LightingCycleSystemTest {
     @Test
     public void updatesLightAndColor() {
         ClearScreenSystem clear = new ClearScreenSystem(new Color());
-        LightingSystem lighting = new LightingSystem(clear);
+        MutableEnvironmentState env = new MutableEnvironmentState();
+        LightingSystem lighting = new LightingSystem(clear, env);
         RayHandler handler = mock(RayHandler.class);
         lighting.setRayHandler(handler);
         final float noon = 12f;
-        lighting.setTimeOfDay(noon);
+        env.setTimeOfDay(noon);
         World world = new World(new WorldConfigurationBuilder()
                 .with(clear, lighting)
                 .build());
@@ -38,7 +40,7 @@ public class LightingCycleSystemTest {
         world.process();
         verify(handler).setAmbientLight(0f, 0f, 0f, 1f);
         assertEquals(DAY_RED, clear.getColor().r, TOLERANCE);
-        lighting.setTimeOfDay(0f);
+        env.setTimeOfDay(0f);
         world.process();
         verify(handler).setAmbientLight(NIGHT_AMBIENT, NIGHT_AMBIENT, NIGHT_AMBIENT, 1f);
         assertEquals(NIGHT_RED, clear.getColor().r, TOLERANCE);
@@ -48,9 +50,10 @@ public class LightingCycleSystemTest {
     @Test
     public void wrapsTimeOfDay() {
         ClearScreenSystem clear = new ClearScreenSystem(new Color());
-        LightingSystem lighting = new LightingSystem(clear);
+        MutableEnvironmentState env = new MutableEnvironmentState();
+        LightingSystem lighting = new LightingSystem(clear, env);
         final float wrapValue = 25f;
-        lighting.setTimeOfDay(wrapValue);
+        env.setTimeOfDay(wrapValue);
         World world = new World(new WorldConfigurationBuilder()
                 .with(clear, lighting)
                 .build());

--- a/tests/src/test/java/net/lapidist/colony/tests/client/systems/LightingSunDirectionTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/systems/LightingSunDirectionTest.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.math.Vector3;
 import net.lapidist.colony.client.systems.ClearScreenSystem;
 import net.lapidist.colony.client.systems.LightingSystem;
+import net.lapidist.colony.components.state.MutableEnvironmentState;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,16 +19,18 @@ public class LightingSunDirectionTest {
 
     @Test
     public void midnightBelowHorizon() {
-        LightingSystem lighting = new LightingSystem(new ClearScreenSystem(new Color()));
-        lighting.setTimeOfDay(0f);
+        MutableEnvironmentState env = new MutableEnvironmentState();
+        LightingSystem lighting = new LightingSystem(new ClearScreenSystem(new Color()), env);
+        env.setTimeOfDay(0f);
         Vector3 dir = lighting.getSunDirection(new Vector3());
         assertTrue(dir.z < 0f);
     }
 
     @Test
     public void noonAboveHorizon() {
-        LightingSystem lighting = new LightingSystem(new ClearScreenSystem(new Color()));
-        lighting.setTimeOfDay(NOON);
+        MutableEnvironmentState env = new MutableEnvironmentState();
+        LightingSystem lighting = new LightingSystem(new ClearScreenSystem(new Color()), env);
+        env.setTimeOfDay(NOON);
         Vector3 dir = lighting.getSunDirection(new Vector3());
         assertTrue(dir.z > 0f);
     }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/systems/LightingSystemDynamicTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/systems/LightingSystemDynamicTest.java
@@ -7,6 +7,7 @@ import com.badlogic.gdx.graphics.Color;
 import static org.mockito.Mockito.*;
 import net.lapidist.colony.client.systems.LightingSystem;
 import net.lapidist.colony.client.systems.ClearScreenSystem;
+import net.lapidist.colony.components.state.MutableEnvironmentState;
 import net.lapidist.colony.components.entities.PlayerComponent;
 import net.lapidist.colony.components.light.PointLightComponent;
 import net.lapidist.colony.tests.GdxTestRunner;
@@ -26,7 +27,8 @@ public class LightingSystemDynamicTest {
     public void createsAndRemovesLights() {
         ClearScreenSystem clear = new ClearScreenSystem(new Color());
         LightingSystem.LightFactory factory = (h, c) -> mock(box2dLight.PointLight.class);
-        LightingSystem lighting = new LightingSystem(clear, factory);
+        MutableEnvironmentState env = new MutableEnvironmentState();
+        LightingSystem lighting = new LightingSystem(clear, factory, env);
         World world = new World(new WorldConfigurationBuilder()
                 .with(clear, lighting)
                 .build());
@@ -58,7 +60,8 @@ public class LightingSystemDynamicTest {
     @Test
     public void usesConfiguredRayCount() {
         final int rays = 24;
-        LightingSystem lighting = new LightingSystem(new ClearScreenSystem(new Color()), rays);
+        MutableEnvironmentState env2 = new MutableEnvironmentState();
+        LightingSystem lighting = new LightingSystem(new ClearScreenSystem(new Color()), rays, env2);
         assertEquals(rays, lighting.getRayCount());
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/systems/LightingSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/systems/LightingSystemTest.java
@@ -6,6 +6,7 @@ import com.artemis.WorldConfigurationBuilder;
 import net.lapidist.colony.tests.GdxTestRunner;
 import net.lapidist.colony.client.systems.LightingSystem;
 import net.lapidist.colony.client.systems.ClearScreenSystem;
+import net.lapidist.colony.components.state.MutableEnvironmentState;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -19,7 +20,8 @@ public class LightingSystemTest {
     public void updatesAndDisposesHandler() {
         RayHandler handler = mock(RayHandler.class);
         ClearScreenSystem clear = new ClearScreenSystem(new com.badlogic.gdx.graphics.Color());
-        LightingSystem system = new LightingSystem(clear);
+        MutableEnvironmentState env = new MutableEnvironmentState();
+        LightingSystem system = new LightingSystem(clear, env);
         system.setRayHandler(handler);
 
         World world = new World(new WorldConfigurationBuilder().with(clear, system).build());
@@ -35,7 +37,8 @@ public class LightingSystemTest {
     @Test
     public void skipsWhenHandlerMissing() {
         ClearScreenSystem clear = new ClearScreenSystem(new com.badlogic.gdx.graphics.Color());
-        LightingSystem system = new LightingSystem(clear);
+        MutableEnvironmentState env2 = new MutableEnvironmentState();
+        LightingSystem system = new LightingSystem(clear, env2);
         World world = new World(new WorldConfigurationBuilder().with(clear, system).build());
         world.setDelta(0f);
         world.process();


### PR DESCRIPTION
## Summary
- propagate save's environment state into LightingSystem
- ensure map builder passes environment to lighting
- adjust unit tests for new LightingSystem API

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test codeCoverageReport`

------
https://chatgpt.com/codex/tasks/task_e_6853012b4c90832886988f78a5bbb682