### PR TITLE
feat: add customizable UI scale

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/Colony.java
+++ b/client/src/main/java/net/lapidist/colony/client/Colony.java
@@ -100,7 +100,8 @@ public final class Colony extends Game {
                 }
                 setScreen(new ErrorScreen(this, I18n.get("error.connectionFailed")));
             }));
-            LoadingScreen loading = new LoadingScreen();
+            float scale = settings == null ? 1f : settings.getUiScale();
+            LoadingScreen loading = new LoadingScreen(scale);
             loading.setMessage(I18n.get("loading.connect"));
             client.setLoadProgressListener(p -> Gdx.app.postRunnable(() -> loading.setProgress(p)));
             client.setLoadMessageListener(msg -> Gdx.app.postRunnable(() -> loading.setMessage(msg)));

--- a/client/src/main/java/net/lapidist/colony/client/screens/ErrorScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/ErrorScreen.java
@@ -10,6 +10,8 @@ import net.lapidist.colony.client.Colony;
 /** Simple screen that displays an error message with a button to return to the main menu. */
 public final class ErrorScreen extends BaseScreen {
     public ErrorScreen(final Colony colony, final String message) {
+        float scale = colony.getSettings() == null ? 1f : colony.getSettings().getUiScale();
+        getStage().getRoot().setScale(scale);
         Label label = new Label(message, getSkin());
         TextButton back = new TextButton(I18n.get("common.back"), getSkin());
 

--- a/client/src/main/java/net/lapidist/colony/client/screens/GraphicsSettingsScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/GraphicsSettingsScreen.java
@@ -7,6 +7,8 @@ import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
 import com.badlogic.gdx.scenes.scene2d.ui.SelectBox;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
+import com.badlogic.gdx.scenes.scene2d.ui.Slider;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.utils.viewport.ScreenViewport;
 import net.lapidist.colony.client.Colony;
@@ -31,7 +33,13 @@ public final class GraphicsSettingsScreen extends BaseScreen {
     private final CheckBox cacheBox;
     private final CheckBox lightingBox;
     private final CheckBox dayNightBox;
+    private final Slider uiScaleSlider;
+    private final Label uiScaleLabel;
     private static final float PADDING = 10f;
+    private static final float SCALE_MIN = 0.5f;
+    private static final float SCALE_MAX = 2f;
+    private static final float SCALE_STEP = 0.1f;
+    private static final float SLIDER_WIDTH = 150f;
 
     public GraphicsSettingsScreen(final Colony game) {
         this(game, new Stage(new ScreenViewport()));
@@ -40,6 +48,8 @@ public final class GraphicsSettingsScreen extends BaseScreen {
     public GraphicsSettingsScreen(final Colony game, final Stage stage) {
         super(stage);
         this.colony = game;
+        float scale = game.getSettings() == null ? 1f : game.getSettings().getUiScale();
+        stage.getRoot().setScale(scale);
 
         GraphicsSettings graphics = colony.getSettings().getGraphicsSettings();
         net.lapidist.colony.settings.Settings general = colony.getSettings();
@@ -70,6 +80,9 @@ public final class GraphicsSettingsScreen extends BaseScreen {
         lightingBox.setChecked(graphics.isLightingEnabled());
         dayNightBox = new CheckBox(I18n.get("graphics.dayNightCycle"), getSkin());
         dayNightBox.setChecked(graphics.isDayNightCycleEnabled());
+        uiScaleSlider = new Slider(SCALE_MIN, SCALE_MAX, SCALE_STEP, false, getSkin());
+        uiScaleSlider.setValue(general.getUiScale());
+        uiScaleLabel = new Label(I18n.get("graphics.uiScale"), getSkin());
 
         TextButton save = new TextButton(I18n.get("common.save"), getSkin());
         TextButton back = new TextButton(I18n.get("common.back"), getSkin());
@@ -86,6 +99,10 @@ public final class GraphicsSettingsScreen extends BaseScreen {
         options.add(rendererBox).left().row();
         options.add(resolutionBox).left().row();
         options.add(fullscreenBox).left().row();
+        Table scaleRow = new Table();
+        scaleRow.add(uiScaleLabel).padRight(PADDING);
+        scaleRow.add(uiScaleSlider).width(SLIDER_WIDTH);
+        options.add(scaleRow).left().row();
 
         ScrollPane scroll = new ScrollPane(options, getSkin());
         scroll.setScrollingDisabled(true, false);
@@ -113,6 +130,7 @@ public final class GraphicsSettingsScreen extends BaseScreen {
                 general.setWidth(Integer.parseInt(res[0]));
                 general.setHeight(Integer.parseInt(res[1]));
                 general.setFullscreen(fullscreenBox.isChecked());
+                general.setUiScale(uiScaleSlider.getValue());
                 save();
             }
         });

--- a/client/src/main/java/net/lapidist/colony/client/screens/KeybindsScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/KeybindsScreen.java
@@ -34,6 +34,8 @@ public final class KeybindsScreen extends BaseScreen {
     public KeybindsScreen(final Colony game, final Stage stage) {
         super(stage);
         this.colony = game;
+        float scale = game.getSettings() == null ? 1f : game.getSettings().getUiScale();
+        stage.getRoot().setScale(scale);
         KeyBindings bindings = game.getSettings().getKeyBindings();
         Table root = getRoot();
         Table list = new Table();

--- a/client/src/main/java/net/lapidist/colony/client/screens/LoadGameScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/LoadGameScreen.java
@@ -25,6 +25,8 @@ public final class LoadGameScreen extends BaseScreen {
 
     public LoadGameScreen(final Colony game) {
         this.colony = game;
+        float scale = game.getSettings() == null ? 1f : game.getSettings().getUiScale();
+        getStage().getRoot().setScale(scale);
 
         Table list = new Table();
 

--- a/client/src/main/java/net/lapidist/colony/client/screens/LoadingScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/LoadingScreen.java
@@ -19,6 +19,11 @@ public final class LoadingScreen extends BaseScreen {
     private final ProgressBar progressBar;
 
     public LoadingScreen() {
+        this(1f);
+    }
+
+    public LoadingScreen(final float scale) {
+        getStage().getRoot().setScale(scale);
         messageLabel = new Label(I18n.get("loading.title"), getSkin());
         ProgressBarStyle style = new ProgressBarStyle();
         style.background = getSkin().newDrawable("white_pixel", Color.DARK_GRAY);

--- a/client/src/main/java/net/lapidist/colony/client/screens/MainMenuScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MainMenuScreen.java
@@ -21,6 +21,8 @@ public final class MainMenuScreen extends BaseScreen {
 
     public MainMenuScreen(final Colony game) {
         this.colony = game;
+        float scale = game.getSettings() == null ? 1f : game.getSettings().getUiScale();
+        getStage().getRoot().setScale(scale);
 
         Image logo = new Image(new TextureRegionDrawable(new Texture(Gdx.files.internal("textures/logo.png"))));
         TextButton continueButton = new TextButton(I18n.get("main.continue"), getSkin());

--- a/client/src/main/java/net/lapidist/colony/client/screens/MapScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapScreen.java
@@ -24,6 +24,8 @@ public final class MapScreen implements Screen {
     public MapScreen(final Colony colonyToSet, final MapState state, final GameClient client) {
         this.colony = colonyToSet;
         stage = new Stage(new ScreenViewport());
+        float scale = colony.getSettings() == null ? 1f : colony.getSettings().getUiScale();
+        stage.getRoot().setScale(scale);
         world = MapWorldBuilder.build(
                 MapWorldBuilder.builder(
                         state,

--- a/client/src/main/java/net/lapidist/colony/client/screens/ModSelectionScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/ModSelectionScreen.java
@@ -29,6 +29,8 @@ public final class ModSelectionScreen extends BaseScreen {
 
     public ModSelectionScreen(final Colony game) {
         this.colony = game;
+        float scale = game.getSettings() == null ? 1f : game.getSettings().getUiScale();
+        getStage().getRoot().setScale(scale);
         this.mods = game.getMods();
         getRoot().add(new com.badlogic.gdx.scenes.scene2d.ui.Label(
                 I18n.get("modSelect.title"), getSkin())).row();

--- a/client/src/main/java/net/lapidist/colony/client/screens/NewGameScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/NewGameScreen.java
@@ -35,6 +35,8 @@ public final class NewGameScreen extends BaseScreen {
 
     public NewGameScreen(final Colony game) {
         this.colony = game;
+        float scale = game.getSettings() == null ? 1f : game.getSettings().getUiScale();
+        getStage().getRoot().setScale(scale);
 
         Label nameLabel = new Label(I18n.get("newGame.saveName"), getSkin());
         TextField nameField = new TextField("", getSkin());

--- a/client/src/main/java/net/lapidist/colony/client/screens/SettingsScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/SettingsScreen.java
@@ -28,6 +28,8 @@ public final class SettingsScreen extends BaseScreen {
 
     public SettingsScreen(final Colony game) {
         this.colony = game;
+        float scale = game.getSettings() == null ? 1f : game.getSettings().getUiScale();
+        getStage().getRoot().setScale(scale);
         localeIndex = findLocaleIndex(colony.getSettings().getLocale());
         language = new TextButton(getLanguageText(SUPPORTED_LOCALES[localeIndex]), getSkin());
         TextButton keybinds = new TextButton(I18n.get("settings.keybinds"), getSkin());

--- a/core/src/main/java/net/lapidist/colony/settings/Settings.java
+++ b/core/src/main/java/net/lapidist/colony/settings/Settings.java
@@ -15,6 +15,8 @@ public final class Settings {
     private static final String WIDTH_KEY = "width";
     private static final String HEIGHT_KEY = "height";
     private static final String FULLSCREEN_KEY = "fullscreen";
+    private static final String UI_SCALE_KEY = "uiScale";
+    private static final float DEFAULT_UI_SCALE = 1f;
 
     private final KeyBindings keyBindings = new KeyBindings();
     private final GraphicsSettings graphicsSettings = new GraphicsSettings();
@@ -23,6 +25,7 @@ public final class Settings {
     private int width = DEFAULT_WIDTH;
     private int height = DEFAULT_HEIGHT;
     private boolean fullscreen;
+    private float uiScale = DEFAULT_UI_SCALE;
 
     public KeyBindings getKeyBindings() {
         return keyBindings;
@@ -64,6 +67,14 @@ public final class Settings {
         this.fullscreen = fullscreenToSet;
     }
 
+    public float getUiScale() {
+        return uiScale;
+    }
+
+    public void setUiScale(final float scale) {
+        this.uiScale = scale;
+    }
+
     /**
      * Load settings from the configuration file located next to the save folder.
      * Defaults are returned when the file does not exist or cannot be read.
@@ -93,6 +104,10 @@ public final class Settings {
             String heightStr = props.getProperty(HEIGHT_KEY);
             if (heightStr != null) {
                 settings.setHeight(Integer.parseInt(heightStr));
+            }
+            String uiScaleStr = props.getProperty(UI_SCALE_KEY);
+            if (uiScaleStr != null) {
+                settings.setUiScale(Float.parseFloat(uiScaleStr));
             }
             settings.setFullscreen(Boolean.parseBoolean(props.getProperty(FULLSCREEN_KEY, "false")));
             KeyBindings loaded = KeyBindings.load(props);
@@ -137,6 +152,7 @@ public final class Settings {
         props.setProperty(WIDTH_KEY, Integer.toString(width));
         props.setProperty(HEIGHT_KEY, Integer.toString(height));
         props.setProperty(FULLSCREEN_KEY, Boolean.toString(fullscreen));
+        props.setProperty(UI_SCALE_KEY, Float.toString(uiScale));
         keyBindings.save(props);
         graphicsSettings.save(props);
         try (java.io.OutputStream out = java.nio.file.Files.newOutputStream(file)) {

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -69,6 +69,7 @@ graphics.dayNightCycle=Day/Night Cycle
 graphics.lightRays=Light Rays
 graphics.resolution=Resolution
 graphics.fullscreen=Fullscreen
+graphics.uiScale=UI Scale
 common.save=Save
 ui.saving=Saving...
 modSelect.title=Mods

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -68,6 +68,7 @@ graphics.dayNightCycle=Tag-/Nachtzyklus
 graphics.lightRays=Lichtstrahlen
 graphics.resolution=Aufl\u00f6sung
 graphics.fullscreen=Vollbild
+graphics.uiScale=UI-Skalierung
 common.save=Speichern
 ui.saving=Speichern...
 modSelect.title=Mods

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -68,6 +68,7 @@ graphics.dayNightCycle=Ciclo d\u00eda/noche
 graphics.lightRays=Rayos de luz
 graphics.resolution=Resoluci\u00f3n
 graphics.fullscreen=Pantalla completa
+graphics.uiScale=Escala de IU
 common.save=Guardar
 ui.saving=Guardando...
 modSelect.title=Mods

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -68,6 +68,7 @@ graphics.dayNightCycle=Cycle jour/nuit
 graphics.lightRays=Rayons lumineux
 graphics.resolution=R\u00e9solution
 graphics.fullscreen=Plein \u00e9cran
+graphics.uiScale=\u00c9chelle UI
 common.save=Sauvegarder
 ui.saving=Sauvegarde...
 modSelect.title=Mods

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,3 +95,6 @@ height=1080
 fullscreen=false
 ```
 
+`uiScale` controls how large UI elements appear. The default is `1.0` and larger
+values increase the interface size.
+

--- a/tests/src/test/java/net/lapidist/colony/client/screens/LoadGameScreenOrderingTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/screens/LoadGameScreenOrderingTest.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
 
 @RunWith(GdxTestRunner.class)
 public class LoadGameScreenOrderingTest {
@@ -39,6 +40,7 @@ public class LoadGameScreenOrderingTest {
         Files.setLastModifiedTime(olderFile, FileTime.fromMillis(now - OLDER_DELTA));
 
         Colony colony = mock(Colony.class);
+        when(colony.getSettings()).thenReturn(new net.lapidist.colony.settings.Settings());
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
             LoadGameScreen screen = new LoadGameScreen(colony);
             Method m = LoadGameScreen.class.getDeclaredMethod("listSaves");

--- a/tests/src/test/java/net/lapidist/colony/tests/core/settings/SettingsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/settings/SettingsTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 public class SettingsTest {
     private static final int RES_W = 1024;
     private static final int RES_H = 768;
+    private static final float SCALE = 1.5f;
 
     @Test
     public void savesAndLoadsLocale() throws IOException {
@@ -105,11 +106,13 @@ public class SettingsTest {
         settings.setWidth(RES_W);
         settings.setHeight(RES_H);
         settings.setFullscreen(true);
+        settings.setUiScale(SCALE);
         settings.save(paths);
 
         Settings loaded = Settings.load(paths);
         assertEquals(RES_W, loaded.getWidth());
         assertEquals(RES_H, loaded.getHeight());
         assertEquals(true, loaded.isFullscreen());
+        assertEquals(SCALE, loaded.getUiScale(), 0f);
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/LoadGameScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/LoadGameScreenTest.java
@@ -50,6 +50,7 @@ public class LoadGameScreenTest {
     @Test
     public void backButtonReturnsToMainMenu() throws Exception {
         Colony colony = mock(Colony.class);
+        when(colony.getSettings()).thenReturn(new net.lapidist.colony.settings.Settings());
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
             LoadGameScreen screen = new LoadGameScreen(colony);
             Table root = getRoot(screen);
@@ -63,6 +64,7 @@ public class LoadGameScreenTest {
     @Test
     public void escapeReturnsToMainMenu() throws Exception {
         Colony colony = mock(Colony.class);
+        when(colony.getSettings()).thenReturn(new net.lapidist.colony.settings.Settings());
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
             LoadGameScreen screen = new LoadGameScreen(colony);
             Stage stage = getStage(screen);
@@ -89,6 +91,7 @@ public class LoadGameScreenTest {
         GameStateIO.save(state, folder.resolve(save + Paths.AUTOSAVE_SUFFIX));
 
         Colony colony = mock(Colony.class);
+        when(colony.getSettings()).thenReturn(new net.lapidist.colony.settings.Settings());
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
             LoadGameScreen screen = new LoadGameScreen(colony);
             Table list = getList(screen);

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MainMenuScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MainMenuScreenTest.java
@@ -36,6 +36,7 @@ public class MainMenuScreenTest {
     @Test
     public void clickingNewGameOpensNewGameScreen() throws Exception {
         Colony colony = mock(Colony.class);
+        when(colony.getSettings()).thenReturn(new Settings());
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
             MainMenuScreen screen = new MainMenuScreen(colony);
             TextButton newGame = (TextButton) getRoot(screen).getChildren().get(NEW_GAME_INDEX);
@@ -48,6 +49,7 @@ public class MainMenuScreenTest {
     @Test
     public void clickingLoadGameOpensLoadGameScreen() throws Exception {
         Colony colony = mock(Colony.class);
+        when(colony.getSettings()).thenReturn(new Settings());
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
             MainMenuScreen screen = new MainMenuScreen(colony);
             TextButton load = (TextButton) getRoot(screen).getChildren().get(LOAD_GAME_INDEX);

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/NewGameScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/NewGameScreenTest.java
@@ -11,6 +11,7 @@ import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import net.lapidist.colony.client.Colony;
 import net.lapidist.colony.client.screens.MainMenuScreen;
 import net.lapidist.colony.client.screens.NewGameScreen;
+import net.lapidist.colony.settings.Settings;
 import org.mockito.MockedConstruction;
 import net.lapidist.colony.tests.GdxTestRunner;
 import org.junit.Test;
@@ -58,6 +59,7 @@ public class NewGameScreenTest {
     @Test
     public void startButtonBeginsGameWithEnteredName() throws Exception {
         Colony colony = mock(Colony.class);
+        when(colony.getSettings()).thenReturn(new Settings());
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
             NewGameScreen screen = new NewGameScreen(colony);
             Table options = getOptions(screen);
@@ -76,6 +78,7 @@ public class NewGameScreenTest {
     @Test
     public void backButtonReturnsToMainMenu() throws Exception {
         Colony colony = mock(Colony.class);
+        when(colony.getSettings()).thenReturn(new Settings());
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
             NewGameScreen screen = new NewGameScreen(colony);
             Table buttons = getButtons(screen);
@@ -89,6 +92,7 @@ public class NewGameScreenTest {
     @Test
     public void escapeReturnsToMainMenu() throws Exception {
         Colony colony = mock(Colony.class);
+        when(colony.getSettings()).thenReturn(new Settings());
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
             NewGameScreen screen = new NewGameScreen(colony);
             Stage stage = getStage(screen);


### PR DESCRIPTION
## Summary
- persist `uiScale` in settings
- scale the Stage root in all UI screens
- expose UI scale in graphics options
- update translations and docs
- adjust tests for new settings usage

## Testing
- `./gradlew test`
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_685324f6dd088328a38bd22f0348b1ca