### PR TITLE
fix: avoid BuildPlacementSystem NPE

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/systems/BuildPlacementSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/BuildPlacementSystem.java
@@ -78,7 +78,10 @@ public final class BuildPlacementSystem extends BaseSystem {
 
     /** @return currently selected building identifier. */
     public String getSelectedBuilding() {
-        return buildingIds.isEmpty() ? null : buildingIds.get(selectedIndex);
+        if (buildingIds == null || buildingIds.isEmpty()) {
+            return null;
+        }
+        return buildingIds.get(selectedIndex);
     }
 
     @Override

--- a/client/src/main/java/net/lapidist/colony/client/ui/BuildMenuActor.java
+++ b/client/src/main/java/net/lapidist/colony/client/ui/BuildMenuActor.java
@@ -110,12 +110,7 @@ public final class BuildMenuActor extends Table implements Disposable {
                 }
             });
             group.add(button);
-            String current = null;
-            try {
-                current = buildSystem.getSelectedBuilding();
-            } catch (NullPointerException ignore) {
-                // system not initialized
-            }
+            String current = buildSystem.getSelectedBuilding();
             if (current != null && def.id().equalsIgnoreCase(current)) {
                 button.setChecked(true);
             }


### PR DESCRIPTION
## Summary
- prevent NullPointerException in BuildPlacementSystem#getSelectedBuilding
- simplify BuildMenuActor to call the safer getter

## Testing
- `./gradlew clean test`
- `./gradlew codeCoverageReport`

------
https://chatgpt.com/codex/tasks/task_e_685326fc33d48328a943c73a38afdfe4