### PR TITLE
fix: dispose map loader thread

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/systems/MapInitSystem.java
+++ b/client/src/main/java/net/lapidist/colony/client/systems/MapInitSystem.java
@@ -67,4 +67,16 @@ public class MapInitSystem extends BaseSystem {
     public boolean isReady() {
         return ready;
     }
+
+    @Override
+    public final void dispose() {
+        if (worker != null && worker.isAlive()) {
+            worker.interrupt();
+            try {
+                worker.join();
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- ensure async map init thread exits when disposing
- test MapInitSystem stops background worker on world dispose

## Testing
- `./scripts/check.sh`
- `./gradlew codeCoverageReport`


------
https://chatgpt.com/codex/tasks/task_e_68558d7455908328b36dd133fa5abe7f