### PR TITLE
feat: encode tile rotation in vertex color

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
@@ -106,10 +106,11 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding>, D
                             power != null ? (float) power : ResourceLoader.DEFAULT_SPECULAR_POWER
                     );
                     shader.setUniformf("u_normalStrength", graphicsSettings.getNormalMapStrength());
-                    shader.setUniformf("u_tileRotation", 0f);
                     com.badlogic.gdx.Gdx.gl.glActiveTexture(com.badlogic.gdx.graphics.GL20.GL_TEXTURE0);
                 }
+                spriteBatch.setColor(1f, 1f, 1f, 0f);
                 spriteBatch.draw(region, worldCoords.x, worldCoords.y);
+                spriteBatch.setColor(com.badlogic.gdx.graphics.Color.WHITE);
             }
             if (!resolver.hasBuildingAsset(type)) {
                 layout.setText(font, type);

--- a/client/src/main/java/net/lapidist/colony/client/renderers/MapTileCache.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/MapTileCache.java
@@ -122,6 +122,8 @@ final class MapTileCache implements Disposable {
 
                 if (region != null) {
                     float rotation = TileRotationUtil.rotationFor(tile.getX(), tile.getY());
+                    int rotationIndex = (int) (rotation / 90f);
+                    cache.setColor(1f, 1f, 1f, rotationIndex / 4f);
                     cache.add(
                             region,
                             worldX,
@@ -182,6 +184,8 @@ final class MapTileCache implements Disposable {
 
                 if (region != null) {
                     float rotation = TileRotationUtil.rotationFor(tile.getX(), tile.getY());
+                    int rotationIndex = (int) (rotation / 90f);
+                    cache.setColor(1f, 1f, 1f, rotationIndex / 4f);
                     cache.add(
                             region,
                             worldX,

--- a/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
@@ -140,14 +140,11 @@ public final class TileRenderer implements EntityRenderer<RenderTile>, Disposabl
                             shader.setUniformf("u_normalStrength", graphicsSettings.getNormalMapStrength());
                         }
                         String upper = type.toUpperCase(java.util.Locale.ROOT);
+                        int rotationIndex = 0;
                         if ("GRASS".equals(upper) || "DIRT".equals(upper)) {
                             rotationAngle = TileRotationUtil.rotationFor(tile.getX(), tile.getY());
-                            if (shader != null) {
-                                shader.setUniformf(
-                                        "u_tileRotation",
-                                        com.badlogic.gdx.math.MathUtils.degreesToRadians * rotationAngle
-                                );
-                            }
+                            rotationIndex = (int) (rotationAngle / 90f);
+                            spriteBatch.setColor(1f, 1f, 1f, rotationIndex / 4f);
                             spriteBatch.draw(
                                     region,
                                     worldCoords.x,
@@ -160,11 +157,11 @@ public final class TileRenderer implements EntityRenderer<RenderTile>, Disposabl
                                     1f,
                                     rotationAngle
                             );
+                            spriteBatch.setColor(com.badlogic.gdx.graphics.Color.WHITE);
                         } else {
-                            if (shader != null) {
-                                shader.setUniformf("u_tileRotation", 0f);
-                            }
+                            spriteBatch.setColor(1f, 1f, 1f, rotationIndex / 4f);
                             spriteBatch.draw(region, worldCoords.x, worldCoords.y);
+                            spriteBatch.setColor(com.badlogic.gdx.graphics.Color.WHITE);
                         }
                         if (shader != null) {
                             com.badlogic.gdx.Gdx.gl.glActiveTexture(com.badlogic.gdx.graphics.GL20.GL_TEXTURE0);

--- a/client/src/main/resources/assets/shaders/normal.frag
+++ b/client/src/main/resources/assets/shaders/normal.frag
@@ -12,12 +12,14 @@ uniform vec3 u_lightDir;
 uniform vec3 u_viewDir;
 uniform float u_specularPower;
 uniform float u_normalStrength;
-uniform float u_tileRotation;
+// Rotation angle is encoded in v_color.a as index / 4.
+// Multiply by 2π to convert to radians inside the shader.
 
 void main() {
     vec2 offset = v_texCoords - 0.5;
-    float c = cos(u_tileRotation);
-    float s = sin(u_tileRotation);
+    float angle = v_color.a * 6.28318;
+    float c = cos(angle);
+    float s = sin(angle);
     mat2 rot = mat2(c, -s, s, c);
     vec2 rCoords = rot * offset + 0.5;
     vec4 diffuse = texture2D(u_texture, v_texCoords);
@@ -31,5 +33,5 @@ void main() {
     float specIntensity = pow(max(dot(normal, halfDir), 0.0), u_specularPower);
     float specMap = texture2D(u_specular, rCoords).r;
     vec3 color = diffuse.rgb * diff + vec3(specIntensity * specMap);
-    gl_FragColor = vec4(color, diffuse.a) * v_color;
+    gl_FragColor = vec4(color, diffuse.a) * vec4(v_color.rgb, 1.0);
 }

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -28,7 +28,9 @@ collections remain necessary despite the overhead.
 `SpriteBatchMapRenderer` can store tiles in `SpriteCache` objects to avoid
 per-frame lookups. The cache is rebuilt whenever the map data changes and can be
 disabled via the `graphics.spritecache` setting. Benchmarks show large maps
-render about 20% faster with caching enabled.
+render about 20% faster with caching enabled. Each cached sprite stores its
+rotation index in the alpha channel via `SpriteCache#setColor` so the shader
+can rotate normal maps without a uniform.
 
 ## Lighting
 

--- a/docs/shaders.md
+++ b/docs/shaders.md
@@ -73,7 +73,8 @@ additional uniforms:
 * `u_viewDir` – direction toward the camera.
 * `u_specularPower` – exponent for the specular highlight.
 * `u_normalStrength` – blend factor for normal maps.
-* `u_tileRotation` – angle applied to normal and specular maps.
+* Tile rotation is encoded in the sprite color alpha channel. The shader multiplies
+  this value by `2π` to rotate normal and specular maps.
 
 The first two values are updated every frame so diffuse and specular terms react
 to camera movement. The specular map supplies the intensity for a Blinn–Phong

--- a/tests/src/test/java/net/lapidist/colony/client/renderers/MapTileCacheTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/renderers/MapTileCacheTest.java
@@ -294,7 +294,10 @@ public class MapTileCacheTest {
             MapTileCache cache = new MapTileCache();
             cache.ensureCache(loader, data, new DefaultAssetResolver(), cam);
             SpriteCache sprite = cons.constructed().get(0);
-            ArgumentCaptor<Float> rotCap = ArgumentCaptor.forClass(Float.class);
+            ArgumentCaptor<Float> angleCap = ArgumentCaptor.forClass(Float.class);
+            ArgumentCaptor<Float> alphaCap = ArgumentCaptor.forClass(Float.class);
+            verify(sprite, times(2))
+                    .setColor(eq(1f), eq(1f), eq(1f), alphaCap.capture());
             verify(sprite, times(2))
                     .add(
                             eq(region),
@@ -302,11 +305,14 @@ public class MapTileCacheTest {
                             anyFloat(), anyFloat(),
                             anyFloat(), anyFloat(),
                             anyFloat(), anyFloat(),
-                            rotCap.capture()
+                            angleCap.capture()
                     );
-            java.util.List<Float> values = rotCap.getAllValues();
-            assertEquals(2, values.size());
-            assertNotEquals(values.get(0), values.get(1));
+            java.util.List<Float> angles = angleCap.getAllValues();
+            java.util.List<Float> alphas = alphaCap.getAllValues();
+            assertEquals(2, angles.size());
+            assertEquals(2, alphas.size());
+            assertNotEquals(angles.get(0), angles.get(1));
+            assertNotEquals(alphas.get(0), alphas.get(1));
         }
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/BuildingRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/BuildingRendererTest.java
@@ -290,6 +290,6 @@ public class BuildingRendererTest {
 
         renderer.render(map);
 
-        verify(shader).setUniformf("u_tileRotation", 0f);
+        verify(batch).setColor(1f, 1f, 1f, 0f);
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/TileRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/TileRendererTest.java
@@ -474,9 +474,11 @@ public class TileRendererTest {
         renderer.render(map);
 
         ArgumentCaptor<Float> captor = ArgumentCaptor.forClass(Float.class);
-        verify(shader, times(2)).setUniformf(eq("u_tileRotation"), captor.capture());
+        verify(batch, times(2)).setColor(eq(1f), eq(1f), eq(1f), captor.capture());
         java.util.List<Float> vals = captor.getAllValues();
-        assertEquals(Math.toRadians(TileRotationUtil.rotationFor(0, 0)), vals.get(0), EPSILON);
-        assertEquals(Math.toRadians(TileRotationUtil.rotationFor(1, 0)), vals.get(1), EPSILON);
+        int index1 = (int) (TileRotationUtil.rotationFor(0, 0) / 90f);
+        int index2 = (int) (TileRotationUtil.rotationFor(1, 0) / 90f);
+        assertEquals(index1 / 4f, vals.get(0), EPSILON);
+        assertEquals(index2 / 4f, vals.get(1), EPSILON);
     }
 }


### PR DESCRIPTION
## Summary
- encode tile rotation in the sprite color alpha channel
- remove `u_tileRotation` uniform usage
- cache and render tiles/buildings with encoded alpha
- document rotation encoding and caching behaviour
- update unit tests

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`


------
https://chatgpt.com/codex/tasks/task_e_6855a232a50c83289d9ee431b6854cee