### PR TITLE
fix: register missing item types

### DIFF
--- a/core/src/main/java/net/lapidist/colony/base/BaseItemsMod.java
+++ b/core/src/main/java/net/lapidist/colony/base/BaseItemsMod.java
@@ -10,5 +10,7 @@ public final class BaseItemsMod implements GameMod {
     public void init() {
         Registries.items().register(new ItemDefinition("stick", "Stick", "stick0"));
         Registries.items().register(new ItemDefinition("stone", "Stone", "stone0"));
+        Registries.items().register(new ItemDefinition("wood", "Wood", "wood0"));
+        Registries.items().register(new ItemDefinition("food", "Food", "food0"));
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/core/base/BaseItemsModTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/base/BaseItemsModTest.java
@@ -15,5 +15,7 @@ public class BaseItemsModTest {
 
         assertNotNull(Registries.items().get("stick"));
         assertNotNull(Registries.items().get("stone"));
+        assertNotNull(Registries.items().get("wood"));
+        assertNotNull(Registries.items().get("food"));
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/server/InventoryServiceTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/InventoryServiceTest.java
@@ -24,11 +24,15 @@ public class InventoryServiceTest {
         AtomicReference<MapState> ref = new AtomicReference<>(state);
         ReentrantLock lock = new ReentrantLock();
         InventoryService inv = new InventoryService(ref::get, ref::set, lock);
-        inv.addItem("stone", 2);
+        final int stoneAmount = 2;
+        final int woodAmount = 3;
+        inv.addItem("stone", stoneAmount);
+        inv.addItem("wood", woodAmount);
         final int unknownAmount = 5;
         inv.addItem("unknown", unknownAmount);
 
-        assertEquals(2, inv.getAmount("stone"));
+        assertEquals(stoneAmount, inv.getAmount("stone"));
+        assertEquals(woodAmount, inv.getAmount("wood"));
         assertEquals(0, inv.getAmount("unknown"));
     }
 }


### PR DESCRIPTION
## Summary
- include wood and food in default items
- update unit tests for new items
- validate InventoryService handles wood items

## Testing
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_6853bb3a57e88328a342120798ba12a5