### PR TITLE
fix: handle rendering without shader

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/renderers/MapTileCache.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/MapTileCache.java
@@ -25,6 +25,8 @@ import net.lapidist.colony.components.GameConstants;
 final class MapTileCache implements Disposable {
 
     private static final int MAX_SPRITES_PER_CACHE = 8191;
+    private static final float ROTATION_QUADRANT_DEG = 90f;
+    private static final float QUADRANT_COUNT = 4f;
 
     private final Array<SpriteCache> spriteCaches = new Array<>();
     private final IntArray cacheIds = new IntArray();
@@ -35,6 +37,11 @@ final class MapTileCache implements Disposable {
     private MapRenderData cachedData;
     private int cachedVersion;
     private boolean invalidated = true;
+    private boolean shaderActive;
+
+    void setShaderActive(final boolean active) {
+        this.shaderActive = active;
+    }
 
     void invalidate() {
         invalidated = true;
@@ -122,8 +129,9 @@ final class MapTileCache implements Disposable {
 
                 if (region != null) {
                     float rotation = TileRotationUtil.rotationFor(tile.getX(), tile.getY());
-                    int rotationIndex = (int) (rotation / 90f);
-                    cache.setColor(1f, 1f, 1f, rotationIndex / 4f);
+                    int rotationIndex = (int) (rotation / ROTATION_QUADRANT_DEG);
+                    float alpha = shaderActive ? rotationIndex / QUADRANT_COUNT : 1f;
+                    cache.setColor(1f, 1f, 1f, alpha);
                     cache.add(
                             region,
                             worldX,
@@ -184,8 +192,9 @@ final class MapTileCache implements Disposable {
 
                 if (region != null) {
                     float rotation = TileRotationUtil.rotationFor(tile.getX(), tile.getY());
-                    int rotationIndex = (int) (rotation / 90f);
-                    cache.setColor(1f, 1f, 1f, rotationIndex / 4f);
+                    int rotationIndex = (int) (rotation / ROTATION_QUADRANT_DEG);
+                    float alpha = shaderActive ? rotationIndex / QUADRANT_COUNT : 1f;
+                    cache.setColor(1f, 1f, 1f, alpha);
                     cache.add(
                             region,
                             worldX,

--- a/client/src/main/java/net/lapidist/colony/client/renderers/SpriteBatchMapRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/SpriteBatchMapRenderer.java
@@ -64,6 +64,7 @@ public final class SpriteBatchMapRenderer implements MapRenderer, Disposable {
     public void render(final MapRenderData map, final CameraProvider camera) {
         spriteBatch.setProjectionMatrix(camera.getCamera().combined);
         if (cacheEnabled) {
+            tileCache.setShaderActive(shader != null);
             tileCache.ensureCache(resourceLoader, map, resolver, camera);
         }
         if (shader != null) {

--- a/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
@@ -42,6 +42,8 @@ public final class TileRenderer implements EntityRenderer<RenderTile>, Disposabl
     private final Vector2 worldCoords = new Vector2();
     private final GraphicsSettings graphicsSettings;
     private boolean overlayOnly;
+    private static final float ROTATION_QUADRANT_DEG = 90f;
+    private static final float QUADRANT_COUNT = 4f;
 
     public TileRenderer(
             final SpriteBatch spriteBatchToSet,
@@ -143,8 +145,9 @@ public final class TileRenderer implements EntityRenderer<RenderTile>, Disposabl
                         int rotationIndex = 0;
                         if ("GRASS".equals(upper) || "DIRT".equals(upper)) {
                             rotationAngle = TileRotationUtil.rotationFor(tile.getX(), tile.getY());
-                            rotationIndex = (int) (rotationAngle / 90f);
-                            spriteBatch.setColor(1f, 1f, 1f, rotationIndex / 4f);
+                            rotationIndex = (int) (rotationAngle / ROTATION_QUADRANT_DEG);
+                            float alpha = spriteBatch.getShader() != null ? rotationIndex / QUADRANT_COUNT : 1f;
+                            spriteBatch.setColor(1f, 1f, 1f, alpha);
                             spriteBatch.draw(
                                     region,
                                     worldCoords.x,
@@ -159,7 +162,8 @@ public final class TileRenderer implements EntityRenderer<RenderTile>, Disposabl
                             );
                             spriteBatch.setColor(com.badlogic.gdx.graphics.Color.WHITE);
                         } else {
-                            spriteBatch.setColor(1f, 1f, 1f, rotationIndex / 4f);
+                            float alpha = spriteBatch.getShader() != null ? rotationIndex / QUADRANT_COUNT : 1f;
+                            spriteBatch.setColor(1f, 1f, 1f, alpha);
                             spriteBatch.draw(region, worldCoords.x, worldCoords.y);
                             spriteBatch.setColor(com.badlogic.gdx.graphics.Color.WHITE);
                         }

--- a/tests/src/test/java/net/lapidist/colony/client/renderers/MapTileCacheTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/renderers/MapTileCacheTest.java
@@ -107,6 +107,7 @@ public class MapTileCacheTest {
                     when(mock.endCache()).thenReturn(0);
                 })) {
             MapTileCache cache = new MapTileCache();
+            cache.setShaderActive(true);
             cache.ensureCache(loader, data, new DefaultAssetResolver(), cam);
             assertEquals(1, cons.constructed().size());
             cache.ensureCache(loader, data, new DefaultAssetResolver(), cam);
@@ -134,6 +135,7 @@ public class MapTileCacheTest {
                     when(mock.endCache()).thenReturn(0);
                 })) {
             MapTileCache cache = new MapTileCache();
+            cache.setShaderActive(true);
             cache.ensureCache(loader, data, new DefaultAssetResolver(), cam);
             SpriteCache sprite = cons.constructed().get(0);
             SpriteBatch batch = mock(SpriteBatch.class);
@@ -170,6 +172,7 @@ public class MapTileCacheTest {
                     when(mock.endCache()).thenReturn(0);
                 })) {
             MapTileCache cache = new MapTileCache();
+            cache.setShaderActive(true);
             cache.ensureCache(loader, data, new DefaultAssetResolver(), cam);
             SpriteCache sprite = cons.constructed().get(0);
             SpriteBatch batch = mock(SpriteBatch.class);
@@ -191,6 +194,7 @@ public class MapTileCacheTest {
                     when(mock.endCache()).thenReturn(0);
                 })) {
             MapTileCache cache = new MapTileCache();
+            cache.setShaderActive(true);
             cache.ensureCache(loader, data, new DefaultAssetResolver(), cam);
             assertEquals(1, cons.constructed().size());
             data.setVersion(data.getVersion() + 1);
@@ -212,6 +216,7 @@ public class MapTileCacheTest {
                     when(mock.endCache()).thenReturn(0);
                 })) {
             MapTileCache cache = new MapTileCache();
+            cache.setShaderActive(true);
             cache.ensureCache(loader, data, new DefaultAssetResolver(), cam);
             assertEquals(1, cons.constructed().size());
             com.badlogic.gdx.utils.IntArray indices = new com.badlogic.gdx.utils.IntArray(new int[] {0});
@@ -292,6 +297,7 @@ public class MapTileCacheTest {
                     when(mock.endCache()).thenReturn(0);
                 })) {
             MapTileCache cache = new MapTileCache();
+            cache.setShaderActive(true);
             cache.ensureCache(loader, data, new DefaultAssetResolver(), cam);
             SpriteCache sprite = cons.constructed().get(0);
             ArgumentCaptor<Float> angleCap = ArgumentCaptor.forClass(Float.class);
@@ -313,6 +319,28 @@ public class MapTileCacheTest {
             assertEquals(2, alphas.size());
             assertNotEquals(angles.get(0), angles.get(1));
             assertNotEquals(alphas.get(0), alphas.get(1));
+        }
+    }
+
+    @Test
+    public void cachesOpaqueTilesWhenNoShader() {
+        MapRenderData data = createManualData();
+
+        CameraProvider cam = mock(CameraProvider.class);
+        when(cam.getCamera()).thenReturn(new OrthographicCamera());
+        ResourceLoader loader = mock(ResourceLoader.class);
+        TextureRegion region = new TextureRegion();
+        when(loader.findRegion(any())).thenReturn(region);
+        try (MockedConstruction<SpriteCache> cons = mockConstruction(SpriteCache.class,
+                (mock, ctx) -> {
+                    when(mock.getProjectionMatrix()).thenReturn(new Matrix4());
+                    when(mock.endCache()).thenReturn(0);
+                })) {
+            MapTileCache cache = new MapTileCache();
+            cache.setShaderActive(false);
+            cache.ensureCache(loader, data, new DefaultAssetResolver(), cam);
+            SpriteCache sprite = cons.constructed().get(0);
+            verify(sprite, times(2)).setColor(1f, 1f, 1f, 1f);
         }
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/TileRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/TileRendererTest.java
@@ -35,6 +35,8 @@ public class TileRendererTest {
     private static final int CUSTOM_POWER = 11;
     private static final float CUSTOM_STRENGTH = 0.5f;
     private static final float EPSILON = 0.001f;
+    private static final float ROTATION_QUADRANT_DEG = 90f;
+    private static final float QUADRANT_COUNT = 4f;
 
     @Test
     public void drawsTileAndOverlay() {
@@ -476,9 +478,64 @@ public class TileRendererTest {
         ArgumentCaptor<Float> captor = ArgumentCaptor.forClass(Float.class);
         verify(batch, times(2)).setColor(eq(1f), eq(1f), eq(1f), captor.capture());
         java.util.List<Float> vals = captor.getAllValues();
-        int index1 = (int) (TileRotationUtil.rotationFor(0, 0) / 90f);
-        int index2 = (int) (TileRotationUtil.rotationFor(1, 0) / 90f);
-        assertEquals(index1 / 4f, vals.get(0), EPSILON);
-        assertEquals(index2 / 4f, vals.get(1), EPSILON);
+        int index1 = (int) (TileRotationUtil.rotationFor(0, 0) / ROTATION_QUADRANT_DEG);
+        int index2 = (int) (TileRotationUtil.rotationFor(1, 0) / ROTATION_QUADRANT_DEG);
+        assertEquals(index1 / QUADRANT_COUNT, vals.get(0), EPSILON);
+        assertEquals(index2 / QUADRANT_COUNT, vals.get(1), EPSILON);
+    }
+
+    @Test
+    public void usesOpaqueColorWhenNoShader() {
+        SpriteBatch batch = mock(SpriteBatch.class);
+        ResourceLoader loader = mock(ResourceLoader.class);
+        TextureRegion region = mock(TextureRegion.class);
+        TextureRegion overlay = mock(TextureRegion.class);
+        when(loader.findRegion(anyString())).thenReturn(region);
+        when(loader.findRegion(eq("hoveredTile0"))).thenReturn(overlay);
+
+        new BaseDefinitionsMod().init();
+
+        CameraProvider camera = mock(CameraProvider.class);
+        com.badlogic.gdx.graphics.OrthographicCamera cam = new com.badlogic.gdx.graphics.OrthographicCamera();
+        com.badlogic.gdx.utils.viewport.ExtendViewport viewport =
+                new com.badlogic.gdx.utils.viewport.ExtendViewport(1f, 1f, cam);
+        cam.update();
+        when(camera.getViewport()).thenReturn(viewport);
+        when(camera.getCamera()).thenReturn(cam);
+
+        GraphicsSettings graphics = new GraphicsSettings();
+        TileRenderer renderer = new TileRenderer(batch, loader, camera, new DefaultAssetResolver(), null, graphics);
+
+        Array<RenderTile> tiles = new Array<>();
+        RenderTile tile1 = RenderTile.builder()
+                .x(0)
+                .y(0)
+                .tileType("GRASS")
+                .selected(false)
+                .wood(0)
+                .stone(0)
+                .food(0)
+                .build();
+        tiles.add(tile1);
+
+        RenderTile tile2 = RenderTile.builder()
+                .x(1)
+                .y(0)
+                .tileType("GRASS")
+                .selected(false)
+                .wood(0)
+                .stone(0)
+                .food(0)
+                .build();
+        tiles.add(tile2);
+
+        RenderTile[][] grid = new RenderTile[MapState.DEFAULT_WIDTH][MapState.DEFAULT_HEIGHT];
+        grid[0][0] = tile1;
+        grid[1][0] = tile2;
+        MapRenderData map = new SimpleMapRenderData(tiles, new Array<RenderBuilding>(), grid);
+
+        renderer.render(map);
+
+        verify(batch, times(2)).setColor(1f, 1f, 1f, 1f);
     }
 }


### PR DESCRIPTION
## Summary
- render tile caches with opaque colors when shader inactive
- check sprite batch shader before applying alpha in TileRenderer
- propagate shader state to tile cache from SpriteBatchMapRenderer
- test that tiles use opaque alpha without a shader

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6855b7ff38e083288ca1246d6388fb1e