### PR TITLE
feat: add map coordinate utils

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
+++ b/client/src/main/java/net/lapidist/colony/client/network/GameClient.java
@@ -13,6 +13,7 @@ import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.ChunkPos;
 import net.lapidist.colony.map.MapChunkData;
+import net.lapidist.colony.map.MapCoordinateUtils;
 import net.lapidist.colony.components.state.MapChunkRequest;
 import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.network.ChatMessage;
@@ -281,10 +282,10 @@ public final class GameClient extends AbstractMessageEndpoint implements AutoClo
         for (var entry : tiles.entrySet()) {
             TilePos pos = entry.getKey();
             TileData data = entry.getValue();
-            int chunkX = Math.floorDiv(pos.x(), MapChunkData.CHUNK_SIZE);
-            int chunkY = Math.floorDiv(pos.y(), MapChunkData.CHUNK_SIZE);
-            int localX = Math.floorMod(pos.x(), MapChunkData.CHUNK_SIZE);
-            int localY = Math.floorMod(pos.y(), MapChunkData.CHUNK_SIZE);
+            int chunkX = MapCoordinateUtils.toChunkCoord(pos.x());
+            int chunkY = MapCoordinateUtils.toChunkCoord(pos.y());
+            int localX = MapCoordinateUtils.toLocalCoord(pos.x());
+            int localY = MapCoordinateUtils.toLocalCoord(pos.y());
             ChunkPos posKey = new ChunkPos(chunkX, chunkY);
             MapChunkData chunk = chunks.computeIfAbsent(posKey, p -> new MapChunkData(chunkX, chunkY));
             chunk.getTiles().put(new TilePos(localX, localY), data);
@@ -332,8 +333,8 @@ public final class GameClient extends AbstractMessageEndpoint implements AutoClo
         }
         for (var entry : chunk.getTiles().entrySet()) {
             TileData td = entry.getValue();
-            int localX = Math.floorMod(td.x(), MapChunkData.CHUNK_SIZE);
-            int localY = Math.floorMod(td.y(), MapChunkData.CHUNK_SIZE);
+            int localX = MapCoordinateUtils.toLocalCoord(td.x());
+            int localY = MapCoordinateUtils.toLocalCoord(td.y());
             data.getTiles().put(new TilePos(localX, localY), td);
         }
     }

--- a/client/src/main/java/net/lapidist/colony/client/network/handlers/ResourceUpdateHandler.java
+++ b/client/src/main/java/net/lapidist/colony/client/network/handlers/ResourceUpdateHandler.java
@@ -5,7 +5,7 @@ import net.lapidist.colony.components.state.ResourceData;
 import net.lapidist.colony.components.state.ResourceUpdateData;
 import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.TilePos;
-import net.lapidist.colony.map.MapChunkData;
+import net.lapidist.colony.map.MapCoordinateUtils;
 import net.lapidist.colony.network.AbstractMessageHandler;
 
 import java.util.Map;
@@ -51,11 +51,12 @@ public final class ResourceUpdateHandler extends AbstractMessageHandler<Resource
                 TileData newTile = tile.toBuilder()
                         .resources(new ResourceData(new java.util.HashMap<>(message.amounts())))
                         .build();
-                int chunkX = Math.floorDiv(pos.x(), MapChunkData.CHUNK_SIZE);
-                int chunkY = Math.floorDiv(pos.y(), MapChunkData.CHUNK_SIZE);
-                int localX = Math.floorMod(pos.x(), MapChunkData.CHUNK_SIZE);
-                int localY = Math.floorMod(pos.y(), MapChunkData.CHUNK_SIZE);
-                state.getOrCreateChunk(chunkX, chunkY).getTiles().put(new TilePos(localX, localY), newTile);
+                int chunkX = MapCoordinateUtils.toChunkCoord(pos.x());
+                int chunkY = MapCoordinateUtils.toChunkCoord(pos.y());
+                int localX = MapCoordinateUtils.toLocalCoord(pos.x());
+                int localY = MapCoordinateUtils.toLocalCoord(pos.y());
+                state.getOrCreateChunk(chunkX, chunkY).getTiles()
+                        .put(new TilePos(localX, localY), newTile);
             }
         }
     }

--- a/client/src/main/java/net/lapidist/colony/client/systems/ChunkLoadSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/ChunkLoadSystem.java
@@ -6,7 +6,7 @@ import net.lapidist.colony.client.network.GameClient;
 import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.components.state.MapChunkRequest;
 import net.lapidist.colony.components.state.ChunkPos;
-import net.lapidist.colony.map.MapChunkData;
+import net.lapidist.colony.map.MapCoordinateUtils;
 import net.lapidist.colony.components.state.MapState;
 
 /**
@@ -40,16 +40,16 @@ public final class ChunkLoadSystem extends BaseSystem {
             return;
         }
         if (!requestedInitial && state.playerPos() != null) {
-            int cx = Math.floorDiv(state.playerPos().x(), MapChunkData.CHUNK_SIZE);
-            int cy = Math.floorDiv(state.playerPos().y(), MapChunkData.CHUNK_SIZE);
+            int cx = MapCoordinateUtils.toChunkCoord(state.playerPos().x());
+            int cy = MapCoordinateUtils.toChunkCoord(state.playerPos().y());
             client.send(new MapChunkRequest(cx, cy));
             requestedInitial = true;
         }
         view.set(cameraSystem.getViewBounds());
         int centerX = Math.round(view.x + view.width / 2f) / GameConstants.TILE_SIZE;
         int centerY = Math.round(view.y + view.height / 2f) / GameConstants.TILE_SIZE;
-        int chunkX = Math.floorDiv(centerX, MapChunkData.CHUNK_SIZE);
-        int chunkY = Math.floorDiv(centerY, MapChunkData.CHUNK_SIZE);
+        int chunkX = MapCoordinateUtils.toChunkCoord(centerX);
+        int chunkY = MapCoordinateUtils.toChunkCoord(centerY);
         int radius = GameConstants.CHUNK_LOAD_RADIUS;
         for (int x = chunkX - radius; x <= chunkX + radius; x++) {
             for (int y = chunkY - radius; y <= chunkY + radius; y++) {

--- a/core/src/main/java/net/lapidist/colony/components/state/MapState.java
+++ b/core/src/main/java/net/lapidist/colony/components/state/MapState.java
@@ -4,6 +4,7 @@ import net.lapidist.colony.serialization.KryoType;
 import net.lapidist.colony.save.SaveVersion;
 
 import net.lapidist.colony.map.MapChunkData;
+import net.lapidist.colony.map.MapCoordinateUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -65,18 +66,18 @@ public record MapState(
     }
 
     public TileData getTile(final int x, final int y) {
-        int chunkX = Math.floorDiv(x, MapChunkData.CHUNK_SIZE);
-        int chunkY = Math.floorDiv(y, MapChunkData.CHUNK_SIZE);
-        int localX = Math.floorMod(x, MapChunkData.CHUNK_SIZE);
-        int localY = Math.floorMod(y, MapChunkData.CHUNK_SIZE);
+        int chunkX = MapCoordinateUtils.toChunkCoord(x);
+        int chunkY = MapCoordinateUtils.toChunkCoord(y);
+        int localX = MapCoordinateUtils.toLocalCoord(x);
+        int localY = MapCoordinateUtils.toLocalCoord(y);
         return getOrCreateChunk(chunkX, chunkY).getTile(localX, localY);
     }
 
     public void putTile(final TileData tile) {
-        int chunkX = Math.floorDiv(tile.x(), MapChunkData.CHUNK_SIZE);
-        int chunkY = Math.floorDiv(tile.y(), MapChunkData.CHUNK_SIZE);
-        int localX = Math.floorMod(tile.x(), MapChunkData.CHUNK_SIZE);
-        int localY = Math.floorMod(tile.y(), MapChunkData.CHUNK_SIZE);
+        int chunkX = MapCoordinateUtils.toChunkCoord(tile.x());
+        int chunkY = MapCoordinateUtils.toChunkCoord(tile.y());
+        int localX = MapCoordinateUtils.toLocalCoord(tile.x());
+        int localY = MapCoordinateUtils.toLocalCoord(tile.y());
         getOrCreateChunk(chunkX, chunkY).getTiles().put(new TilePos(localX, localY), tile);
     }
 
@@ -95,10 +96,10 @@ public record MapState(
 
         @Override
         public TileData put(final TilePos key, final TileData value) {
-            int chunkX = Math.floorDiv(key.x(), MapChunkData.CHUNK_SIZE);
-            int chunkY = Math.floorDiv(key.y(), MapChunkData.CHUNK_SIZE);
-            int localX = Math.floorMod(key.x(), MapChunkData.CHUNK_SIZE);
-            int localY = Math.floorMod(key.y(), MapChunkData.CHUNK_SIZE);
+            int chunkX = MapCoordinateUtils.toChunkCoord(key.x());
+            int chunkY = MapCoordinateUtils.toChunkCoord(key.y());
+            int localX = MapCoordinateUtils.toLocalCoord(key.x());
+            int localY = MapCoordinateUtils.toLocalCoord(key.y());
             return MapState.this.getOrCreateChunk(chunkX, chunkY)
                     .getTiles()
                     .put(new TilePos(localX, localY), value);

--- a/core/src/main/java/net/lapidist/colony/map/MapCoordinateUtils.java
+++ b/core/src/main/java/net/lapidist/colony/map/MapCoordinateUtils.java
@@ -1,0 +1,57 @@
+package net.lapidist.colony.map;
+
+import net.lapidist.colony.components.state.ChunkPos;
+import net.lapidist.colony.components.state.TilePos;
+
+/**
+ * Utility methods for converting world tile coordinates to chunk coordinates
+ * and local chunk positions.
+ */
+public final class MapCoordinateUtils {
+
+    private MapCoordinateUtils() { }
+
+    /**
+     * Converts a world tile coordinate to its containing chunk coordinate.
+     *
+     * @param worldCoord world tile coordinate
+     * @return chunk coordinate index
+     */
+    public static int toChunkCoord(final int worldCoord) {
+        return Math.floorDiv(worldCoord, MapChunkData.CHUNK_SIZE);
+    }
+
+    /**
+     * Converts a world tile coordinate to the local coordinate inside its chunk.
+     *
+     * @param worldCoord world tile coordinate
+     * @return local coordinate within the chunk
+     */
+    public static int toLocalCoord(final int worldCoord) {
+        return Math.floorMod(worldCoord, MapChunkData.CHUNK_SIZE);
+    }
+
+    /**
+     * Converts world tile coordinates to a {@link ChunkPos} identifying the
+     * containing chunk.
+     *
+     * @param worldX world tile x coordinate
+     * @param worldY world tile y coordinate
+     * @return chunk position
+     */
+    public static ChunkPos toChunkPos(final int worldX, final int worldY) {
+        return new ChunkPos(toChunkCoord(worldX), toChunkCoord(worldY));
+    }
+
+    /**
+     * Converts world tile coordinates to a {@link TilePos} representing the
+     * local coordinates within the chunk.
+     *
+     * @param worldX world tile x coordinate
+     * @param worldY world tile y coordinate
+     * @return local tile position inside the chunk
+     */
+    public static TilePos toLocalPos(final int worldX, final int worldY) {
+        return new TilePos(toLocalCoord(worldX), toLocalCoord(worldY));
+    }
+}

--- a/core/src/main/java/net/lapidist/colony/save/V6ToV7Migration.java
+++ b/core/src/main/java/net/lapidist/colony/save/V6ToV7Migration.java
@@ -5,6 +5,7 @@ import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.TilePos;
 import net.lapidist.colony.components.state.ChunkPos;
 import net.lapidist.colony.map.MapChunkData;
+import net.lapidist.colony.map.MapCoordinateUtils;
 
 import java.util.Map;
 
@@ -31,10 +32,10 @@ public final class V6ToV7Migration implements MapStateMigration {
             Object key = e.getKey();
             Object value = e.getValue();
             if (key instanceof TilePos pos && value instanceof TileData tile) {
-                int chunkX = Math.floorDiv(pos.x(), MapChunkData.CHUNK_SIZE);
-                int chunkY = Math.floorDiv(pos.y(), MapChunkData.CHUNK_SIZE);
-                int localX = Math.floorMod(pos.x(), MapChunkData.CHUNK_SIZE);
-                int localY = Math.floorMod(pos.y(), MapChunkData.CHUNK_SIZE);
+                int chunkX = MapCoordinateUtils.toChunkCoord(pos.x());
+                int chunkY = MapCoordinateUtils.toChunkCoord(pos.y());
+                int localX = MapCoordinateUtils.toLocalCoord(pos.x());
+                int localY = MapCoordinateUtils.toLocalCoord(pos.y());
                 ChunkPos cp = new ChunkPos(chunkX, chunkY);
                 MapChunkData chunk = chunks.computeIfAbsent(cp, p -> new MapChunkData(chunkX, chunkY));
                 chunk.getTiles().put(new TilePos(localX, localY), tile);

--- a/server/src/main/java/net/lapidist/colony/server/commands/GatherCommandHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/GatherCommandHandler.java
@@ -5,7 +5,7 @@ import net.lapidist.colony.components.state.ResourceData;
 import net.lapidist.colony.components.state.ResourceUpdateData;
 import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.TilePos;
-import net.lapidist.colony.map.MapChunkData;
+import net.lapidist.colony.map.MapCoordinateUtils;
 import net.lapidist.colony.server.services.NetworkService;
 import net.lapidist.colony.server.services.InventoryService;
 import net.lapidist.colony.registry.Registries;
@@ -59,11 +59,12 @@ public final class GatherCommandHandler implements CommandHandler<GatherCommand>
             amounts.put(command.resourceId(), updatedValue);
             ResourceData updated = new ResourceData(new java.util.HashMap<>(amounts));
             TileData newTile = tile.toBuilder().resources(updated).build();
-            int chunkX = Math.floorDiv(command.x(), MapChunkData.CHUNK_SIZE);
-            int chunkY = Math.floorDiv(command.y(), MapChunkData.CHUNK_SIZE);
-            int localX = Math.floorMod(command.x(), MapChunkData.CHUNK_SIZE);
-            int localY = Math.floorMod(command.y(), MapChunkData.CHUNK_SIZE);
-            state.getOrCreateChunk(chunkX, chunkY).getTiles().put(new TilePos(localX, localY), newTile);
+            int chunkX = MapCoordinateUtils.toChunkCoord(command.x());
+            int chunkY = MapCoordinateUtils.toChunkCoord(command.y());
+            int localX = MapCoordinateUtils.toLocalCoord(command.x());
+            int localY = MapCoordinateUtils.toLocalCoord(command.y());
+            state.getOrCreateChunk(chunkX, chunkY).getTiles()
+                    .put(new TilePos(localX, localY), newTile);
             ResourceData player = state.playerResources();
             java.util.Map<String, Integer> playerAmounts = new java.util.HashMap<>(player.amounts());
             playerAmounts.merge(command.resourceId(), current - updatedValue, Integer::sum);

--- a/server/src/main/java/net/lapidist/colony/server/commands/TileSelectionCommandHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/TileSelectionCommandHandler.java
@@ -3,7 +3,7 @@ package net.lapidist.colony.server.commands;
 import net.lapidist.colony.components.state.MapState;
 import net.lapidist.colony.components.state.TileData;
 import net.lapidist.colony.components.state.TilePos;
-import net.lapidist.colony.map.MapChunkData;
+import net.lapidist.colony.map.MapCoordinateUtils;
 import net.lapidist.colony.components.state.TileSelectionData;
 import net.lapidist.colony.events.Events;
 import net.lapidist.colony.server.events.TileSelectionEvent;
@@ -41,11 +41,12 @@ public final class TileSelectionCommandHandler implements CommandHandler<TileSel
             TileData tile = state.getTile(command.x(), command.y());
             if (tile != null) {
                 TileData updated = tile.toBuilder().selected(command.selected()).build();
-                int chunkX = Math.floorDiv(command.x(), MapChunkData.CHUNK_SIZE);
-                int chunkY = Math.floorDiv(command.y(), MapChunkData.CHUNK_SIZE);
-                int localX = Math.floorMod(command.x(), MapChunkData.CHUNK_SIZE);
-                int localY = Math.floorMod(command.y(), MapChunkData.CHUNK_SIZE);
-                state.getOrCreateChunk(chunkX, chunkY).getTiles().put(new TilePos(localX, localY), updated);
+                int chunkX = MapCoordinateUtils.toChunkCoord(command.x());
+                int chunkY = MapCoordinateUtils.toChunkCoord(command.y());
+                int localX = MapCoordinateUtils.toLocalCoord(command.x());
+                int localY = MapCoordinateUtils.toLocalCoord(command.y());
+                state.getOrCreateChunk(chunkX, chunkY).getTiles()
+                        .put(new TilePos(localX, localY), updated);
             }
             Events.dispatch(new TileSelectionEvent(command.x(), command.y(), command.selected()));
             networkService.broadcast(new TileSelectionData(command.x(), command.y(), command.selected()));

--- a/server/src/main/java/net/lapidist/colony/server/services/NetworkService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/NetworkService.java
@@ -9,6 +9,7 @@ import net.lapidist.colony.components.state.MapChunkBytes;
 import net.lapidist.colony.components.state.MapMetadata;
 import net.lapidist.colony.components.GameConstants;
 import net.lapidist.colony.map.MapChunkData;
+import net.lapidist.colony.map.MapCoordinateUtils;
 import net.lapidist.colony.network.DispatchListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -108,8 +109,8 @@ public final class NetworkService {
         if (state.playerPos() == null) {
             return;
         }
-        int chunkX = Math.floorDiv(state.playerPos().x(), MapChunkData.CHUNK_SIZE);
-        int chunkY = Math.floorDiv(state.playerPos().y(), MapChunkData.CHUNK_SIZE);
+        int chunkX = MapCoordinateUtils.toChunkCoord(state.playerPos().x());
+        int chunkY = MapCoordinateUtils.toChunkCoord(state.playerPos().y());
         int radius = GameConstants.CHUNK_LOAD_RADIUS;
         int sent = 0;
         for (int x = chunkX - radius; x <= chunkX + radius; x++) {

--- a/tests/src/test/java/net/lapidist/colony/tests/map/MapCoordinateUtilsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/map/MapCoordinateUtilsTest.java
@@ -1,0 +1,44 @@
+package net.lapidist.colony.tests.map;
+
+import net.lapidist.colony.map.MapCoordinateUtils;
+import net.lapidist.colony.map.MapChunkData;
+import net.lapidist.colony.components.state.ChunkPos;
+import net.lapidist.colony.components.state.TilePos;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MapCoordinateUtilsTest {
+    private static final int WORLD_X = MapChunkData.CHUNK_SIZE * 2 + 5;
+    private static final int WORLD_Y = MapChunkData.CHUNK_SIZE * 3 + 7;
+    private static final int NEG_X = -5;
+    private static final int NEG_Y = -1;
+    private static final int EXPECT_CHUNK_X = 2;
+    private static final int EXPECT_CHUNK_Y = 3;
+    private static final int EXPECT_LOCAL_X = 5;
+    private static final int EXPECT_LOCAL_Y = 7;
+    private static final int EXPECT_NEG_CHUNK = -1;
+
+    @Test
+    public void convertsWorldCoordinates() {
+        assertEquals(EXPECT_CHUNK_X, MapCoordinateUtils.toChunkCoord(WORLD_X));
+        assertEquals(EXPECT_CHUNK_Y, MapCoordinateUtils.toChunkCoord(WORLD_Y));
+        assertEquals(EXPECT_LOCAL_X, MapCoordinateUtils.toLocalCoord(WORLD_X));
+        assertEquals(EXPECT_LOCAL_Y, MapCoordinateUtils.toLocalCoord(WORLD_Y));
+
+        ChunkPos chunk = MapCoordinateUtils.toChunkPos(WORLD_X, WORLD_Y);
+        TilePos local = MapCoordinateUtils.toLocalPos(WORLD_X, WORLD_Y);
+        assertEquals(EXPECT_CHUNK_X, chunk.x());
+        assertEquals(EXPECT_CHUNK_Y, chunk.y());
+        assertEquals(EXPECT_LOCAL_X, local.x());
+        assertEquals(EXPECT_LOCAL_Y, local.y());
+    }
+
+    @Test
+    public void handlesNegativeCoordinates() {
+        assertEquals(EXPECT_NEG_CHUNK, MapCoordinateUtils.toChunkCoord(NEG_X));
+        assertEquals(EXPECT_NEG_CHUNK, MapCoordinateUtils.toChunkCoord(NEG_Y));
+        assertEquals(MapChunkData.CHUNK_SIZE - EXPECT_LOCAL_X, MapCoordinateUtils.toLocalCoord(NEG_X));
+        assertEquals(MapChunkData.CHUNK_SIZE - 1, MapCoordinateUtils.toLocalCoord(NEG_Y));
+    }
+}


### PR DESCRIPTION
## Summary
- add `MapCoordinateUtils` for world to chunk conversions
- use utility in server command handlers and network service
- apply it in client systems and handlers
- update map state logic
- cover coordinate conversions with unit tests

## Testing
- `./scripts/check.sh`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_6853392aee948328afb6ef4c9ef1ae5f