### PR TITLE
fix: use consistent id for builtin mod

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/ui/BuildMenuActor.java
+++ b/client/src/main/java/net/lapidist/colony/client/ui/BuildMenuActor.java
@@ -42,12 +42,12 @@ public final class BuildMenuActor extends Table implements Disposable {
     private final Texture foodTexture;
 
     public BuildMenuActor(
-            final Skin skin,
+            final Skin skinToUse,
             final BuildPlacementSystem buildSystemToUse,
             final GraphicsSettings graphics
     ) {
         this.buildSystem = buildSystemToUse;
-        this.skin = skin;
+        this.skin = skinToUse;
         setName("buildMenu");
         setFillParent(true);
         bottom().left();

--- a/core/src/main/java/net/lapidist/colony/base/ModMetadataUtil.java
+++ b/core/src/main/java/net/lapidist/colony/base/ModMetadataUtil.java
@@ -19,8 +19,9 @@ public final class ModMetadataUtil {
             Map.entry("net.lapidist.colony.base.BaseItemsMod", "base-items"),
             Map.entry("net.lapidist.colony.base.BaseCommandBusMod", "base-command-bus"),
             Map.entry("net.lapidist.colony.base.BaseGameplaySystemsMod", "base-systems"),
-            Map.entry("net.lapidist.colony.base.BaseSeasonCycleMod", "base-season-cycle")
-    );
+            Map.entry("net.lapidist.colony.base.BaseSeasonCycleMod", "base-season-cycle"),
+            Map.entry("net.lapidist.colony.base.BaseDayCycleMod", "base-day-cycle")
+        );
 
     private ModMetadataUtil() {
     }


### PR DESCRIPTION
## Summary
- add missing metadata entry for BaseDayCycleMod
- avoid Checkstyle hidden field in BuildMenuActor constructor

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68532afc502083288efd3f90c758e35d