### PR TITLE
feat(server): add LockedCommandHandler

### DIFF
--- a/server/src/main/java/net/lapidist/colony/server/commands/GatherCommandHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/GatherCommandHandler.java
@@ -15,23 +15,18 @@ import java.util.function.Supplier;
 import java.util.concurrent.locks.ReentrantLock;
 
 /** Applies a {@link GatherCommand} to the game state and broadcasts the change. */
-public final class GatherCommandHandler implements CommandHandler<GatherCommand> {
-    private final Supplier<MapState> stateSupplier;
-    private final java.util.function.Consumer<MapState> stateConsumer;
+public final class GatherCommandHandler extends LockedCommandHandler<GatherCommand> {
     private final NetworkService networkService;
     private final InventoryService inventoryService;
-    private final ReentrantLock lock;
 
     public GatherCommandHandler(final Supplier<MapState> stateSupplierToUse,
                                final java.util.function.Consumer<MapState> stateConsumerToUse,
                                final NetworkService networkServiceToUse,
                                final InventoryService inventoryServiceToUse,
                                final ReentrantLock lockToUse) {
-        this.stateSupplier = stateSupplierToUse;
-        this.stateConsumer = stateConsumerToUse;
+        super(stateSupplierToUse, stateConsumerToUse, lockToUse);
         this.networkService = networkServiceToUse;
         this.inventoryService = inventoryServiceToUse;
-        this.lock = lockToUse;
     }
 
     @Override
@@ -40,48 +35,41 @@ public final class GatherCommandHandler implements CommandHandler<GatherCommand>
     }
 
     @Override
-    public void handle(final GatherCommand command) {
-        lock.lock();
-        try {
-            MapState state = stateSupplier.get();
-            if (Registries.resources().get(command.resourceId()) == null) {
-                return;
-            }
-            TileData tile = state.getTile(command.x(), command.y());
-            TilePos pos = new TilePos(command.x(), command.y());
-            if (tile == null) {
-                return;
-            }
-            ResourceData res = tile.resources();
-            java.util.Map<String, Integer> amounts = new java.util.HashMap<>(res.amounts());
-            int current = amounts.getOrDefault(command.resourceId(), 0);
-            int updatedValue = Math.max(current - 1, 0);
-            amounts.put(command.resourceId(), updatedValue);
-            ResourceData updated = new ResourceData(new java.util.HashMap<>(amounts));
-            TileData newTile = tile.toBuilder().resources(updated).build();
-            int chunkX = MapCoordinateUtils.toChunkCoord(command.x());
-            int chunkY = MapCoordinateUtils.toChunkCoord(command.y());
-            int localX = MapCoordinateUtils.toLocalCoord(command.x());
-            int localY = MapCoordinateUtils.toLocalCoord(command.y());
-            state.getOrCreateChunk(chunkX, chunkY).getTiles()
-                    .put(new TilePos(localX, localY), newTile);
-            ResourceData player = state.playerResources();
-            java.util.Map<String, Integer> playerAmounts = new java.util.HashMap<>(player.amounts());
-            playerAmounts.merge(command.resourceId(), current - updatedValue, Integer::sum);
-            inventoryService.addItem(command.resourceId().toLowerCase(Locale.ROOT), current - updatedValue);
-            state = stateSupplier.get();
-            ResourceData newPlayer = new ResourceData(new java.util.HashMap<>(playerAmounts));
-            MapState updatedState = state.toBuilder()
-                    .playerResources(newPlayer)
-                    .build();
-            stateConsumer.accept(updatedState);
-            networkService.broadcast(new ResourceUpdateData(
-                    pos.x(),
-                    pos.y(),
-                    new java.util.HashMap<>(updated.amounts())
-            ));
-        } finally {
-            lock.unlock();
+    protected MapState modify(final GatherCommand command, final MapState state) {
+        if (Registries.resources().get(command.resourceId()) == null) {
+            return null;
         }
+        TileData tile = state.getTile(command.x(), command.y());
+        TilePos pos = new TilePos(command.x(), command.y());
+        if (tile == null) {
+            return null;
+        }
+        ResourceData res = tile.resources();
+        java.util.Map<String, Integer> amounts = new java.util.HashMap<>(res.amounts());
+        int current = amounts.getOrDefault(command.resourceId(), 0);
+        int updatedValue = Math.max(current - 1, 0);
+        amounts.put(command.resourceId(), updatedValue);
+        ResourceData updated = new ResourceData(new java.util.HashMap<>(amounts));
+        TileData newTile = tile.toBuilder().resources(updated).build();
+        int chunkX = MapCoordinateUtils.toChunkCoord(command.x());
+        int chunkY = MapCoordinateUtils.toChunkCoord(command.y());
+        int localX = MapCoordinateUtils.toLocalCoord(command.x());
+        int localY = MapCoordinateUtils.toLocalCoord(command.y());
+        state.getOrCreateChunk(chunkX, chunkY).getTiles()
+                .put(new TilePos(localX, localY), newTile);
+        ResourceData player = state.playerResources();
+        java.util.Map<String, Integer> playerAmounts = new java.util.HashMap<>(player.amounts());
+        playerAmounts.merge(command.resourceId(), current - updatedValue, Integer::sum);
+        inventoryService.addItem(command.resourceId().toLowerCase(Locale.ROOT), current - updatedValue);
+        ResourceData newPlayer = new ResourceData(new java.util.HashMap<>(playerAmounts));
+        MapState updatedState = state.toBuilder()
+                .playerResources(newPlayer)
+                .build();
+        networkService.broadcast(new ResourceUpdateData(
+                pos.x(),
+                pos.y(),
+                new java.util.HashMap<>(updated.amounts())
+        ));
+        return updatedState;
     }
 }

--- a/server/src/main/java/net/lapidist/colony/server/commands/LockedCommandHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/LockedCommandHandler.java
@@ -1,0 +1,59 @@
+package net.lapidist.colony.server.commands;
+
+import net.lapidist.colony.components.state.MapState;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Base handler that acquires a {@link ReentrantLock} before modifying the state.
+ * Subclasses implement {@link #modify(Object, MapState)} to perform their changes.
+ *
+ * @param <C> command type
+ */
+public abstract class LockedCommandHandler<C extends ServerCommand> implements CommandHandler<C> {
+
+    private final Supplier<MapState> stateSupplier;
+    private final Consumer<MapState> stateConsumer;
+    private final ReentrantLock lock;
+
+    protected LockedCommandHandler(final Supplier<MapState> stateSupplierToUse,
+                                   final Consumer<MapState> stateConsumerToUse,
+                                   final ReentrantLock lockToUse) {
+        this.stateSupplier = stateSupplierToUse;
+        this.stateConsumer = stateConsumerToUse;
+        this.lock = lockToUse;
+    }
+
+    @Override
+    public final void handle(final C command) {
+        lock.lock();
+        try {
+            MapState state = stateSupplier.get();
+            MapState updated = modify(command, state);
+            if (updated != null) {
+                stateConsumer.accept(updated);
+            }
+            afterUpdate(command, updated != null ? updated : state);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Apply the command to the supplied state.
+     *
+     * @param command command to process
+     * @param state   current map state
+     * @return new state instance, or {@code null} if unchanged
+     */
+    protected abstract MapState modify(C command, MapState state);
+
+    /**
+     * Hook invoked after the state has been consumed.
+     * Subclasses may override to perform side effects like broadcasting events.
+     */
+    protected void afterUpdate(final C command, final MapState newState) {
+        // default no-op
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/server/commands/PlayerPositionCommandHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/PlayerPositionCommandHandler.java
@@ -7,17 +7,12 @@ import java.util.function.Supplier;
 import java.util.concurrent.locks.ReentrantLock;
 
 /** Applies a {@link PlayerPositionCommand} to the map state. */
-public final class PlayerPositionCommandHandler implements CommandHandler<PlayerPositionCommand> {
-    private final Supplier<MapState> stateSupplier;
-    private final Consumer<MapState> stateConsumer;
-    private final ReentrantLock lock;
+public final class PlayerPositionCommandHandler extends LockedCommandHandler<PlayerPositionCommand> {
 
     public PlayerPositionCommandHandler(final Supplier<MapState> stateSupplierToUse,
                                         final Consumer<MapState> stateConsumerToUse,
                                         final ReentrantLock lockToUse) {
-        this.stateSupplier = stateSupplierToUse;
-        this.stateConsumer = stateConsumerToUse;
-        this.lock = lockToUse;
+        super(stateSupplierToUse, stateConsumerToUse, lockToUse);
     }
 
     @Override
@@ -26,16 +21,9 @@ public final class PlayerPositionCommandHandler implements CommandHandler<Player
     }
 
     @Override
-    public void handle(final PlayerPositionCommand command) {
-        lock.lock();
-        try {
-            MapState state = stateSupplier.get();
-            MapState updated = state.toBuilder()
-                    .playerPos(new PlayerPosition(command.x(), command.y()))
-                    .build();
-            stateConsumer.accept(updated);
-        } finally {
-            lock.unlock();
-        }
+    protected MapState modify(final PlayerPositionCommand command, final MapState state) {
+        return state.toBuilder()
+                .playerPos(new PlayerPosition(command.x(), command.y()))
+                .build();
     }
 }

--- a/server/src/main/java/net/lapidist/colony/server/commands/RemoveBuildingCommandHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/RemoveBuildingCommandHandler.java
@@ -13,20 +13,15 @@ import java.util.function.Supplier;
 import java.util.concurrent.locks.ReentrantLock;
 
 /** Applies a {@link RemoveBuildingCommand} to the game state and broadcasts the change. */
-public final class RemoveBuildingCommandHandler implements CommandHandler<RemoveBuildingCommand> {
-    private final Supplier<MapState> stateSupplier;
-    private final Consumer<MapState> stateConsumer;
+public final class RemoveBuildingCommandHandler extends LockedCommandHandler<RemoveBuildingCommand> {
     private final NetworkService networkService;
-    private final ReentrantLock lock;
 
     public RemoveBuildingCommandHandler(final Supplier<MapState> stateSupplierToUse,
                                         final Consumer<MapState> stateConsumerToUse,
                                         final NetworkService networkServiceToUse,
                                         final ReentrantLock lockToUse) {
-        this.stateSupplier = stateSupplierToUse;
-        this.stateConsumer = stateConsumerToUse;
+        super(stateSupplierToUse, stateConsumerToUse, lockToUse);
         this.networkService = networkServiceToUse;
-        this.lock = lockToUse;
     }
 
     @Override
@@ -35,28 +30,22 @@ public final class RemoveBuildingCommandHandler implements CommandHandler<Remove
     }
 
     @Override
-    public void handle(final RemoveBuildingCommand command) {
-        lock.lock();
-        try {
-            MapState state = stateSupplier.get();
-            Iterator<BuildingData> it = state.buildings().iterator();
-            BuildingData target = null;
-            while (it.hasNext()) {
-                BuildingData bd = it.next();
-                if (bd.x() == command.x() && bd.y() == command.y()) {
-                    target = bd;
-                    it.remove();
-                    break;
-                }
+    protected MapState modify(final RemoveBuildingCommand command, final MapState state) {
+        Iterator<BuildingData> it = state.buildings().iterator();
+        BuildingData target = null;
+        while (it.hasNext()) {
+            BuildingData bd = it.next();
+            if (bd.x() == command.x() && bd.y() == command.y()) {
+                target = bd;
+                it.remove();
+                break;
             }
-            if (target == null) {
-                return;
-            }
-            stateConsumer.accept(state);
-            Events.dispatch(new BuildingRemovedEvent(command.x(), command.y()));
-            networkService.broadcast(new BuildingRemovalData(command.x(), command.y()));
-        } finally {
-            lock.unlock();
         }
+        if (target == null) {
+            return null;
+        }
+        Events.dispatch(new BuildingRemovedEvent(command.x(), command.y()));
+        networkService.broadcast(new BuildingRemovalData(command.x(), command.y()));
+        return state;
     }
 }


### PR DESCRIPTION
## Summary
- add `LockedCommandHandler` abstraction to centralize locking
- refactor command handlers to extend the new base class

## Testing
- `./gradlew spotlessApply`
- `./gradlew clean test` *(fails: 1 test)*
- `./gradlew check` *(fails: javadoc generation)*

------
https://chatgpt.com/codex/tasks/task_e_685343c01e4483288c1ad85e85026c5b