### PR TITLE
feat: queue events for batched processing

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,6 +38,12 @@ camera is managed by `PlayerCameraSystem` and the UI by `UISystem`.
 mutate the shared `MapState`. Kryonet handlers convert incoming messages into
 commands processed by these services.
 
+### Event Queue
+
+`Events.dispatch` now queues events instead of sending them immediately. Each
+call to `Events.update` processes up to ten queued events, forwarding them to the
+underlying Artemis `EventSystem` and any listeners.
+
 ### Client ↔ Server Systems
 
 | Client System | Client File | Server Handler | Server File | Purpose |

--- a/tests/src/test/java/net/lapidist/colony/tests/client/ColonyTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/ColonyTest.java
@@ -138,6 +138,7 @@ public class ColonyTest {
             });
 
             colony.create();
+            Events.update();
 
             settingsStatic.verify(Settings::load);
             verify(paths).createGameFoldersIfNotExists();

--- a/tests/src/test/java/net/lapidist/colony/tests/server/DayNightCycleServiceTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/DayNightCycleServiceTest.java
@@ -11,7 +11,6 @@ import static org.junit.Assert.assertTrue;
 
 public class DayNightCycleServiceTest {
     private static final int INTERVAL = 10;
-    private static final int WAIT_MS = 30;
     private static final float DAY_LENGTH = 0.02f;
 
     @Test
@@ -26,10 +25,9 @@ public class DayNightCycleServiceTest {
                 new ReentrantLock()
         );
 
-        service.start();
-        Thread.sleep(WAIT_MS);
-        service.stop();
-
+        java.lang.reflect.Method run = DayNightCycleService.class.getDeclaredMethod("runTask");
+        run.setAccessible(true);
+        run.invoke(service);
         assertTrue(ref.get().environment().timeOfDay() > 0f);
     }
 }


### PR DESCRIPTION
## Summary
- queue game events using ArrayDeque
- batch dispatch queued events when calling update()
- adjust unit tests for queued dispatch behavior
- document event queue in architecture docs

## Testing
- `./scripts/check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6853390bdee08328ac144b69d9e0e7f4