### PR TITLE
refactor: remove UI scaling system

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/Colony.java
+++ b/client/src/main/java/net/lapidist/colony/client/Colony.java
@@ -100,8 +100,7 @@ public final class Colony extends Game {
                 }
                 setScreen(new ErrorScreen(this, I18n.get("error.connectionFailed")));
             }));
-            float scale = settings == null ? 1f : settings.getUiScale();
-            LoadingScreen loading = new LoadingScreen(scale);
+            LoadingScreen loading = new LoadingScreen();
             loading.setMessage(I18n.get("loading.connect"));
             client.setLoadProgressListener(p -> Gdx.app.postRunnable(() -> loading.setProgress(p)));
             client.setLoadMessageListener(msg -> Gdx.app.postRunnable(() -> loading.setMessage(msg)));

--- a/client/src/main/java/net/lapidist/colony/client/screens/ErrorScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/ErrorScreen.java
@@ -10,8 +10,6 @@ import net.lapidist.colony.client.Colony;
 /** Simple screen that displays an error message with a button to return to the main menu. */
 public final class ErrorScreen extends BaseScreen {
     public ErrorScreen(final Colony colony, final String message) {
-        float scale = colony.getSettings() == null ? 1f : colony.getSettings().getUiScale();
-        getStage().getRoot().setScale(scale);
         Label label = createLabel(message);
         TextButton back = createButton(I18n.get("common.back"));
 

--- a/client/src/main/java/net/lapidist/colony/client/screens/GraphicsSettingsScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/GraphicsSettingsScreen.java
@@ -7,8 +7,6 @@ import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
 import com.badlogic.gdx.scenes.scene2d.ui.SelectBox;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
-import com.badlogic.gdx.scenes.scene2d.ui.Slider;
-import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.utils.viewport.ScreenViewport;
 import net.lapidist.colony.client.Colony;
@@ -33,13 +31,7 @@ public final class GraphicsSettingsScreen extends BaseScreen {
     private final CheckBox cacheBox;
     private final CheckBox lightingBox;
     private final CheckBox dayNightBox;
-    private final Slider uiScaleSlider;
-    private final Label uiScaleLabel;
     private static final float PADDING = 10f;
-    private static final float SCALE_MIN = 0.5f;
-    private static final float SCALE_MAX = 2f;
-    private static final float SCALE_STEP = 0.1f;
-    private static final float SLIDER_WIDTH = 150f;
 
     public GraphicsSettingsScreen(final Colony game) {
         this(game, new Stage(new ScreenViewport()));
@@ -48,8 +40,6 @@ public final class GraphicsSettingsScreen extends BaseScreen {
     public GraphicsSettingsScreen(final Colony game, final Stage stage) {
         super(stage);
         this.colony = game;
-        float scale = game.getSettings() == null ? 1f : game.getSettings().getUiScale();
-        stage.getRoot().setScale(scale);
 
         GraphicsSettings graphics = colony.getSettings().getGraphicsSettings();
         net.lapidist.colony.settings.Settings general = colony.getSettings();
@@ -86,9 +76,6 @@ public final class GraphicsSettingsScreen extends BaseScreen {
         lightingBox.setChecked(graphics.isLightingEnabled());
         dayNightBox = new CheckBox(I18n.get("graphics.dayNightCycle"), getSkin());
         dayNightBox.setChecked(graphics.isDayNightCycleEnabled());
-        uiScaleSlider = new Slider(SCALE_MIN, SCALE_MAX, SCALE_STEP, false, getSkin());
-        uiScaleSlider.setValue(general.getUiScale());
-        uiScaleLabel = new Label(I18n.get("graphics.uiScale"), getSkin());
 
         TextButton save = new TextButton(I18n.get("common.save"), getSkin());
         TextButton back = new TextButton(I18n.get("common.back"), getSkin());
@@ -105,10 +92,6 @@ public final class GraphicsSettingsScreen extends BaseScreen {
         options.add(rendererBox).left().row();
         options.add(resolutionBox).left().row();
         options.add(fullscreenBox).left().row();
-        Table scaleRow = new Table();
-        scaleRow.add(uiScaleLabel).padRight(PADDING);
-        scaleRow.add(uiScaleSlider).width(SLIDER_WIDTH);
-        options.add(scaleRow).left().row();
 
         ScrollPane scroll = new ScrollPane(options, getSkin());
         scroll.setScrollingDisabled(true, false);
@@ -136,7 +119,6 @@ public final class GraphicsSettingsScreen extends BaseScreen {
                 general.setWidth(Integer.parseInt(res[0]));
                 general.setHeight(Integer.parseInt(res[1]));
                 general.setFullscreen(fullscreenBox.isChecked());
-                general.setUiScale(uiScaleSlider.getValue());
                 save();
             }
         });

--- a/client/src/main/java/net/lapidist/colony/client/screens/KeybindsScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/KeybindsScreen.java
@@ -34,8 +34,6 @@ public final class KeybindsScreen extends BaseScreen {
     public KeybindsScreen(final Colony game, final Stage stage) {
         super(stage);
         this.colony = game;
-        float scale = game.getSettings() == null ? 1f : game.getSettings().getUiScale();
-        stage.getRoot().setScale(scale);
         KeyBindings bindings = game.getSettings().getKeyBindings();
         Table root = getRoot();
         Table list = new Table();

--- a/client/src/main/java/net/lapidist/colony/client/screens/LoadGameScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/LoadGameScreen.java
@@ -28,8 +28,6 @@ public final class LoadGameScreen extends BaseScreen {
 
     public LoadGameScreen(final Colony game) {
         this.colony = game;
-        float scale = game.getSettings() == null ? 1f : game.getSettings().getUiScale();
-        getStage().getRoot().setScale(scale);
 
         this.saves = listSaves();
         this.list = new Table();

--- a/client/src/main/java/net/lapidist/colony/client/screens/LoadingScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/LoadingScreen.java
@@ -19,11 +19,6 @@ public final class LoadingScreen extends BaseScreen {
     private final ProgressBar progressBar;
 
     public LoadingScreen() {
-        this(1f);
-    }
-
-    public LoadingScreen(final float scale) {
-        getStage().getRoot().setScale(scale);
         messageLabel = new Label(I18n.get("loading.title"), getSkin());
         ProgressBarStyle style = new ProgressBarStyle();
         style.background = getSkin().newDrawable("white_pixel", Color.DARK_GRAY);

--- a/client/src/main/java/net/lapidist/colony/client/screens/MainMenuScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MainMenuScreen.java
@@ -21,8 +21,6 @@ public final class MainMenuScreen extends BaseScreen {
 
     public MainMenuScreen(final Colony game) {
         this.colony = game;
-        float scale = game.getSettings() == null ? 1f : game.getSettings().getUiScale();
-        getStage().getRoot().setScale(scale);
 
         Image logo = new Image(new TextureRegionDrawable(new Texture(Gdx.files.internal("textures/logo.png"))));
         TextButton continueButton = createButton(I18n.get("main.continue"));

--- a/client/src/main/java/net/lapidist/colony/client/screens/MapScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapScreen.java
@@ -27,7 +27,6 @@ public final class MapScreen implements Screen {
     private boolean paused;
     /** Multiplier applied to frame time for slow or fast motion. */
     private float speedMultiplier;
-    private static final float DEFAULT_SCALE = 1f;
     /** Fixed time step used for deterministic updates. */
     private static final double STEP_TIME = 1d / 60d;
     /**
@@ -35,12 +34,6 @@ public final class MapScreen implements Screen {
      */
     private double accumulator;
 
-    private void applyScale() {
-        float scale = colony.getSettings() == null ? DEFAULT_SCALE : colony.getSettings().getUiScale();
-        ScreenViewport viewport = (ScreenViewport) stage.getViewport();
-        viewport.setUnitsPerPixel(1f / scale);
-        viewport.update(Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), true);
-    }
 
     public MapScreen(final Colony colonyToSet, final MapState state, final GameClient client) {
         this(colonyToSet, state, client, null);
@@ -54,7 +47,6 @@ public final class MapScreen implements Screen {
     ) {
         this.colony = colonyToSet;
         stage = new Stage(new ScreenViewport());
-        applyScale();
         logicWorld = LogicWorldBuilder.build(
                 LogicWorldBuilder.builder(
                         state,
@@ -152,7 +144,6 @@ public final class MapScreen implements Screen {
     @Override
     public void resume() {
         events.resume();
-        applyScale();
         events.resize(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
     }
 
@@ -163,7 +154,6 @@ public final class MapScreen implements Screen {
 
     @Override
     public void show() {
-        applyScale();
         events.resize(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
         events.show();
     }

--- a/client/src/main/java/net/lapidist/colony/client/screens/ModSelectionScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/ModSelectionScreen.java
@@ -29,8 +29,6 @@ public final class ModSelectionScreen extends BaseScreen {
 
     public ModSelectionScreen(final Colony game) {
         this.colony = game;
-        float scale = game.getSettings() == null ? 1f : game.getSettings().getUiScale();
-        getStage().getRoot().setScale(scale);
         this.mods = game.getMods();
         getRoot().add(new com.badlogic.gdx.scenes.scene2d.ui.Label(
                 I18n.get("modSelect.title"), getSkin())).row();

--- a/client/src/main/java/net/lapidist/colony/client/screens/NewGameScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/NewGameScreen.java
@@ -35,8 +35,6 @@ public final class NewGameScreen extends BaseScreen {
 
     public NewGameScreen(final Colony game) {
         this.colony = game;
-        float scale = game.getSettings() == null ? 1f : game.getSettings().getUiScale();
-        getStage().getRoot().setScale(scale);
 
         Label nameLabel = new Label(I18n.get("newGame.saveName"), getSkin());
         TextField nameField = new TextField("", getSkin());

--- a/client/src/main/java/net/lapidist/colony/client/screens/SettingsScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/SettingsScreen.java
@@ -28,8 +28,6 @@ public final class SettingsScreen extends BaseScreen {
 
     public SettingsScreen(final Colony game) {
         this.colony = game;
-        float scale = game.getSettings() == null ? 1f : game.getSettings().getUiScale();
-        getStage().getRoot().setScale(scale);
         localeIndex = findLocaleIndex(colony.getSettings().getLocale());
         language = new TextButton(getLanguageText(SUPPORTED_LOCALES[localeIndex]), getSkin());
         TextButton keybinds = new TextButton(I18n.get("settings.keybinds"), getSkin());

--- a/core/src/main/java/net/lapidist/colony/settings/Settings.java
+++ b/core/src/main/java/net/lapidist/colony/settings/Settings.java
@@ -15,8 +15,6 @@ public final class Settings {
     private static final String WIDTH_KEY = "width";
     private static final String HEIGHT_KEY = "height";
     private static final String FULLSCREEN_KEY = "fullscreen";
-    private static final String UI_SCALE_KEY = "uiScale";
-    private static final float DEFAULT_UI_SCALE = 1f;
 
     private final KeyBindings keyBindings = new KeyBindings();
     private final GraphicsSettings graphicsSettings = new GraphicsSettings();
@@ -25,7 +23,6 @@ public final class Settings {
     private int width = DEFAULT_WIDTH;
     private int height = DEFAULT_HEIGHT;
     private boolean fullscreen;
-    private float uiScale = DEFAULT_UI_SCALE;
 
     public KeyBindings getKeyBindings() {
         return keyBindings;
@@ -67,13 +64,6 @@ public final class Settings {
         this.fullscreen = fullscreenToSet;
     }
 
-    public float getUiScale() {
-        return uiScale;
-    }
-
-    public void setUiScale(final float scale) {
-        this.uiScale = scale;
-    }
 
     /**
      * Load settings from the configuration file located next to the save folder.
@@ -104,10 +94,6 @@ public final class Settings {
             String heightStr = props.getProperty(HEIGHT_KEY);
             if (heightStr != null) {
                 settings.setHeight(Integer.parseInt(heightStr));
-            }
-            String uiScaleStr = props.getProperty(UI_SCALE_KEY);
-            if (uiScaleStr != null) {
-                settings.setUiScale(Float.parseFloat(uiScaleStr));
             }
             settings.setFullscreen(Boolean.parseBoolean(props.getProperty(FULLSCREEN_KEY, "false")));
             KeyBindings loaded = KeyBindings.load(props);
@@ -152,7 +138,6 @@ public final class Settings {
         props.setProperty(WIDTH_KEY, Integer.toString(width));
         props.setProperty(HEIGHT_KEY, Integer.toString(height));
         props.setProperty(FULLSCREEN_KEY, Boolean.toString(fullscreen));
-        props.setProperty(UI_SCALE_KEY, Float.toString(uiScale));
         keyBindings.save(props);
         graphicsSettings.save(props);
         try (java.io.OutputStream out = java.nio.file.Files.newOutputStream(file)) {

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -79,7 +79,6 @@ graphics.dayNightCycle=Day/Night Cycle
 graphics.lightRays=Light Rays
 graphics.resolution=Resolution
 graphics.fullscreen=Fullscreen
-graphics.uiScale=UI Scale
 common.save=Save
 ui.saving=Saving...
 modSelect.title=Mods

--- a/core/src/main/resources/i18n/messages_de.properties
+++ b/core/src/main/resources/i18n/messages_de.properties
@@ -78,7 +78,6 @@ graphics.dayNightCycle=Tag-/Nachtzyklus
 graphics.lightRays=Lichtstrahlen
 graphics.resolution=Aufl\u00f6sung
 graphics.fullscreen=Vollbild
-graphics.uiScale=UI-Skalierung
 common.save=Speichern
 ui.saving=Speichern...
 modSelect.title=Mods

--- a/core/src/main/resources/i18n/messages_es.properties
+++ b/core/src/main/resources/i18n/messages_es.properties
@@ -78,7 +78,6 @@ graphics.dayNightCycle=Ciclo d\u00eda/noche
 graphics.lightRays=Rayos de luz
 graphics.resolution=Resoluci\u00f3n
 graphics.fullscreen=Pantalla completa
-graphics.uiScale=Escala de IU
 common.save=Guardar
 ui.saving=Guardando...
 modSelect.title=Mods

--- a/core/src/main/resources/i18n/messages_fr.properties
+++ b/core/src/main/resources/i18n/messages_fr.properties
@@ -78,7 +78,6 @@ graphics.dayNightCycle=Cycle jour/nuit
 graphics.lightRays=Rayons lumineux
 graphics.resolution=R\u00e9solution
 graphics.fullscreen=Plein \u00e9cran
-graphics.uiScale=\u00c9chelle UI
 common.save=Sauvegarder
 ui.saving=Sauvegarde...
 modSelect.title=Mods

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,6 +95,3 @@ height=1080
 fullscreen=false
 ```
 
-`uiScale` controls how large UI elements appear. The default is `1.0` and larger
-values increase the interface size.
-

--- a/tests/src/test/java/net/lapidist/colony/tests/core/settings/SettingsTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/core/settings/SettingsTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertEquals;
 public class SettingsTest {
     private static final int RES_W = 1024;
     private static final int RES_H = 768;
-    private static final float SCALE = 1.5f;
 
     @Test
     public void savesAndLoadsLocale() throws IOException {
@@ -106,13 +105,11 @@ public class SettingsTest {
         settings.setWidth(RES_W);
         settings.setHeight(RES_H);
         settings.setFullscreen(true);
-        settings.setUiScale(SCALE);
         settings.save(paths);
 
         Settings loaded = Settings.load(paths);
         assertEquals(RES_W, loaded.getWidth());
         assertEquals(RES_H, loaded.getHeight());
         assertEquals(true, loaded.isFullscreen());
-        assertEquals(SCALE, loaded.getUiScale(), 0f);
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MapScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MapScreenTest.java
@@ -33,7 +33,6 @@ public class MapScreenTest {
     private static final float HALF = 0.5f;
     private static final int WIDTH = 800;
     private static final int HEIGHT = 600;
-    private static final float SCALE = 1.5f;
 
     private static Stage extractStage(final MapScreen screen) throws Exception {
         Field stageField = MapScreen.class.getDeclaredField("stage");
@@ -132,7 +131,6 @@ public class MapScreenTest {
     public void viewportUsesUiScale() throws Exception {
         Colony colony = mock(Colony.class);
         Settings settings = new Settings();
-        settings.setUiScale(SCALE);
         when(colony.getSettings()).thenReturn(settings);
         MapState state = new MapState();
         GameClient client = mock(GameClient.class);
@@ -177,7 +175,7 @@ public class MapScreenTest {
             MapScreen screen = new MapScreen(colony, state, client);
             Stage stage = extractStage(screen);
             ScreenViewport vp = (ScreenViewport) stage.getViewport();
-            assertEquals(1f / settings.getUiScale(), vp.getUnitsPerPixel(), 0f);
+            assertEquals(1f, vp.getUnitsPerPixel(), 0f);
         }
     }
 


### PR DESCRIPTION
## Summary
- strip out uiScale support from settings
- drop uiScale slider from graphics settings
- stop using uiScale across client screens
- update docs and translations
- adjust tests

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68545dd7fea08328a2f3b17375a6227e