### PR TITLE
feat(server): add generic environment cycle service

### DIFF
--- a/server/src/main/java/net/lapidist/colony/base/BaseDayCycleMod.java
+++ b/server/src/main/java/net/lapidist/colony/base/BaseDayCycleMod.java
@@ -2,23 +2,29 @@ package net.lapidist.colony.base;
 
 import net.lapidist.colony.mod.GameMod;
 import net.lapidist.colony.mod.GameServer;
-import net.lapidist.colony.server.services.DayNightCycleService;
+import net.lapidist.colony.server.services.EnvironmentCycleService;
 import net.lapidist.colony.components.GameConstants;
+import net.lapidist.colony.components.state.EnvironmentState;
 
 /** Built-in mod registering the day/night cycle service. */
 public final class BaseDayCycleMod implements GameMod {
     private static final long TICK_PERIOD_MS = 1000L;
+    private static final float HOURS_PER_DAY = 24f;
     private static final float DAY_LENGTH_SECONDS = GameConstants.DAY_LENGTH_SECONDS;
 
     @Override
     public void registerSystems(final GameServer srv) {
         net.lapidist.colony.server.GameServer s = (net.lapidist.colony.server.GameServer) srv;
-        srv.registerSystem(new DayNightCycleService(
+        srv.registerSystem(new EnvironmentCycleService(
                 TICK_PERIOD_MS,
-                DAY_LENGTH_SECONDS,
                 s::getMapState,
                 s::setMapState,
-                s.getStateLock()
+                s.getStateLock(),
+                (env, dt) -> {
+                    float increment = (dt * HOURS_PER_DAY) / DAY_LENGTH_SECONDS;
+                    float time = ((env.timeOfDay() + increment) % HOURS_PER_DAY + HOURS_PER_DAY) % HOURS_PER_DAY;
+                    return new EnvironmentState(time, env.season(), env.moonPhase());
+                }
         ));
     }
 }

--- a/server/src/main/java/net/lapidist/colony/base/BaseSeasonCycleMod.java
+++ b/server/src/main/java/net/lapidist/colony/base/BaseSeasonCycleMod.java
@@ -2,7 +2,8 @@ package net.lapidist.colony.base;
 
 import net.lapidist.colony.mod.GameMod;
 import net.lapidist.colony.mod.GameServer;
-import net.lapidist.colony.server.services.SeasonCycleService;
+import net.lapidist.colony.server.services.EnvironmentCycleService;
+import net.lapidist.colony.components.state.EnvironmentState;
 
 /** Built-in mod registering the season cycle service. */
 public final class BaseSeasonCycleMod implements GameMod {
@@ -11,12 +12,24 @@ public final class BaseSeasonCycleMod implements GameMod {
     @Override
     public void registerSystems(final GameServer srv) {
         net.lapidist.colony.server.GameServer s = (net.lapidist.colony.server.GameServer) srv;
-        srv.registerSystem(new SeasonCycleService(
+        srv.registerSystem(new EnvironmentCycleService(
                 TICK_PERIOD_MS,
-                SEASON_LENGTH_SECONDS,
                 s::getMapState,
                 s::setMapState,
-                s.getStateLock()
+                s.getStateLock(),
+                new java.util.function.BiFunction<EnvironmentState, Float, EnvironmentState>() {
+                    private float elapsed;
+
+                    @Override
+                    public EnvironmentState apply(final EnvironmentState env, final Float dt) {
+                        elapsed += dt;
+                        if (elapsed < SEASON_LENGTH_SECONDS) {
+                            return env;
+                        }
+                        elapsed -= SEASON_LENGTH_SECONDS;
+                        return new EnvironmentState(env.timeOfDay(), env.season().next(), env.moonPhase());
+                    }
+                }
         ));
     }
 }

--- a/server/src/main/java/net/lapidist/colony/server/commands/GatherCommandHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/GatherCommandHandler.java
@@ -61,8 +61,11 @@ public final class GatherCommandHandler extends LockedCommandHandler<GatherComma
         java.util.Map<String, Integer> playerAmounts = new java.util.HashMap<>(player.amounts());
         playerAmounts.merge(command.resourceId(), current - updatedValue, Integer::sum);
         inventoryService.addItem(command.resourceId().toLowerCase(Locale.ROOT), current - updatedValue);
+        java.util.Map<String, Integer> invMap = new java.util.HashMap<>(state.inventory());
+        invMap.merge(command.resourceId().toLowerCase(Locale.ROOT), current - updatedValue, Integer::sum);
         ResourceData newPlayer = new ResourceData(new java.util.HashMap<>(playerAmounts));
         MapState updatedState = state.toBuilder()
+                .inventory(new java.util.HashMap<>(invMap))
                 .playerResources(newPlayer)
                 .build();
         networkService.broadcast(new ResourceUpdateData(

--- a/server/src/main/java/net/lapidist/colony/server/commands/LockedCommandHandler.java
+++ b/server/src/main/java/net/lapidist/colony/server/commands/LockedCommandHandler.java
@@ -1,13 +1,13 @@
 package net.lapidist.colony.server.commands;
 
-import net.lapidist.colony.components.state.MapState;
+import net.lapidist.colony.components.state.map.MapState;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
  * Base handler that acquires a {@link ReentrantLock} before modifying the state.
- * Subclasses implement {@link #modify(Object, MapState)} to perform their changes.
+ * Subclasses implement {@code modify(Object, MapState)} to perform their changes.
  *
  * @param <C> command type
  */

--- a/server/src/main/java/net/lapidist/colony/server/services/EnvironmentCycleService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/EnvironmentCycleService.java
@@ -1,0 +1,53 @@
+package net.lapidist.colony.server.services;
+
+import net.lapidist.colony.components.state.EnvironmentState;
+import net.lapidist.colony.components.state.map.MapState;
+import net.lapidist.colony.mod.ScheduledService;
+
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Generic service that updates the {@link EnvironmentState} each tick using a supplied function.
+ */
+public class EnvironmentCycleService extends ScheduledService {
+    private static final float MS_TO_SECONDS = 1000f;
+
+    private final long interval;
+    private final Supplier<MapState> supplier;
+    private final Consumer<MapState> consumer;
+    private final ReentrantLock lock;
+    private final BiFunction<EnvironmentState, Float, EnvironmentState> updater;
+
+    public EnvironmentCycleService(
+            final long intervalMs,
+            final Supplier<MapState> stateSupplier,
+            final Consumer<MapState> stateConsumer,
+            final ReentrantLock stateLock,
+            final BiFunction<EnvironmentState, Float, EnvironmentState> updateFn) {
+        super(intervalMs);
+        this.interval = intervalMs;
+        this.supplier = stateSupplier;
+        this.consumer = stateConsumer;
+        this.lock = stateLock;
+        this.updater = updateFn;
+    }
+
+    @Override
+    protected final void runTask() {
+        lock.lock();
+        try {
+            MapState state = supplier.get();
+            EnvironmentState updated = updater.apply(state.environment(), getIntervalSeconds());
+            consumer.accept(state.toBuilder().environment(updated).build());
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private float getIntervalSeconds() {
+        return interval / MS_TO_SECONDS;
+    }
+}

--- a/server/src/main/java/net/lapidist/colony/server/services/SeasonCycleService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/SeasonCycleService.java
@@ -3,54 +3,41 @@ package net.lapidist.colony.server.services;
 import net.lapidist.colony.components.state.EnvironmentState;
 import net.lapidist.colony.components.state.map.MapState;
 import net.lapidist.colony.components.state.Season;
-import net.lapidist.colony.mod.ScheduledService;
 
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /** Service that periodically advances the world season. */
-public final class SeasonCycleService extends ScheduledService {
-    private static final float MS_TO_SECONDS = 1000f;
-    private final long period;
-    private final float seasonLength;
-    private final Supplier<MapState> supplier;
-    private final Consumer<MapState> consumer;
-    private final ReentrantLock lock;
-    private float elapsed;
+public final class SeasonCycleService extends EnvironmentCycleService {
 
     public SeasonCycleService(final long periodMs,
                               final float lengthInSeconds,
                               final Supplier<MapState> stateSupplier,
                               final Consumer<MapState> stateConsumer,
                               final ReentrantLock stateLock) {
-        super(periodMs);
-        this.period = periodMs;
-        this.seasonLength = lengthInSeconds;
-        this.supplier = stateSupplier;
-        this.consumer = stateConsumer;
-        this.lock = stateLock;
+        super(periodMs, stateSupplier, stateConsumer, stateLock,
+                new SeasonUpdater(lengthInSeconds));
     }
 
+    private static final class SeasonUpdater implements BiFunction<EnvironmentState, Float, EnvironmentState> {
+        private final float seasonLength;
+        private float elapsed;
 
+        SeasonUpdater(final float lengthInSeconds) {
+            this.seasonLength = lengthInSeconds;
+        }
 
-    @Override
-    protected void runTask() {
-        lock.lock();
-        try {
-            elapsed += period / MS_TO_SECONDS;
+        @Override
+        public EnvironmentState apply(final EnvironmentState env, final Float deltaSeconds) {
+            elapsed += deltaSeconds;
             if (elapsed < seasonLength) {
-                return;
+                return env;
             }
             elapsed -= seasonLength;
-            MapState state = supplier.get();
-            EnvironmentState env = state.environment();
             Season next = env.season().next();
-            consumer.accept(state.toBuilder()
-                    .environment(new EnvironmentState(env.timeOfDay(), next, env.moonPhase()))
-                    .build());
-        } finally {
-            lock.unlock();
+            return new EnvironmentState(env.timeOfDay(), next, env.moonPhase());
         }
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/server/DayNightCycleServiceTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/DayNightCycleServiceTest.java
@@ -1,7 +1,8 @@
 package net.lapidist.colony.tests.server;
 
 import net.lapidist.colony.components.state.map.MapState;
-import net.lapidist.colony.server.services.DayNightCycleService;
+import net.lapidist.colony.server.services.EnvironmentCycleService;
+import net.lapidist.colony.components.state.EnvironmentState;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicReference;
@@ -11,21 +12,26 @@ import static org.junit.Assert.assertTrue;
 
 public class DayNightCycleServiceTest {
     private static final int INTERVAL = 10;
+    private static final float HOURS_PER_DAY = 24f;
     private static final float DAY_LENGTH = 0.02f;
 
     @Test
     public void advancesTimeOfDay() throws Exception {
         MapState state = new MapState();
         AtomicReference<MapState> ref = new AtomicReference<>(state);
-        DayNightCycleService service = new DayNightCycleService(
+        EnvironmentCycleService service = new EnvironmentCycleService(
                 INTERVAL,
-                DAY_LENGTH,
                 ref::get,
                 ref::set,
-                new ReentrantLock()
+                new ReentrantLock(),
+                (env, dt) -> {
+                    float inc = (dt * HOURS_PER_DAY) / DAY_LENGTH;
+                    float time = ((env.timeOfDay() + inc) % HOURS_PER_DAY + HOURS_PER_DAY) % HOURS_PER_DAY;
+                    return new EnvironmentState(time, env.season(), env.moonPhase());
+                }
         );
 
-        java.lang.reflect.Method run = DayNightCycleService.class.getDeclaredMethod("runTask");
+        java.lang.reflect.Method run = EnvironmentCycleService.class.getDeclaredMethod("runTask");
         run.setAccessible(true);
         run.invoke(service);
         assertTrue(ref.get().environment().timeOfDay() > 0f);

--- a/tests/src/test/java/net/lapidist/colony/tests/server/GameServerBaseSystemsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/GameServerBaseSystemsTest.java
@@ -3,8 +3,7 @@ package net.lapidist.colony.tests.server;
 import net.lapidist.colony.server.GameServer;
 import net.lapidist.colony.server.GameServerConfig;
 import net.lapidist.colony.server.services.ResourceProductionService;
-import net.lapidist.colony.server.services.SeasonCycleService;
-import net.lapidist.colony.server.services.DayNightCycleService;
+import net.lapidist.colony.server.services.EnvironmentCycleService;
 import net.lapidist.colony.io.Paths;
 import org.junit.Test;
 
@@ -41,7 +40,7 @@ public class GameServerBaseSystemsTest {
         GameServer server = new GameServer(GameServerConfig.builder().saveName(name).build());
         server.start();
 
-        assertTrue(systems(server).stream().anyMatch(s -> s instanceof SeasonCycleService));
+        assertTrue(systems(server).stream().anyMatch(s -> s instanceof EnvironmentCycleService));
         server.stop();
     }
 
@@ -52,7 +51,7 @@ public class GameServerBaseSystemsTest {
         GameServer server = new GameServer(GameServerConfig.builder().saveName(name).build());
         server.start();
 
-        assertTrue(systems(server).stream().anyMatch(s -> s instanceof DayNightCycleService));
+        assertTrue(systems(server).stream().anyMatch(s -> s instanceof EnvironmentCycleService));
         server.stop();
     }
 }


### PR DESCRIPTION
## Summary
- create `EnvironmentCycleService` for generic environment updates
- wrap day/night and season cycle logic using the new service
- adjust base mods to use `EnvironmentCycleService`
- fix gather command inventory update
- update server tests for new service

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_685345805cd48328b2b9a5e6185f0c54