### PR TITLE
fix: order load screen saves by timestamp

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/LoadGameScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/LoadGameScreen.java
@@ -103,11 +103,32 @@ public final class LoadGameScreen extends BaseScreen {
     }
 
     private List<String> listSaves() {
+        List<String> names;
         try {
-            return Paths.get().listAutosaves();
+            names = Paths.get().listAutosaves();
         } catch (IOException e) {
             return new ArrayList<>();
         }
+
+        try {
+            // sort by most recently modified first
+            names.sort((a, b) -> {
+                try {
+                    java.nio.file.Path pa = Paths.get().getAutosave(a);
+                    java.nio.file.Path pb = Paths.get().getAutosave(b);
+                    java.nio.file.attribute.FileTime ta = java.nio.file.Files.getLastModifiedTime(pa);
+                    java.nio.file.attribute.FileTime tb = java.nio.file.Files.getLastModifiedTime(pb);
+                    return -ta.compareTo(tb);
+                } catch (IOException ex) {
+                    // propagate to outer catch block
+                    throw new RuntimeException(ex);
+                }
+            });
+        } catch (RuntimeException e) {
+            names.sort(String::compareTo);
+        }
+
+        return names;
     }
 
 }

--- a/tests/src/test/java/net/lapidist/colony/client/screens/LoadGameScreenOrderingTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/screens/LoadGameScreenOrderingTest.java
@@ -1,0 +1,55 @@
+package net.lapidist.colony.client.screens;
+
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import net.lapidist.colony.client.Colony;
+import net.lapidist.colony.io.Paths;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedConstruction;
+
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+
+@RunWith(GdxTestRunner.class)
+public class LoadGameScreenOrderingTest {
+
+    private static final long OLDER_DELTA = 10_000L;
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void newerSavesAppearFirst() throws Exception {
+        String newer = "newer-" + UUID.randomUUID();
+        String older = "older-" + UUID.randomUUID();
+        Paths.get().createGameFoldersIfNotExists();
+        Path newerFile = Paths.get().getAutosave(newer);
+        Path olderFile = Paths.get().getAutosave(older);
+        Files.writeString(newerFile, "n");
+        Files.writeString(olderFile, "o");
+        long now = System.currentTimeMillis();
+        Files.setLastModifiedTime(newerFile, FileTime.fromMillis(now));
+        Files.setLastModifiedTime(olderFile, FileTime.fromMillis(now - OLDER_DELTA));
+
+        Colony colony = mock(Colony.class);
+        try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
+            LoadGameScreen screen = new LoadGameScreen(colony);
+            Method m = LoadGameScreen.class.getDeclaredMethod("listSaves");
+            m.setAccessible(true);
+            List<String> result = (List<String>) m.invoke(screen);
+            assertEquals(newer, result.get(0));
+            assertEquals(older, result.get(1));
+            screen.dispose();
+        }
+
+        Files.deleteIfExists(newerFile);
+        Files.deleteIfExists(olderFile);
+    }
+}


### PR DESCRIPTION
## Summary
- sort LoadGameScreen saves by last modified time
- test ordering so newer saves appear first

## Testing
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_685317636d9c83289c4bffa0b8f6d6ed