### PR TITLE
fix: preserve custom resolution in settings

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/GraphicsSettingsScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/GraphicsSettingsScreen.java
@@ -59,8 +59,14 @@ public final class GraphicsSettingsScreen extends BaseScreen {
         rendererBox.setItems("sprite");
         rendererBox.setSelected(graphics.getRenderer());
         resolutionBox = new SelectBox<>(getSkin());
-        resolutionBox.setItems("1280x720", "1600x900", "1920x1080");
+        com.badlogic.gdx.utils.Array<String> resolutions = new com.badlogic.gdx.utils.Array<>(new String[] {
+                "1280x720", "1600x900", "1920x1080"
+        });
         String resText = general.getWidth() + "x" + general.getHeight();
+        if (!resolutions.contains(resText, false)) {
+            resolutions.add(resText);
+        }
+        resolutionBox.setItems(resolutions);
         resolutionBox.setSelected(resText);
         fullscreenBox = new CheckBox(I18n.get("graphics.fullscreen"), getSkin());
         fullscreenBox.setChecked(general.isFullscreen());


### PR DESCRIPTION
## Summary
- ensure GraphicsSettingsScreen doesn't discard custom resolutions

## Testing
- `./scripts/check.sh`


------
https://chatgpt.com/codex/tasks/task_e_685323f45bbc8328a917f40bf4d2b9fd