### PR TITLE
feat: add menu key binding

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/KeybindsScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/KeybindsScreen.java
@@ -95,7 +95,7 @@ public final class KeybindsScreen extends BaseScreen {
         getStage().addListener(new InputListener() {
             @Override
             public boolean keyDown(final InputEvent event, final int keycode) {
-                if (awaiting == null && keycode == Input.Keys.ESCAPE) {
+                if (awaiting == null && keycode == bindings.getKey(KeyAction.MENU)) {
                     colony.setScreen(new SettingsScreen(colony));
                     return true;
                 }

--- a/client/src/main/java/net/lapidist/colony/client/screens/MapUiBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapUiBuilder.java
@@ -155,7 +155,7 @@ public final class MapUiBuilder {
         infoTable.add(progressBar).pad(PADDING);
         stage.addActor(infoTable);
 
-        stage.addListener(createStageListener(keyBindings, chatBox, minimapActor, minimapButton));
+        stage.addListener(createStageListener(colony, keyBindings, chatBox, minimapActor, minimapButton));
         return new MapUi(stage, minimapActor, chatBox);
     }
 
@@ -252,6 +252,7 @@ public final class MapUiBuilder {
     }
 
     private static InputListener createStageListener(
+            final Colony colony,
             final KeyBindings keyBindings,
             final ChatBox chatBox,
             final MinimapActor minimapActor,
@@ -270,6 +271,10 @@ public final class MapUiBuilder {
                     minimapButton.setProgrammaticChangeEvents(false);
                     minimapButton.setChecked(visible);
                     minimapButton.setProgrammaticChangeEvents(true);
+                    return true;
+                }
+                if (keycode == keyBindings.getKey(KeyAction.MENU)) {
+                    colony.returnToMainMenu();
                     return true;
                 }
                 return false;

--- a/core/src/main/java/net/lapidist/colony/settings/KeyAction.java
+++ b/core/src/main/java/net/lapidist/colony/settings/KeyAction.java
@@ -13,6 +13,7 @@ public enum KeyAction {
     REMOVE("remove"),
     CHAT("chat"),
     MINIMAP("minimap"),
+    MENU("menu"),
     TOGGLE_CAMERA("toggleCamera"),
     SELECT("select"),
     SELECT_WOOD("selectWood"),

--- a/core/src/main/java/net/lapidist/colony/settings/KeyBindings.java
+++ b/core/src/main/java/net/lapidist/colony/settings/KeyBindings.java
@@ -21,6 +21,7 @@ public final class KeyBindings {
             Map.entry(KeyAction.REMOVE, Input.Keys.R),
             Map.entry(KeyAction.CHAT, Input.Keys.T),
             Map.entry(KeyAction.MINIMAP, Input.Keys.M),
+            Map.entry(KeyAction.MENU, Input.Keys.ESCAPE),
             Map.entry(KeyAction.TOGGLE_CAMERA, Input.Keys.F),
             Map.entry(KeyAction.SELECT, Input.Keys.ENTER),
             Map.entry(KeyAction.SELECT_WOOD, Input.Keys.NUM_1),

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -43,6 +43,7 @@ keybind.build=Build
 keybind.remove=Remove
 keybind.chat=Chat
 keybind.minimap=Minimap
+keybind.menu=Menu
 keybind.toggleCamera=Toggle Camera
 keybind.select=Select
 common.reset=Reset

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -42,6 +42,7 @@ keybind.build=Bauen
 keybind.remove=Entfernen
 keybind.chat=Chat
 keybind.minimap=Minikarte
+keybind.menu=Menü
 keybind.toggleCamera=Kamera Umschalten
 keybind.select=Auswählen
 common.reset=Zurücksetzen

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -42,6 +42,7 @@ keybind.build=Construir
 keybind.remove=Eliminar
 keybind.chat=Chat
 keybind.minimap=Minimapa
+keybind.menu=Menú
 keybind.toggleCamera=Cambiar Cámara
 keybind.select=Seleccionar
 common.reset=Restablecer

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -42,6 +42,7 @@ keybind.build=Construire
 keybind.remove=Supprimer
 keybind.chat=Chat
 keybind.minimap=Mini-carte
+keybind.menu=Menu
 keybind.toggleCamera=Basculer Caméra
 keybind.select=Sélectionner
 common.reset=Réinitialiser

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -15,6 +15,7 @@ This page lists the default keyboard bindings and how to customize them in-game.
 | Chat | **T** | Open the chat input box |
 | Toggle Minimap | **M** | Show or hide the minimap |
 | Toggle Camera | **F** | Switch between map overview and player camera |
+| Menu | **Esc** | Return to the main menu |
 
 The defaults are defined in [`KeyBindings.java`](../core/src/main/java/net/lapidist/colony/settings/KeyBindings.java).
 


### PR DESCRIPTION
## Summary
- add MENU action constant and ESC default key
- listen for the new action and show in Keybinds
- update language files and controls documentation

## Testing
- `./scripts/check.sh`


------
https://chatgpt.com/codex/tasks/task_e_685324f23a848328a80fcd5d52cf2811