### PR TITLE
fix: use map size when client missing

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/systems/MapRenderDataSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/MapRenderDataSystem.java
@@ -72,12 +72,9 @@ public final class MapRenderDataSystem extends BaseSystem {
         buildingMapper = world.getMapper(BuildingComponent.class);
         map = MapUtils.findMap(world).orElse(null);
         if (map != null) {
-            int width = client != null
-                    ? client.getMapWidth()
-                    : net.lapidist.colony.components.state.map.MapState.DEFAULT_WIDTH;
-            int height = client != null
-                    ? client.getMapHeight()
-                    : net.lapidist.colony.components.state.map.MapState.DEFAULT_HEIGHT;
+            int[] dims = determineDimensions();
+            int width = dims[0];
+            int height = dims[1];
             renderData = MapRenderDataBuilder.fromMap(map, world, width, height);
             lastVersion = map.getVersion();
             lastWidth = width;
@@ -95,12 +92,9 @@ public final class MapRenderDataSystem extends BaseSystem {
             }
         }
         if (renderData == null) {
-            int width = client != null
-                    ? client.getMapWidth()
-                    : net.lapidist.colony.components.state.map.MapState.DEFAULT_WIDTH;
-            int height = client != null
-                    ? client.getMapHeight()
-                    : net.lapidist.colony.components.state.map.MapState.DEFAULT_HEIGHT;
+            int[] dims = determineDimensions();
+            int width = dims[0];
+            int height = dims[1];
             renderData = MapRenderDataBuilder.fromMap(map, world, width, height);
             lastVersion = map.getVersion();
             lastWidth = width;
@@ -108,12 +102,9 @@ public final class MapRenderDataSystem extends BaseSystem {
             rebuildSelectedIndices();
             return;
         }
-        int width = client != null
-                ? client.getMapWidth()
-                : net.lapidist.colony.components.state.map.MapState.DEFAULT_WIDTH;
-        int height = client != null
-                ? client.getMapHeight()
-                : net.lapidist.colony.components.state.map.MapState.DEFAULT_HEIGHT;
+        int[] dims = determineDimensions();
+        int width = dims[0];
+        int height = dims[1];
         if (width != lastWidth || height != lastHeight) {
             renderData = MapRenderDataBuilder.fromMap(map, world, width, height);
             lastVersion = map.getVersion();
@@ -184,6 +175,37 @@ public final class MapRenderDataSystem extends BaseSystem {
         }
 
         data.setVersion(map.getVersion());
+    }
+
+    /**
+     * Determine the current map dimensions. When the client provides valid
+     * values they are used, otherwise the dimensions are calculated from the
+     * tile components.
+     */
+    private int[] determineDimensions() {
+        int width = 0;
+        int height = 0;
+        if (client != null) {
+            width = client.getMapWidth();
+            height = client.getMapHeight();
+        }
+        if (width <= 0 || height <= 0) {
+            if (map != null) {
+                Array<Entity> tiles = map.getTiles();
+                for (int i = 0; i < tiles.size; i++) {
+                    TileComponent tc = tileMapper.get(tiles.get(i));
+                    width = Math.max(width, tc.getX() + 1);
+                    height = Math.max(height, tc.getY() + 1);
+                }
+            }
+            if (width <= 0) {
+                width = net.lapidist.colony.components.state.map.MapState.DEFAULT_WIDTH;
+            }
+            if (height <= 0) {
+                height = net.lapidist.colony.components.state.map.MapState.DEFAULT_HEIGHT;
+            }
+        }
+        return new int[] {width, height};
     }
 
     private void rebuildSelectedIndices() {

--- a/tests/src/test/java/net/lapidist/colony/tests/systems/MapRenderDataSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/systems/MapRenderDataSystemTest.java
@@ -15,6 +15,10 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 public class MapRenderDataSystemTest {
+    private static final int STATE_WIDTH = 5;
+    private static final int STATE_HEIGHT = 4;
+    private static final int CLIENT_WIDTH = 8;
+    private static final int CLIENT_HEIGHT = 6;
 
     @Test
     public void returnsNullWhenNoMapPresent() {
@@ -29,7 +33,10 @@ public class MapRenderDataSystemTest {
 
     @Test
     public void populatesRenderDataFromMap() {
-        MapState state = new MapState();
+        MapState state = MapState.builder()
+                .width(STATE_WIDTH)
+                .height(STATE_HEIGHT)
+                .build();
         state.putTile(TileData.builder()
                 .x(0).y(0).tileType("GRASS").passable(true)
                 .build());
@@ -213,6 +220,58 @@ public class MapRenderDataSystemTest {
         world.process();
         assertEquals(1, system.getSelectedTileIndices().size);
         assertEquals(0, system.getSelectedTileIndices().first());
+        world.dispose();
+    }
+
+    @Test
+    public void usesClientDimensionsWhenProvided() {
+        MapState state = MapState.builder()
+                .width(STATE_WIDTH - 2)
+                .height(STATE_HEIGHT - 1)
+                .build();
+        state.putTile(TileData.builder()
+                .x(0).y(0).tileType("GRASS").passable(true)
+                .build());
+
+        var client = org.mockito.Mockito.mock(net.lapidist.colony.client.network.GameClient.class);
+        org.mockito.Mockito.when(client.getMapWidth()).thenReturn(CLIENT_WIDTH);
+        org.mockito.Mockito.when(client.getMapHeight()).thenReturn(CLIENT_HEIGHT);
+
+        World world = new World(new WorldConfigurationBuilder()
+                .with(new MapInitSystem(new ProvidedMapStateProvider(state)),
+                        new MapRenderDataSystem(client))
+                .build());
+        world.process();
+
+        MapRenderDataSystem system = world.getSystem(MapRenderDataSystem.class);
+        assertEquals(CLIENT_WIDTH, system.getRenderData().getWidth());
+        assertEquals(CLIENT_HEIGHT, system.getRenderData().getHeight());
+        world.dispose();
+    }
+
+    @Test
+    public void fallsBackWhenClientReportsZero() {
+        MapState state = MapState.builder()
+                .width(STATE_WIDTH - 1)
+                .height(STATE_HEIGHT + 1)
+                .build();
+        state.putTile(TileData.builder()
+                .x(0).y(0).tileType("GRASS").passable(true)
+                .build());
+
+        var client = org.mockito.Mockito.mock(net.lapidist.colony.client.network.GameClient.class);
+        org.mockito.Mockito.when(client.getMapWidth()).thenReturn(0);
+        org.mockito.Mockito.when(client.getMapHeight()).thenReturn(0);
+
+        World world = new World(new WorldConfigurationBuilder()
+                .with(new MapInitSystem(new ProvidedMapStateProvider(state)),
+                        new MapRenderDataSystem(client))
+                .build());
+        world.process();
+
+        MapRenderDataSystem system = world.getSystem(MapRenderDataSystem.class);
+        assertEquals(STATE_WIDTH - 1, system.getRenderData().getWidth());
+        assertEquals(STATE_HEIGHT + 1, system.getRenderData().getHeight());
         world.dispose();
     }
 }


### PR DESCRIPTION
## Summary
- fallback to map dimensions when the client doesn't provide size
- test rendering data sizing with mocked client dimensions

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_68558d72a8c48328a2c0a02e227fa07a