### PR TITLE
feat(client): split map screen into logic and render worlds

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/LogicWorldBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/LogicWorldBuilder.java
@@ -1,0 +1,118 @@
+package net.lapidist.colony.client.screens;
+
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import net.lapidist.colony.client.entities.PlayerFactory;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.client.systems.BuildPlacementSystem;
+import net.lapidist.colony.client.systems.CameraInputSystem;
+import net.lapidist.colony.client.systems.CelestialSystem;
+import net.lapidist.colony.client.systems.PlayerCameraSystem;
+import net.lapidist.colony.client.systems.PlayerMovementSystem;
+import net.lapidist.colony.client.systems.SelectionSystem;
+import net.lapidist.colony.client.systems.SeasonCycleSystem;
+import net.lapidist.colony.client.systems.network.BuildingUpdateSystem;
+import net.lapidist.colony.client.systems.ChunkLoadSystem;
+import net.lapidist.colony.client.systems.network.ChunkRequestQueueSystem;
+import net.lapidist.colony.client.systems.network.ResourceUpdateSystem;
+import net.lapidist.colony.client.systems.network.TileUpdateSystem;
+import net.lapidist.colony.components.state.MutableEnvironmentState;
+import net.lapidist.colony.components.state.map.MapState;
+import net.lapidist.colony.map.MapStateProvider;
+import net.lapidist.colony.components.state.map.PlayerPosition;
+import net.lapidist.colony.components.state.resources.ResourceData;
+import net.lapidist.colony.events.Events;
+import net.lapidist.colony.map.ProvidedMapStateProvider;
+import net.lapidist.colony.settings.KeyBindings;
+import net.mostlyoriginal.api.event.common.EventSystem;
+
+/** Builder for the update-only logic world. */
+public final class LogicWorldBuilder {
+
+    private LogicWorldBuilder() {
+    }
+
+    public static WorldConfigurationBuilder baseBuilder(
+            final GameClient client,
+            final KeyBindings keyBindings
+    ) {
+        return baseBuilder(client, keyBindings, new ResourceData());
+    }
+
+    public static WorldConfigurationBuilder baseBuilder(
+            final GameClient client,
+            final KeyBindings keyBindings,
+            final ResourceData playerResources
+    ) {
+        MapState state = MapState.builder()
+                .playerResources(playerResources)
+                .build();
+        return createBuilder(client, keyBindings, null, state, null);
+    }
+
+    public static WorldConfigurationBuilder builder(
+            final MapStateProvider provider,
+            final GameClient client,
+            final KeyBindings keyBindings,
+            final java.util.function.Consumer<Float> callback
+    ) {
+        return createBuilder(client, keyBindings, provider, new MapState(), callback);
+    }
+
+    public static WorldConfigurationBuilder builder(
+            final MapState state,
+            final GameClient client,
+            final KeyBindings keyBindings,
+            final java.util.function.Consumer<Float> callback
+    ) {
+        return createBuilder(
+                client,
+                keyBindings,
+                new ProvidedMapStateProvider(state),
+                state,
+                callback
+        );
+    }
+
+    private static WorldConfigurationBuilder createBuilder(
+            final GameClient client,
+            final KeyBindings keyBindings,
+            final MapStateProvider provider,
+            final MapState state,
+            final java.util.function.Consumer<Float> callback
+    ) {
+        MutableEnvironmentState environment = new MutableEnvironmentState(state.environment());
+        WorldConfigurationBuilder builder = new WorldConfigurationBuilder()
+                .with(
+                        new EventSystem(),
+                        new CameraInputSystem(client, keyBindings),
+                        new SelectionSystem(client, keyBindings),
+                        new BuildPlacementSystem(client, keyBindings),
+                        new PlayerMovementSystem(client, keyBindings),
+                        new TileUpdateSystem(client),
+                        new BuildingUpdateSystem(client),
+                        new ResourceUpdateSystem(client),
+                        new ChunkLoadSystem(client),
+                        new ChunkRequestQueueSystem(client),
+                        new CelestialSystem(client, environment),
+                        new SeasonCycleSystem(environment)
+                );
+        if (provider != null) {
+            builder.with(new net.lapidist.colony.client.systems.MapInitSystem(provider, true, callback));
+        }
+        return builder;
+    }
+
+    public static World build(
+            final WorldConfigurationBuilder builder,
+            final GameClient client,
+            final ResourceData playerResources,
+            final PlayerPosition playerPos
+    ) {
+        builder.with(new PlayerCameraSystem());
+        World world = new World(builder.build());
+        PlayerFactory.create(world, client, playerResources, playerPos);
+        Events.init(world.getSystem(EventSystem.class));
+        return world;
+    }
+}

--- a/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -12,20 +12,11 @@ import net.lapidist.colony.settings.Settings;
 import net.lapidist.colony.settings.GraphicsSettings;
 import net.lapidist.colony.client.graphics.ShaderPlugin;
 import net.lapidist.colony.client.systems.ClearScreenSystem;
-import net.lapidist.colony.client.systems.CameraInputSystem;
-import net.lapidist.colony.client.systems.SelectionSystem;
-import net.lapidist.colony.client.systems.BuildPlacementSystem;
 import net.lapidist.colony.client.systems.MapRenderSystem;
 import net.lapidist.colony.client.systems.LightingSystem;
 import net.lapidist.colony.client.systems.ParticleSystem;
 import net.lapidist.colony.client.systems.PlayerCameraSystem;
-import net.lapidist.colony.client.systems.PlayerMovementSystem;
 import net.lapidist.colony.client.systems.UISystem;
-import net.lapidist.colony.client.systems.ChunkLoadSystem;
-import net.lapidist.colony.client.systems.network.ChunkRequestQueueSystem;
-import net.lapidist.colony.client.systems.network.TileUpdateSystem;
-import net.lapidist.colony.client.systems.network.BuildingUpdateSystem;
-import net.lapidist.colony.client.systems.network.ResourceUpdateSystem;
 import net.lapidist.colony.client.systems.CelestialSystem;
 import net.lapidist.colony.client.systems.MapInitSystem;
 import net.lapidist.colony.client.systems.MapRenderDataSystem;
@@ -155,12 +146,7 @@ public final class MapWorldBuilder {
         PlayerPosition playerPos = state.playerPos();
         CameraPosition cameraPos = state.cameraPos();
         MutableEnvironmentState environment = new MutableEnvironmentState(state.environment());
-        CameraInputSystem cameraInputSystem = new CameraInputSystem(client, keyBindings);
-        cameraInputSystem.addProcessor(stage);
-        SelectionSystem selectionSystem = new SelectionSystem(client, keyBindings);
-        BuildPlacementSystem buildPlacementSystem = new BuildPlacementSystem(client, keyBindings);
         ParticleSystem particleSystem = new ParticleSystem(new com.badlogic.gdx.graphics.g2d.SpriteBatch());
-        PlayerMovementSystem movementSystem = new PlayerMovementSystem(client, keyBindings);
 
         ClearScreenSystem clear = new ClearScreenSystem(Color.BLACK);
         int rays = graphics != null ? graphics.getLightRays() : LightingSystem.DEFAULT_RAYS;
@@ -175,15 +161,6 @@ public final class MapWorldBuilder {
                 .with(
                         new EventSystem(),
                         clear,
-                        cameraInputSystem,
-                        selectionSystem,
-                        buildPlacementSystem,
-                        movementSystem,
-                        new TileUpdateSystem(client),
-                        new BuildingUpdateSystem(client),
-                        new ResourceUpdateSystem(client),
-                        new ChunkLoadSystem(client),
-                        new ChunkRequestQueueSystem(client),
                         new CelestialSystem(client, environment),
                         new MapRenderSystem(),
                         particleSystem,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,16 +22,15 @@ tested without a graphical context.
 
 ## ECS Systems
 
-`MapWorldBuilder` assembles the client's Artemis‑ODB world. Input systems like
-`CameraInputSystem`, `SelectionSystem` and `PlayerMovementSystem` handle user
-actions, while `BuildPlacementSystem` and `PlayerFactory` create entities.
-`TileUpdateSystem`, `BuildingUpdateSystem` and `ResourceUpdateSystem` apply
-server messages. `ChunkLoadSystem` and `ChunkRequestQueueSystem` request missing
-chunks. `MapRenderSystem` draws the world using a renderer from
-`SpriteMapRendererFactory`, which loads textures asynchronously as noted in
-[performance.md](performance.md#asynchronous-renderer-loading). `ParticleSystem`
-plays back `ParticleEffect` instances for events like building placement. The
-camera is managed by `PlayerCameraSystem` and the UI by `UISystem`.
+`LogicWorldBuilder` assembles the update-only world used for deterministic
+simulation. Systems like `CameraInputSystem`, `SelectionSystem` and
+`PlayerMovementSystem` handle user input while networking systems process
+server messages. `MapWorldBuilder` builds the render world which contains
+`MapRenderSystem`, `LightingSystem` and other drawing code. Both worlds are
+advanced each frame – the logic world in fixed steps and the render world with
+interpolation. Textures are loaded asynchronously as noted in
+[performance.md](performance.md#asynchronous-renderer-loading). The camera is
+managed by `PlayerCameraSystem` and the UI by `UISystem`.
 
 `GameServer` does not maintain an Artemis world. It initializes an
 `EventSystem` and relies on `NetworkService`, `MapService` and other services to

--- a/docs/background_tasks.md
+++ b/docs/background_tasks.md
@@ -6,11 +6,18 @@ Provide a progress callback to receive updates between `0` and `1` as the map st
 is generated. `MapScreen` polls this system during the loading phase and processes
 the world once initialization completes.
 
-Use `MapWorldBuilder.builder` with the new callback parameter to create a world
-that reports loading progress:
+Use `LogicWorldBuilder.builder` with the new callback parameter to create the
+logic world and `MapWorldBuilder.builder` for the render world. Both report
+loading progress:
 
 ```java
-WorldConfigurationBuilder builder = MapWorldBuilder.builder(
+WorldConfigurationBuilder builder = LogicWorldBuilder.builder(
+        provider,
+        client,
+        keys,
+        progress -> loadingScreen.setProgress(progress)
+);
+WorldConfigurationBuilder render = MapWorldBuilder.builder(
         provider,
         client,
         stage,

--- a/tests/src/test/java/net/lapidist/colony/tests/async/MapScreenAsyncTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/async/MapScreenAsyncTest.java
@@ -10,6 +10,7 @@ import net.lapidist.colony.client.screens.MapScreen;
 import net.lapidist.colony.client.screens.MapUi;
 import net.lapidist.colony.client.screens.MapUiBuilder;
 import net.lapidist.colony.client.screens.MapWorldBuilder;
+import net.lapidist.colony.client.screens.LogicWorldBuilder;
 import net.lapidist.colony.client.systems.MapInitSystem;
 import net.lapidist.colony.client.ui.MinimapActor;
 import net.lapidist.colony.components.state.map.MapState;
@@ -42,8 +43,21 @@ public class MapScreenAsyncTest {
         GameClient client = mock(GameClient.class);
         AtomicBoolean called = new AtomicBoolean(false);
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class);
+             MockedStatic<LogicWorldBuilder> logicStatic = mockStatic(LogicWorldBuilder.class);
              MockedStatic<MapWorldBuilder> worldStatic = mockStatic(MapWorldBuilder.class);
              MockedStatic<MapUiBuilder> uiStatic = mockStatic(MapUiBuilder.class)) {
+            logicStatic.when(() -> LogicWorldBuilder.builder(
+                    eq(state),
+                    eq(client),
+                    eq(settings.getKeyBindings()),
+                    any()
+            )).thenReturn(new WorldConfigurationBuilder());
+            logicStatic.when(() -> LogicWorldBuilder.build(
+                    any(),
+                    eq(client),
+                    any(),
+                    any()
+            )).thenReturn(new World(new WorldConfigurationBuilder().build()));
             World world = new World(new WorldConfigurationBuilder()
                     .with(new MapInitSystem(new ProvidedMapStateProvider(state), true, p -> {
                         if (p == 1f) {

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/LogicWorldBuilderTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/LogicWorldBuilderTest.java
@@ -1,0 +1,55 @@
+package net.lapidist.colony.tests.screens;
+
+import com.artemis.World;
+import net.lapidist.colony.client.network.GameClient;
+import net.lapidist.colony.client.screens.LogicWorldBuilder;
+import net.lapidist.colony.client.systems.BuildPlacementSystem;
+import net.lapidist.colony.client.systems.CameraInputSystem;
+import net.lapidist.colony.client.systems.PlayerMovementSystem;
+import net.lapidist.colony.client.systems.SelectionSystem;
+import net.lapidist.colony.client.systems.network.TileUpdateSystem;
+import net.lapidist.colony.components.state.map.MapState;
+import net.lapidist.colony.settings.KeyBindings;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(GdxTestRunner.class)
+public class LogicWorldBuilderTest {
+
+    @Test
+    public void baseBuilderRegistersLogicSystems() {
+        GameClient client = mock(GameClient.class);
+        KeyBindings keys = new KeyBindings();
+        World world = LogicWorldBuilder.build(
+                LogicWorldBuilder.baseBuilder(client, keys),
+                client,
+                new net.lapidist.colony.components.state.resources.ResourceData(),
+                null
+        );
+        assertNotNull(world.getSystem(CameraInputSystem.class));
+        assertNotNull(world.getSystem(SelectionSystem.class));
+        assertNotNull(world.getSystem(BuildPlacementSystem.class));
+        assertNotNull(world.getSystem(PlayerMovementSystem.class));
+        world.dispose();
+    }
+
+    @Test
+    public void builderAddsMapInitSystem() {
+        GameClient client = mock(GameClient.class);
+        KeyBindings keys = new KeyBindings();
+        MapState state = new MapState();
+        World world = LogicWorldBuilder.build(
+                LogicWorldBuilder.builder(state, client, keys, null),
+                client,
+                state.playerResources(),
+                state.playerPos()
+        );
+        assertNotNull(world.getSystem(net.lapidist.colony.client.systems.MapInitSystem.class));
+        assertNotNull(world.getSystem(TileUpdateSystem.class));
+        world.dispose();
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MapScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MapScreenTest.java
@@ -12,6 +12,7 @@ import net.lapidist.colony.client.screens.MapScreenEventHandler;
 import net.lapidist.colony.client.screens.MapUi;
 import net.lapidist.colony.client.screens.MapUiBuilder;
 import net.lapidist.colony.client.screens.MapWorldBuilder;
+import net.lapidist.colony.client.screens.LogicWorldBuilder;
 import net.lapidist.colony.client.ui.MinimapActor;
 import net.lapidist.colony.components.state.map.MapState;
 import net.lapidist.colony.settings.Settings;
@@ -47,15 +48,34 @@ public class MapScreenTest {
         when(colony.getSettings()).thenReturn(settings);
         MapState state = new MapState();
         GameClient client = mock(GameClient.class);
+        World logic = mock(World.class);
         World world = mock(World.class);
         MinimapActor minimap = mock(MinimapActor.class);
 
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class);
+             MockedStatic<LogicWorldBuilder> logicStatic = mockStatic(LogicWorldBuilder.class);
              MockedStatic<MapWorldBuilder> worldStatic = mockStatic(MapWorldBuilder.class);
              MockedStatic<MapUiBuilder> uiStatic = mockStatic(MapUiBuilder.class)) {
-            worldStatic.when(() -> MapWorldBuilder.builder(eq(state), eq(client),
-                    any(Stage.class), eq(settings.getKeyBindings()), eq(settings.getGraphicsSettings()), any()))
-                    .thenReturn(new WorldConfigurationBuilder());
+            logicStatic.when(() -> LogicWorldBuilder.builder(
+                    eq(state),
+                    eq(client),
+                    eq(settings.getKeyBindings()),
+                    any()
+            )).thenReturn(new WorldConfigurationBuilder());
+            logicStatic.when(() -> LogicWorldBuilder.build(
+                    any(),
+                    eq(client),
+                    any(),
+                    any()
+            )).thenReturn(logic);
+            worldStatic.when(() -> MapWorldBuilder.builder(
+                    eq(state),
+                    eq(client),
+                    any(Stage.class),
+                    eq(settings.getKeyBindings()),
+                    eq(settings.getGraphicsSettings()),
+                    any()
+            )).thenReturn(new WorldConfigurationBuilder());
             worldStatic.when(() -> MapWorldBuilder.build(
                     any(),
                     isNull(),
@@ -63,8 +83,8 @@ public class MapScreenTest {
                     any(),
                     eq(client),
                     any(),
-                    any()))
-                    .thenReturn(world);
+                    any()
+            )).thenReturn(world);
             uiStatic.when(() -> MapUiBuilder.build(any(Stage.class), eq(world), eq(client), eq(colony), any()))
                     .thenAnswer(inv -> new MapUi(
                             inv.getArgument(0),
@@ -92,14 +112,17 @@ public class MapScreenTest {
             int expectedSteps = (int) Math.round(DELTA / step);
 
             verify(handler).update();
-            verify(world, times(expectedSteps)).setDelta((float) step);
-            verify(world, times(expectedSteps)).process();
+            verify(logic, times(expectedSteps)).setDelta((float) step);
+            verify(logic, times(expectedSteps)).process();
+            verify(world).setDelta(DELTA);
+            verify(world).process();
             verify(handler).resize(WIDTH, HEIGHT);
             verify(handler).pause();
             verify(handler).resume();
             verify(handler).hide();
             verify(handler).show();
             verify(handler).dispose();
+            verify(logic).dispose();
             verify(world).dispose();
             verify(minimap).dispose();
         }
@@ -115,14 +138,38 @@ public class MapScreenTest {
         GameClient client = mock(GameClient.class);
 
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class);
+             MockedStatic<LogicWorldBuilder> logicStatic = mockStatic(LogicWorldBuilder.class);
              MockedStatic<MapWorldBuilder> worldStatic = mockStatic(MapWorldBuilder.class);
              MockedStatic<MapUiBuilder> uiStatic = mockStatic(MapUiBuilder.class)) {
-            worldStatic.when(() -> MapWorldBuilder.builder(eq(state), eq(client), any(Stage.class),
-                    eq(settings.getKeyBindings()), eq(settings.getGraphicsSettings()), any()))
-                    .thenReturn(new WorldConfigurationBuilder());
-            worldStatic.when(() -> MapWorldBuilder.build(any(), isNull(), eq(settings), any(),
-                    eq(client), any(), any()))
-                    .thenReturn(new World(new WorldConfigurationBuilder().build()));
+            logicStatic.when(() -> LogicWorldBuilder.builder(
+                    eq(state),
+                    eq(client),
+                    eq(settings.getKeyBindings()),
+                    any()
+            )).thenReturn(new WorldConfigurationBuilder());
+            logicStatic.when(() -> LogicWorldBuilder.build(
+                    any(),
+                    eq(client),
+                    any(),
+                    any()
+            )).thenReturn(new World(new WorldConfigurationBuilder().build()));
+            worldStatic.when(() -> MapWorldBuilder.builder(
+                    eq(state),
+                    eq(client),
+                    any(Stage.class),
+                    eq(settings.getKeyBindings()),
+                    eq(settings.getGraphicsSettings()),
+                    any()
+            )).thenReturn(new WorldConfigurationBuilder());
+            worldStatic.when(() -> MapWorldBuilder.build(
+                    any(),
+                    isNull(),
+                    eq(settings),
+                    any(),
+                    eq(client),
+                    any(),
+                    any()
+            )).thenReturn(new World(new WorldConfigurationBuilder().build()));
             uiStatic.when(() -> MapUiBuilder.build(any(Stage.class), any(World.class), eq(client), eq(colony), any()))
                     .thenAnswer(inv -> new MapUi(inv.getArgument(0), mock(MinimapActor.class),
                             mock(net.lapidist.colony.client.ui.ChatBox.class)));
@@ -141,17 +188,42 @@ public class MapScreenTest {
         when(colony.getSettings()).thenReturn(settings);
         MapState state = new MapState();
         GameClient client = mock(GameClient.class);
+        World logic = mock(World.class);
         World world = mock(World.class);
 
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class);
+             MockedStatic<LogicWorldBuilder> logicStatic = mockStatic(LogicWorldBuilder.class);
              MockedStatic<MapWorldBuilder> worldStatic = mockStatic(MapWorldBuilder.class);
              MockedStatic<MapUiBuilder> uiStatic = mockStatic(MapUiBuilder.class)) {
-            worldStatic.when(() -> MapWorldBuilder.builder(eq(state), eq(client), any(Stage.class),
-                    eq(settings.getKeyBindings()), eq(settings.getGraphicsSettings()), any()))
-                    .thenReturn(new WorldConfigurationBuilder());
-            worldStatic.when(() -> MapWorldBuilder.build(any(), isNull(), eq(settings), any(),
-                    eq(client), any(), any()))
-                    .thenReturn(world);
+            logicStatic.when(() -> LogicWorldBuilder.builder(
+                    eq(state),
+                    eq(client),
+                    eq(settings.getKeyBindings()),
+                    any()
+            )).thenReturn(new WorldConfigurationBuilder());
+            logicStatic.when(() -> LogicWorldBuilder.build(
+                    any(),
+                    eq(client),
+                    any(),
+                    any()
+            )).thenReturn(logic);
+            worldStatic.when(() -> MapWorldBuilder.builder(
+                    eq(state),
+                    eq(client),
+                    any(Stage.class),
+                    eq(settings.getKeyBindings()),
+                    eq(settings.getGraphicsSettings()),
+                    any()
+            )).thenReturn(new WorldConfigurationBuilder());
+            worldStatic.when(() -> MapWorldBuilder.build(
+                    any(),
+                    isNull(),
+                    eq(settings),
+                    any(),
+                    eq(client),
+                    any(),
+                    any()
+            )).thenReturn(world);
             uiStatic.when(() -> MapUiBuilder.build(any(Stage.class), eq(world), eq(client), eq(colony), any()))
                     .thenAnswer(inv -> new MapUi(inv.getArgument(0), mock(MinimapActor.class),
                             mock(net.lapidist.colony.client.ui.ChatBox.class)));
@@ -160,6 +232,7 @@ public class MapScreenTest {
             screen.setPaused(true);
             screen.render(DELTA);
 
+            verify(logic, never()).process();
             verify(world, never()).process();
         }
     }
@@ -171,14 +244,33 @@ public class MapScreenTest {
         when(colony.getSettings()).thenReturn(settings);
         MapState state = new MapState();
         GameClient client = mock(GameClient.class);
+        World logic = mock(World.class);
         World world = mock(World.class);
 
         try (MockedConstruction<SpriteBatch> ignored = mockConstruction(SpriteBatch.class);
+             MockedStatic<LogicWorldBuilder> logicStatic = mockStatic(LogicWorldBuilder.class);
              MockedStatic<MapWorldBuilder> worldStatic = mockStatic(MapWorldBuilder.class);
              MockedStatic<MapUiBuilder> uiStatic = mockStatic(MapUiBuilder.class)) {
-            worldStatic.when(() -> MapWorldBuilder.builder(eq(state), eq(client), any(Stage.class),
-                    eq(settings.getKeyBindings()), eq(settings.getGraphicsSettings()), any()))
-                    .thenReturn(new WorldConfigurationBuilder());
+            logicStatic.when(() -> LogicWorldBuilder.builder(
+                    eq(state),
+                    eq(client),
+                    eq(settings.getKeyBindings()),
+                    any()
+            )).thenReturn(new WorldConfigurationBuilder());
+            logicStatic.when(() -> LogicWorldBuilder.build(
+                    any(),
+                    eq(client),
+                    any(),
+                    any()
+            )).thenReturn(logic);
+            worldStatic.when(() -> MapWorldBuilder.builder(
+                    eq(state),
+                    eq(client),
+                    any(Stage.class),
+                    eq(settings.getKeyBindings()),
+                    eq(settings.getGraphicsSettings()),
+                    any()
+            )).thenReturn(new WorldConfigurationBuilder());
             worldStatic.when(() -> MapWorldBuilder.build(any(), isNull(), eq(settings), any(),
                     eq(client), any(), any()))
                     .thenReturn(world);
@@ -195,7 +287,8 @@ public class MapScreenTest {
             screen.setSpeedMultiplier(HALF);
             screen.render(DELTA);
 
-            verify(world, times(expectedSteps)).process();
+            verify(logic, times(expectedSteps)).process();
+            verify(world).process();
         }
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MapWorldBuilderConfigurationTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MapWorldBuilderConfigurationTest.java
@@ -63,10 +63,10 @@ public class MapWorldBuilderConfigurationTest {
                     null
             );
 
-            assertNotNull(world.getSystem(CameraInputSystem.class));
-            assertNotNull(world.getSystem(SelectionSystem.class));
-            assertNotNull(world.getSystem(BuildPlacementSystem.class));
-            assertNotNull(world.getSystem(PlayerMovementSystem.class));
+            assertNull(world.getSystem(CameraInputSystem.class));
+            assertNull(world.getSystem(SelectionSystem.class));
+            assertNull(world.getSystem(BuildPlacementSystem.class));
+            assertNull(world.getSystem(PlayerMovementSystem.class));
             assertNotNull(world.getSystem(MapRenderSystem.class));
             assertNull(world.getSystem(MapInitSystem.class));
             assertNull(world.getSystem(MapRenderDataSystem.class));
@@ -112,7 +112,7 @@ public class MapWorldBuilderConfigurationTest {
 
             assertNotNull(world.getSystem(MapInitSystem.class));
             assertNotNull(world.getSystem(PlayerCameraSystem.class));
-            assertNotNull(world.getSystem(PlayerMovementSystem.class));
+            assertNull(world.getSystem(PlayerMovementSystem.class));
             assertNotNull(world.getSystem(MapRenderDataSystem.class));
             assertNotNull(world.getSystem(net.lapidist.colony.client.systems.CelestialSystem.class));
             assertNotNull(world.getSystem(SeasonCycleSystem.class));


### PR DESCRIPTION
## Summary
- add `LogicWorldBuilder` for update-only world construction
- strip logic systems from `MapWorldBuilder`
- maintain logic and render worlds in `MapScreen`
- update docs to describe the two-world setup
- adjust tests for the new architecture

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_6853acba5c108328881d1417ef653ce8