### PR TITLE
fix: prevent negative inventory updates

### DIFF
--- a/server/src/main/java/net/lapidist/colony/server/services/InventoryService.java
+++ b/server/src/main/java/net/lapidist/colony/server/services/InventoryService.java
@@ -30,7 +30,7 @@ public final class InventoryService {
      * @param amount quantity to add
      */
     public void addItem(final String itemId, final int amount) {
-        if (itemId == null || amount == 0 || Registries.items().get(itemId) == null) {
+        if (itemId == null || amount <= 0 || Registries.items().get(itemId) == null) {
             return;
         }
         lock.lock();

--- a/tests/src/test/java/net/lapidist/colony/tests/map/PerlinNoiseTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/map/PerlinNoiseTest.java
@@ -35,8 +35,10 @@ public class PerlinNoiseTest {
     @Test
     public void negativeIntegerInputsStable() {
         PerlinNoise noise = new PerlinNoise(SEED_TWO);
+        final double epsilon = 1e-6;
+        final double tolerance = 1e-5;
         double exact = noise.noise(-1.0, 0.0);
-        double near = noise.noise(-1.0 + 1e-6, 0.0);
-        assertEquals(exact, near, 1e-5);
+        double near = noise.noise(-1.0 + epsilon, 0.0);
+        assertEquals(exact, near, tolerance);
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/server/InventoryServiceTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/server/InventoryServiceTest.java
@@ -35,4 +35,19 @@ public class InventoryServiceTest {
         assertEquals(woodAmount, inv.getAmount("wood"));
         assertEquals(0, inv.getAmount("unknown"));
     }
+
+    @Test
+    public void ignoresNegativeAmount() {
+        MapState state = new MapState();
+        java.util.concurrent.atomic.AtomicReference<MapState> ref =
+                new java.util.concurrent.atomic.AtomicReference<>(state);
+        java.util.concurrent.locks.ReentrantLock lock =
+                new java.util.concurrent.locks.ReentrantLock();
+        InventoryService inv = new InventoryService(ref::get, ref::set, lock);
+
+        final int negative = -5;
+        inv.addItem("stone", negative);
+
+        assertEquals(0, inv.getAmount("stone"));
+    }
 }


### PR DESCRIPTION
## Summary
- ignore negative amounts in InventoryService
- add regression test for negative amounts
- tidy PerlinNoiseTest

## Testing
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_6853c1545cd88328b9e6fa99efa56d31