### PR TITLE
fix: initialize map UI with logic world

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/MapScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapScreen.java
@@ -87,7 +87,7 @@ public final class MapScreen implements Screen {
             cameraSystem.setClient(client);
         }
         events = new MapScreenEventHandler();
-        MapUi ui = MapUiBuilder.build(stage, renderWorld, client, colony, events);
+        MapUi ui = MapUiBuilder.build(stage, logicWorld, client, colony, events);
         minimapActor = ui.getMinimapActor();
         events.attach(this);
         accumulator = 0.0;

--- a/tests/src/test/java/net/lapidist/colony/tests/async/MapScreenAsyncTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/async/MapScreenAsyncTest.java
@@ -70,7 +70,7 @@ public class MapScreenAsyncTest {
             worldStatic.when(() -> MapWorldBuilder.build(any(), isNull(), eq(settings), any(),
                     eq(client), any(), any()))
                     .thenReturn(world);
-            uiStatic.when(() -> MapUiBuilder.build(any(Stage.class), eq(world), eq(client), eq(colony), any()))
+            uiStatic.when(() -> MapUiBuilder.build(any(Stage.class), any(World.class), eq(client), eq(colony), any()))
                     .thenAnswer(inv -> new MapUi(inv.getArgument(0), mock(MinimapActor.class),
                             mock(net.lapidist.colony.client.ui.ChatBox.class)));
 

--- a/tests/src/test/java/net/lapidist/colony/tests/map/PerlinNoiseTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/map/PerlinNoiseTest.java
@@ -15,6 +15,8 @@ public class PerlinNoiseTest {
     private static final double X2 = 0.2;
     private static final double Y2 = 0.8;
     private static final double EPSILON = 1e-6;
+    private static final double SMALL_DELTA = 1e-6;
+    private static final double COMP_EPSILON = 1e-5;
 
     @Test
     public void sameSeedProducesSameValues() {
@@ -36,7 +38,7 @@ public class PerlinNoiseTest {
     public void negativeIntegerInputsStable() {
         PerlinNoise noise = new PerlinNoise(SEED_TWO);
         double exact = noise.noise(-1.0, 0.0);
-        double near = noise.noise(-1.0 + 1e-6, 0.0);
-        assertEquals(exact, near, 1e-5);
+        double near = noise.noise(-1.0 + SMALL_DELTA, 0.0);
+        assertEquals(exact, near, COMP_EPSILON);
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MapScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MapScreenTest.java
@@ -85,7 +85,7 @@ public class MapScreenTest {
                     any(),
                     any()
             )).thenReturn(world);
-            uiStatic.when(() -> MapUiBuilder.build(any(Stage.class), eq(world), eq(client), eq(colony), any()))
+            uiStatic.when(() -> MapUiBuilder.build(any(Stage.class), eq(logic), eq(client), eq(colony), any()))
                     .thenAnswer(inv -> new MapUi(
                             inv.getArgument(0),
                             minimap,
@@ -224,7 +224,7 @@ public class MapScreenTest {
                     any(),
                     any()
             )).thenReturn(world);
-            uiStatic.when(() -> MapUiBuilder.build(any(Stage.class), eq(world), eq(client), eq(colony), any()))
+            uiStatic.when(() -> MapUiBuilder.build(any(Stage.class), eq(logic), eq(client), eq(colony), any()))
                     .thenAnswer(inv -> new MapUi(inv.getArgument(0), mock(MinimapActor.class),
                             mock(net.lapidist.colony.client.ui.ChatBox.class)));
 
@@ -274,7 +274,7 @@ public class MapScreenTest {
             worldStatic.when(() -> MapWorldBuilder.build(any(), isNull(), eq(settings), any(),
                     eq(client), any(), any()))
                     .thenReturn(world);
-            uiStatic.when(() -> MapUiBuilder.build(any(Stage.class), eq(world), eq(client), eq(colony), any()))
+            uiStatic.when(() -> MapUiBuilder.build(any(Stage.class), eq(logic), eq(client), eq(colony), any()))
                     .thenAnswer(inv -> new MapUi(inv.getArgument(0), mock(MinimapActor.class),
                             mock(net.lapidist.colony.client.ui.ChatBox.class)));
 


### PR DESCRIPTION
## Summary
- ensure MapUi uses logic world so build system is available
- adjust async and sync MapScreen tests for new world reference
- fix checkstyle warning by replacing magic numbers in PerlinNoiseTest

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6853c358158c8328b9f79377a06627b8