### PR TITLE
feat: load maps asynchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Scenario test utilities are covered in [docs/tests.md](docs/tests.md).
 Developer build steps are summarized in [docs/developer_workflow.md](docs/developer_workflow.md).
 Shader plugins are described in [docs/shaders.md](docs/shaders.md).
 The asset pipeline is documented in [docs/asset_pipeline.md](docs/asset_pipeline.md).
+Asynchronous loading hooks are covered in [docs/background_tasks.md](docs/background_tasks.md).
 
 ## License
 This project is licensed under the [MIT License](LICENSE).

--- a/client/src/main/java/net/lapidist/colony/client/screens/MapScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapScreen.java
@@ -7,6 +7,7 @@ import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.utils.viewport.ScreenViewport;
 import net.lapidist.colony.client.Colony;
 import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.client.systems.MapInitSystem;
 import net.lapidist.colony.client.ui.MinimapActor;
 import net.lapidist.colony.components.state.MapState;
 
@@ -37,6 +38,15 @@ public final class MapScreen implements Screen {
     }
 
     public MapScreen(final Colony colonyToSet, final MapState state, final GameClient client) {
+        this(colonyToSet, state, client, null);
+    }
+
+    public MapScreen(
+            final Colony colonyToSet,
+            final MapState state,
+            final GameClient client,
+            final java.util.function.Consumer<Float> callback
+    ) {
         this.colony = colonyToSet;
         stage = new Stage(new ScreenViewport());
         applyScale();
@@ -46,7 +56,8 @@ public final class MapScreen implements Screen {
                         client,
                         stage,
                         colony.getSettings().getKeyBindings(),
-                        colony.getSettings().getGraphicsSettings()
+                        colony.getSettings().getGraphicsSettings(),
+                        callback
                 ),
                 null,
                 colony.getSettings(),
@@ -69,10 +80,15 @@ public final class MapScreen implements Screen {
     public void render(final float deltaTime) {
         events.update();
         accumulator += deltaTime;
+        MapInitSystem init = world.getSystem(MapInitSystem.class);
+        boolean loading = init != null && !init.isReady();
         while (accumulator >= STEP_TIME) {
             world.setDelta((float) STEP_TIME);
             world.process();
             accumulator -= STEP_TIME;
+            if (loading) {
+                break;
+            }
         }
     }
 

--- a/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -97,7 +97,7 @@ public final class MapWorldBuilder {
         MapState state = MapState.builder()
                 .playerResources(playerResources)
                 .build();
-        return createBuilder(client, stage, keyBindings, null, state, graphics);
+        return createBuilder(client, stage, keyBindings, null, state, graphics, null);
     }
 
     /**
@@ -114,9 +114,10 @@ public final class MapWorldBuilder {
             final GameClient client,
             final Stage stage,
             final KeyBindings keyBindings,
-            final GraphicsSettings graphics
+            final GraphicsSettings graphics,
+            final java.util.function.Consumer<Float> callback
     ) {
-        return createBuilder(client, stage, keyBindings, provider, new MapState(), graphics);
+        return createBuilder(client, stage, keyBindings, provider, new MapState(), graphics, callback);
     }
 
     /**
@@ -127,7 +128,8 @@ public final class MapWorldBuilder {
             final GameClient client,
             final Stage stage,
             final KeyBindings keyBindings,
-            final GraphicsSettings graphics
+            final GraphicsSettings graphics,
+            final java.util.function.Consumer<Float> callback
     ) {
         return createBuilder(
                 client,
@@ -135,7 +137,8 @@ public final class MapWorldBuilder {
                 keyBindings,
                 new ProvidedMapStateProvider(state),
                 state,
-                graphics
+                graphics,
+                callback
         );
     }
 
@@ -145,7 +148,8 @@ public final class MapWorldBuilder {
             final KeyBindings keyBindings,
             final MapStateProvider provider,
             final MapState state,
-            final GraphicsSettings graphics
+            final GraphicsSettings graphics,
+            final java.util.function.Consumer<Float> callback
     ) {
         ResourceData playerResources = state.playerResources();
         PlayerPosition playerPos = state.playerPos();
@@ -194,7 +198,7 @@ public final class MapWorldBuilder {
 
         if (provider != null) {
             builder.with(
-                    new MapInitSystem(provider),
+                    new MapInitSystem(provider, true, callback),
                     new MapRenderDataSystem(client)
             );
         }

--- a/client/src/main/java/net/lapidist/colony/client/systems/MapInitSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/MapInitSystem.java
@@ -3,24 +3,68 @@ package net.lapidist.colony.client.systems;
 import com.artemis.BaseSystem;
 import net.lapidist.colony.map.MapFactory;
 import net.lapidist.colony.map.MapStateProvider;
+import net.lapidist.colony.components.state.MapState;
+
+import java.util.function.Consumer;
 
 /**
  * Initializes the game world using a {@link MapStateProvider}.
  */
 public class MapInitSystem extends BaseSystem {
     private final MapStateProvider provider;
+    private final boolean async;
+    private final Consumer<Float> progressCallback;
+    private volatile boolean ready;
+    private MapState pendingState;
+    private Thread worker;
 
     public MapInitSystem(final MapStateProvider providerToSet) {
+        this(providerToSet, false, null);
+    }
+
+    public MapInitSystem(
+            final MapStateProvider providerToSet,
+            final boolean asyncFlag,
+            final Consumer<Float> callback
+    ) {
         this.provider = providerToSet;
+        this.async = asyncFlag;
+        this.progressCallback = callback;
     }
 
     @Override
     public final void initialize() {
-        MapFactory.create(world, provider.provide());
+        ready = false;
+        if (async) {
+            worker = new Thread(() -> {
+                if (progressCallback != null) {
+                    progressCallback.accept(0f);
+                }
+                pendingState = provider.provide();
+                if (progressCallback != null) {
+                    progressCallback.accept(1f);
+                }
+            }, "map-init");
+            worker.setDaemon(true);
+            worker.start();
+        } else {
+            MapFactory.create(world, provider.provide());
+            ready = true;
+        }
     }
 
     @Override
     protected final void processSystem() {
-        // initialization occurs once in initialize
+        if (async && pendingState != null) {
+            MapFactory.create(world, pendingState);
+            pendingState = null;
+            ready = true;
+        }
+        // initialization occurs once
+    }
+
+    /** Indicates whether the map has been created. */
+    public boolean isReady() {
+        return ready;
     }
 }

--- a/docs/background_tasks.md
+++ b/docs/background_tasks.md
@@ -1,0 +1,24 @@
+# Background Tasks
+
+Some operations such as map generation and mod initialization can take several seconds.
+`MapInitSystem` now supports asynchronous loading when constructed with `async` enabled.
+Provide a progress callback to receive updates between `0` and `1` as the map state
+is generated. `MapScreen` polls this system during the loading phase and processes
+the world once initialization completes.
+
+Use `MapWorldBuilder.builder` with the new callback parameter to create a world
+that reports loading progress:
+
+```java
+WorldConfigurationBuilder builder = MapWorldBuilder.builder(
+        provider,
+        client,
+        stage,
+        keys,
+        graphics,
+        progress -> loadingScreen.setProgress(progress)
+);
+```
+
+The default constructors remain synchronous for tests and simple cases.
+

--- a/tests/src/test/java/net/lapidist/colony/tests/async/MapInitSystemAsyncTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/async/MapInitSystemAsyncTest.java
@@ -1,0 +1,51 @@
+package net.lapidist.colony.tests.async;
+
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import net.lapidist.colony.client.systems.MapInitSystem;
+import net.lapidist.colony.components.maps.MapComponent;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.TileData;
+import net.lapidist.colony.map.ProvidedMapStateProvider;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MapInitSystemAsyncTest {
+
+    private static final int WAIT_MS = 1000;
+    private static final int SLEEP_MS = 10;
+
+    @Test
+    public void generatesMapInBackground() throws Exception {
+        new net.lapidist.colony.base.BaseDefinitionsMod().init();
+        MapState state = new MapState();
+        state.putTile(TileData.builder()
+                .x(0)
+                .y(0)
+                .tileType("GRASS")
+                .passable(true)
+                .build());
+        AtomicBoolean done = new AtomicBoolean(false);
+        MapInitSystem init = new MapInitSystem(new ProvidedMapStateProvider(state), true, p -> {
+            if (p == 1f) {
+                done.set(true);
+            }
+        });
+        World world = new World(new WorldConfigurationBuilder().with(init).build());
+        long wait = System.currentTimeMillis() + WAIT_MS;
+        while (!init.isReady() && System.currentTimeMillis() < wait) {
+            world.process();
+            Thread.sleep(SLEEP_MS);
+        }
+        assertTrue(done.get());
+        world.process();
+        var maps = world.getAspectSubscriptionManager()
+                .get(com.artemis.Aspect.all(MapComponent.class))
+                .getEntities();
+        assertEquals(1, maps.size());
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/async/MapScreenAsyncTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/async/MapScreenAsyncTest.java
@@ -1,0 +1,71 @@
+package net.lapidist.colony.tests.async;
+
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import net.lapidist.colony.client.Colony;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.client.screens.MapScreen;
+import net.lapidist.colony.client.screens.MapUi;
+import net.lapidist.colony.client.screens.MapUiBuilder;
+import net.lapidist.colony.client.screens.MapWorldBuilder;
+import net.lapidist.colony.client.systems.MapInitSystem;
+import net.lapidist.colony.client.ui.MinimapActor;
+import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.map.ProvidedMapStateProvider;
+import net.lapidist.colony.settings.Settings;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(GdxTestRunner.class)
+public class MapScreenAsyncTest {
+
+    private static final int ITERATIONS = 10;
+    private static final float STEP = 0.1f;
+    private static final int SLEEP_MS = 10;
+
+    @Test
+    public void processesUntilMapReady() throws Exception {
+        new net.lapidist.colony.base.BaseDefinitionsMod().init();
+        Colony colony = mock(Colony.class);
+        Settings settings = new Settings();
+        when(colony.getSettings()).thenReturn(settings);
+        MapState state = new MapState();
+        GameClient client = mock(GameClient.class);
+        AtomicBoolean called = new AtomicBoolean(false);
+        try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class);
+             MockedStatic<MapWorldBuilder> worldStatic = mockStatic(MapWorldBuilder.class);
+             MockedStatic<MapUiBuilder> uiStatic = mockStatic(MapUiBuilder.class)) {
+            World world = new World(new WorldConfigurationBuilder()
+                    .with(new MapInitSystem(new ProvidedMapStateProvider(state), true, p -> {
+                        if (p == 1f) {
+                            called.set(true);
+                        }
+                    })).build());
+            worldStatic.when(() -> MapWorldBuilder.builder(eq(state), eq(client), any(Stage.class),
+                    eq(settings.getKeyBindings()), eq(settings.getGraphicsSettings()), any()))
+                    .thenReturn(new WorldConfigurationBuilder());
+            worldStatic.when(() -> MapWorldBuilder.build(any(), isNull(), eq(settings), any(),
+                    eq(client), any(), any()))
+                    .thenReturn(world);
+            uiStatic.when(() -> MapUiBuilder.build(any(Stage.class), eq(world), eq(client), eq(colony)))
+                    .thenAnswer(inv -> new MapUi(inv.getArgument(0), mock(MinimapActor.class),
+                            mock(net.lapidist.colony.client.ui.ChatBox.class)));
+
+            MapScreen screen = new MapScreen(colony, state, client, p -> { });
+            for (int i = 0; i < ITERATIONS && !called.get(); i++) {
+                screen.render(STEP);
+                Thread.sleep(SLEEP_MS);
+            }
+            screen.render(STEP);
+        }
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/async/package-info.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/async/package-info.java
@@ -1,0 +1,2 @@
+/** Async test utilities. */
+package net.lapidist.colony.tests.async;

--- a/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationSpawnNetworkTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/scenario/GameSimulationSpawnNetworkTest.java
@@ -73,7 +73,8 @@ public class GameSimulationSpawnNetworkTest {
                                 client,
                                 stage,
                                 new KeyBindings(),
-                                settings.getGraphicsSettings()
+                                settings.getGraphicsSettings(),
+                                null
                         ),
                         null,
                         settings,

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MapScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MapScreenTest.java
@@ -53,7 +53,7 @@ public class MapScreenTest {
              MockedStatic<MapWorldBuilder> worldStatic = mockStatic(MapWorldBuilder.class);
              MockedStatic<MapUiBuilder> uiStatic = mockStatic(MapUiBuilder.class)) {
             worldStatic.when(() -> MapWorldBuilder.builder(eq(state), eq(client),
-                    any(Stage.class), eq(settings.getKeyBindings()), eq(settings.getGraphicsSettings())))
+                    any(Stage.class), eq(settings.getKeyBindings()), eq(settings.getGraphicsSettings()), any()))
                     .thenReturn(new WorldConfigurationBuilder());
             worldStatic.when(() -> MapWorldBuilder.build(
                     any(),
@@ -117,7 +117,7 @@ public class MapScreenTest {
              MockedStatic<MapWorldBuilder> worldStatic = mockStatic(MapWorldBuilder.class);
              MockedStatic<MapUiBuilder> uiStatic = mockStatic(MapUiBuilder.class)) {
             worldStatic.when(() -> MapWorldBuilder.builder(eq(state), eq(client), any(Stage.class),
-                    eq(settings.getKeyBindings()), eq(settings.getGraphicsSettings())))
+                    eq(settings.getKeyBindings()), eq(settings.getGraphicsSettings()), any()))
                     .thenReturn(new WorldConfigurationBuilder());
             worldStatic.when(() -> MapWorldBuilder.build(any(), isNull(), eq(settings), any(),
                     eq(client), any(), any()))

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MapWorldBuilderConfigurationTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MapWorldBuilderConfigurationTest.java
@@ -98,7 +98,8 @@ public class MapWorldBuilderConfigurationTest {
                             client,
                             stage,
                             keys,
-                            settings.getGraphicsSettings()
+                            settings.getGraphicsSettings(),
+                            null
                     ),
                     null,
                     settings,
@@ -138,7 +139,7 @@ public class MapWorldBuilderConfigurationTest {
         net.lapidist.colony.settings.Settings settings = new net.lapidist.colony.settings.Settings();
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
             World world = MapWorldBuilder.build(
-                    MapWorldBuilder.builder(state, client, stage, keys, settings.getGraphicsSettings()),
+                    MapWorldBuilder.builder(state, client, stage, keys, settings.getGraphicsSettings(), null),
                     null,
                     settings,
                     null,
@@ -215,7 +216,7 @@ public class MapWorldBuilderConfigurationTest {
         net.lapidist.colony.settings.Settings settings = new net.lapidist.colony.settings.Settings();
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class)) {
             World world = MapWorldBuilder.build(
-                    MapWorldBuilder.builder(state, client, stage, keys, settings.getGraphicsSettings()),
+                    MapWorldBuilder.builder(state, client, stage, keys, settings.getGraphicsSettings(), null),
                     null,
                     settings,
                     null,


### PR DESCRIPTION
## Summary
- make `MapInitSystem` optionally asynchronous with progress callback
- let `MapWorldBuilder` accept a progress callback for map loading
- poll the map init task in `MapScreen`
- cover async map loading in tests
- document async workflow

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68533d5b6a2c8328b815a79328166bb5