### PR TITLE
fix: apply ui scale after returning to map

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/MapScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapScreen.java
@@ -70,6 +70,9 @@ public final class MapScreen implements Screen {
     @Override
     public void resume() {
         events.resume();
+        float scale = colony.getSettings() == null ? 1f : colony.getSettings().getUiScale();
+        stage.getRoot().setScale(scale);
+        events.resize(com.badlogic.gdx.Gdx.graphics.getWidth(), com.badlogic.gdx.Gdx.graphics.getHeight());
     }
 
     @Override
@@ -79,6 +82,9 @@ public final class MapScreen implements Screen {
 
     @Override
     public void show() {
+        float scale = colony.getSettings() == null ? 1f : colony.getSettings().getUiScale();
+        stage.getRoot().setScale(scale);
+        events.resize(com.badlogic.gdx.Gdx.graphics.getWidth(), com.badlogic.gdx.Gdx.graphics.getHeight());
         events.show();
     }
 

--- a/client/src/main/java/net/lapidist/colony/client/ui/BuildMenuActor.java
+++ b/client/src/main/java/net/lapidist/colony/client/ui/BuildMenuActor.java
@@ -42,12 +42,12 @@ public final class BuildMenuActor extends Table implements Disposable {
     private final Texture foodTexture;
 
     public BuildMenuActor(
-            final Skin skin,
+            final Skin skinParam,
             final BuildPlacementSystem buildSystemToUse,
             final GraphicsSettings graphics
     ) {
         this.buildSystem = buildSystemToUse;
-        this.skin = skin;
+        this.skin = skinParam;
         setName("buildMenu");
         setFillParent(true);
         bottom().left();


### PR DESCRIPTION
## Summary
- apply the UI scale whenever the map screen is shown or resumed
- rename BuildMenuActor constructor parameter to avoid Checkstyle issue

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685329cf9c048328a127c83088e57933