### PR TITLE
Fix Perlin noise floor rounding

### DIFF
--- a/core/src/main/java/net/lapidist/colony/map/PerlinNoise.java
+++ b/core/src/main/java/net/lapidist/colony/map/PerlinNoise.java
@@ -56,7 +56,8 @@ public final class PerlinNoise {
     }
 
     private static int fastFloor(final double x) {
-        return x > 0 ? (int) x : (int) x - 1;
+        int xi = (int) x;
+        return x < xi ? xi - 1 : xi;
     }
 
     private static double fade(final double t) {

--- a/tests/src/test/java/net/lapidist/colony/tests/map/PerlinNoiseTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/map/PerlinNoiseTest.java
@@ -31,4 +31,12 @@ public class PerlinNoiseTest {
         double value = noise.noise(X2, Y2);
         assertTrue(value >= -1.0 && value <= 1.0);
     }
+
+    @Test
+    public void negativeIntegerInputsStable() {
+        PerlinNoise noise = new PerlinNoise(SEED_TWO);
+        double exact = noise.noise(-1.0, 0.0);
+        double near = noise.noise(-1.0 + 1e-6, 0.0);
+        assertEquals(exact, near, 1e-5);
+    }
 }


### PR DESCRIPTION
## Summary
- fix fastFloor so negative integer coordinates return correct values
- test Perlin noise around negative integer coordinates

## Testing
- `./gradlew spotlessApply`
- `./gradlew tests:copyAssets`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`

------
https://chatgpt.com/codex/tasks/task_e_6853b9f0add88328821e479a59a789a5