### PR TITLE
feat(client): add UI helpers and refactor screens

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/BaseScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/BaseScreen.java
@@ -5,6 +5,9 @@ import com.badlogic.gdx.ScreenAdapter;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.utils.ScreenUtils;
 import com.badlogic.gdx.utils.viewport.ScreenViewport;
 
@@ -66,6 +69,36 @@ public abstract class BaseScreen extends ScreenAdapter {
      */
     protected final Table getRoot() {
         return root;
+    }
+
+    /**
+     * Creates a text button using the active UI skin.
+     *
+     * @param text button label
+     * @return newly created button
+     */
+    protected final TextButton createButton(final String text) {
+        return new TextButton(text, skin);
+    }
+
+    /**
+     * Creates a label using the active UI skin.
+     *
+     * @param text label contents
+     * @return newly created label
+     */
+    protected final Label createLabel(final String text) {
+        return new Label(text, skin);
+    }
+
+    /**
+     * Creates a dialog using the "dialog" style of the active UI skin.
+     *
+     * @param title dialog title
+     * @return newly created dialog
+     */
+    protected final Dialog createDialog(final String title) {
+        return new Dialog(title, skin, "dialog");
     }
 
     @Override

--- a/client/src/main/java/net/lapidist/colony/client/screens/ErrorScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/ErrorScreen.java
@@ -12,8 +12,8 @@ public final class ErrorScreen extends BaseScreen {
     public ErrorScreen(final Colony colony, final String message) {
         float scale = colony.getSettings() == null ? 1f : colony.getSettings().getUiScale();
         getStage().getRoot().setScale(scale);
-        Label label = new Label(message, getSkin());
-        TextButton back = new TextButton(I18n.get("common.back"), getSkin());
+        Label label = createLabel(message);
+        TextButton back = createButton(I18n.get("common.back"));
 
         getRoot().add(label).row();
         getRoot().add(back).row();

--- a/client/src/main/java/net/lapidist/colony/client/screens/LoadGameScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/LoadGameScreen.java
@@ -5,7 +5,6 @@ import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
-import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
@@ -50,7 +49,7 @@ public final class LoadGameScreen extends BaseScreen {
         getRoot().add(filterField).growX().row();
         getRoot().add(scroll).expand().fill().row();
 
-        TextButton backButton = new TextButton(I18n.get("common.back"), getSkin());
+        TextButton backButton = createButton(I18n.get("common.back"));
         getRoot().add(backButton).row();
         backButton.addListener(new ChangeListener() {
             @Override
@@ -81,8 +80,8 @@ public final class LoadGameScreen extends BaseScreen {
             }
         }
         for (String save : matched) {
-            TextButton loadButton = new TextButton(save, getSkin());
-            TextButton deleteButton = new TextButton(I18n.get("loadGame.delete"), getSkin());
+            TextButton loadButton = createButton(save);
+            TextButton deleteButton = createButton(I18n.get("loadGame.delete"));
             Table row = new Table();
             row.add(loadButton).padRight(PADDING);
             row.add(deleteButton);
@@ -125,7 +124,7 @@ public final class LoadGameScreen extends BaseScreen {
         }
 
         if (matched.isEmpty()) {
-            list.add(new Label(I18n.get("loadGame.none"), getSkin())).row();
+            list.add(createLabel(I18n.get("loadGame.none"))).row();
         }
     }
 

--- a/client/src/main/java/net/lapidist/colony/client/screens/MainMenuScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MainMenuScreen.java
@@ -25,11 +25,11 @@ public final class MainMenuScreen extends BaseScreen {
         getStage().getRoot().setScale(scale);
 
         Image logo = new Image(new TextureRegionDrawable(new Texture(Gdx.files.internal("textures/logo.png"))));
-        TextButton continueButton = new TextButton(I18n.get("main.continue"), getSkin());
-        TextButton newGameButton = new TextButton(I18n.get("main.newGame"), getSkin());
-        TextButton loadGameButton = new TextButton(I18n.get("main.loadGame"), getSkin());
-        TextButton settingsButton = new TextButton(I18n.get("main.settings"), getSkin());
-        TextButton exitButton = new TextButton(I18n.get("main.exit"), getSkin());
+        TextButton continueButton = createButton(I18n.get("main.continue"));
+        TextButton newGameButton = createButton(I18n.get("main.newGame"));
+        TextButton loadGameButton = createButton(I18n.get("main.loadGame"));
+        TextButton settingsButton = createButton(I18n.get("main.settings"));
+        TextButton exitButton = createButton(I18n.get("main.exit"));
 
         String lastSave = null;
         boolean canContinue = false;


### PR DESCRIPTION
## Summary
- extend `BaseScreen` with helper methods for common widgets
- refactor `MainMenuScreen`, `LoadGameScreen` and `ErrorScreen` to use helpers

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685343ad734c83288f4640c220e91fd2