### PR TITLE
fix(client): rebuild render data after metadata load

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/render/MapRenderData.java
+++ b/client/src/main/java/net/lapidist/colony/client/render/MapRenderData.java
@@ -17,4 +17,10 @@ public interface MapRenderData {
 
     /** Returns the map version used to generate this data. */
     int getVersion();
+
+    /** Width of the rendered map in tiles. */
+    int getWidth();
+
+    /** Height of the rendered map in tiles. */
+    int getHeight();
 }

--- a/client/src/main/java/net/lapidist/colony/client/render/SimpleMapRenderData.java
+++ b/client/src/main/java/net/lapidist/colony/client/render/SimpleMapRenderData.java
@@ -47,6 +47,16 @@ public final class SimpleMapRenderData implements MapRenderData {
         return version;
     }
 
+    @Override
+    public int getWidth() {
+        return tileGrid.length;
+    }
+
+    @Override
+    public int getHeight() {
+        return tileGrid.length > 0 ? tileGrid[0].length : 0;
+    }
+
     /** Sets the map version for this render data. */
     public void setVersion(final int newVersion) {
         this.version = newVersion;

--- a/client/src/main/java/net/lapidist/colony/client/systems/MapRenderDataSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/MapRenderDataSystem.java
@@ -23,6 +23,8 @@ public final class MapRenderDataSystem extends BaseSystem {
     private MapRenderData renderData;
     private MapComponent map;
     private int lastVersion;
+    private int lastWidth;
+    private int lastHeight;
     private ComponentMapper<TileComponent> tileMapper;
     private ComponentMapper<ResourceComponent> resourceMapper;
     private ComponentMapper<BuildingComponent> buildingMapper;
@@ -78,6 +80,8 @@ public final class MapRenderDataSystem extends BaseSystem {
                     : net.lapidist.colony.components.state.map.MapState.DEFAULT_HEIGHT;
             renderData = MapRenderDataBuilder.fromMap(map, world, width, height);
             lastVersion = map.getVersion();
+            lastWidth = width;
+            lastHeight = height;
             rebuildSelectedIndices();
         }
     }
@@ -99,7 +103,25 @@ public final class MapRenderDataSystem extends BaseSystem {
                     : net.lapidist.colony.components.state.map.MapState.DEFAULT_HEIGHT;
             renderData = MapRenderDataBuilder.fromMap(map, world, width, height);
             lastVersion = map.getVersion();
+            lastWidth = width;
+            lastHeight = height;
             rebuildSelectedIndices();
+            return;
+        }
+        int width = client != null
+                ? client.getMapWidth()
+                : net.lapidist.colony.components.state.map.MapState.DEFAULT_WIDTH;
+        int height = client != null
+                ? client.getMapHeight()
+                : net.lapidist.colony.components.state.map.MapState.DEFAULT_HEIGHT;
+        if (width != lastWidth || height != lastHeight) {
+            renderData = MapRenderDataBuilder.fromMap(map, world, width, height);
+            lastVersion = map.getVersion();
+            lastWidth = width;
+            lastHeight = height;
+            rebuildSelectedIndices();
+            dirtyIndices.clear();
+            updatedIndices.clear();
             return;
         }
         if (map.getVersion() != lastVersion) {


### PR DESCRIPTION
## Summary
- add width/height to MapRenderData
- expose these from SimpleMapRenderData
- recreate render data when client map size changes

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_6853d263565883288bb7d7cb0573cebc