### PR TITLE
fix: update lighting system order

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -231,7 +231,7 @@ public final class MapWorldBuilder {
 
         ShaderPlugin plugin = new net.lapidist.colony.client.graphics.LightsNormalMapShaderPlugin();
         if (plugin instanceof net.lapidist.colony.client.graphics.LightsNormalMapShaderPlugin ln) {
-            builder.with(new net.lapidist.colony.client.systems.LightOcclusionSystem(ln.getWorld()));
+            builder.with(-1, new net.lapidist.colony.client.systems.LightOcclusionSystem(ln.getWorld()));
         }
 
         World world = new World(builder.build());

--- a/tests/src/test/java/net/lapidist/colony/tests/client/systems/LightOcclusionSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/systems/LightOcclusionSystemTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertEquals;
 
 /** Tests for {@link LightOcclusionSystem}. */
 @RunWith(GdxTestRunner.class)
+@SuppressWarnings("checkstyle:magicnumber")
 public class LightOcclusionSystemTest {
 
     @Test


### PR DESCRIPTION
## Summary
- reorder LightOcclusionSystem to run before lighting updates
- suppress magic number warnings in LightOcclusionSystemTest

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685301c8f2808328b39e22549f6cac94