### PR TITLE
fix: handle missing shaders

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/LoadingSpriteMapRenderer.java
@@ -55,6 +55,14 @@ public final class LoadingSpriteMapRenderer implements MapRenderer, Disposable {
         this.shader = shaderProgram;
     }
 
+    /** Indicates if a custom shader program was created. */
+    public boolean hasShader() {
+        if (delegate instanceof SpriteBatchMapRenderer sb) {
+            return sb.hasShader();
+        }
+        return shader != null;
+    }
+
     /** Set graphics settings for renderer creation. */
     public void setGraphicsSettings(final GraphicsSettings settings) {
         this.graphicsSettings = settings;

--- a/client/src/main/java/net/lapidist/colony/client/renderers/MapTileCache.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/MapTileCache.java
@@ -60,7 +60,8 @@ final class MapTileCache implements Disposable {
             final ResourceLoader loader,
             final MapRenderData map,
             final AssetResolver resolver,
-            final CameraProvider camera
+            final CameraProvider camera,
+            final boolean hasShader
     ) {
         if (map == null) {
             dispose();
@@ -69,7 +70,7 @@ final class MapTileCache implements Disposable {
 
         if (spriteCaches.isEmpty() || cachedData != map) {
             dispose();
-            rebuildAll(loader, map, resolver, camera);
+            rebuildAll(loader, map, resolver, camera, hasShader);
             return;
         }
 
@@ -86,7 +87,7 @@ final class MapTileCache implements Disposable {
 
         if (invalidated) {
             dispose();
-            rebuildAll(loader, map, resolver, camera);
+            rebuildAll(loader, map, resolver, camera, hasShader);
             return;
         }
 
@@ -126,7 +127,8 @@ final class MapTileCache implements Disposable {
                 if (region != null) {
                     float rotation = TileRotationUtil.rotationFor(tile.getX(), tile.getY());
                     int rotationIndex = (int) (rotation / RIGHT_ANGLE);
-                    cache.setColor(1f, 1f, 1f, rotationIndex / INDEX_SCALE);
+                    float alpha = hasShader ? rotationIndex / INDEX_SCALE : 1f;
+                    cache.setColor(1f, 1f, 1f, alpha);
                     cache.add(
                             region,
                             worldX,
@@ -156,7 +158,8 @@ final class MapTileCache implements Disposable {
             final ResourceLoader loader,
             final MapRenderData map,
             final AssetResolver resolver,
-            final CameraProvider camera
+            final CameraProvider camera,
+            final boolean hasShader
     ) {
         dispose();
         cachedData = map;
@@ -189,7 +192,8 @@ final class MapTileCache implements Disposable {
                 if (region != null) {
                     float rotation = TileRotationUtil.rotationFor(tile.getX(), tile.getY());
                     int rotationIndex = (int) (rotation / RIGHT_ANGLE);
-                    cache.setColor(1f, 1f, 1f, rotationIndex / INDEX_SCALE);
+                    float alpha = hasShader ? rotationIndex / INDEX_SCALE : 1f;
+                    cache.setColor(1f, 1f, 1f, alpha);
                     cache.add(
                             region,
                             worldX,

--- a/client/src/main/java/net/lapidist/colony/client/renderers/SpriteBatchMapRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/SpriteBatchMapRenderer.java
@@ -48,6 +48,11 @@ public final class SpriteBatchMapRenderer implements MapRenderer, Disposable {
         this.plugin = pluginToSet;
     }
 
+    /** Indicates if this renderer is using a custom shader program. */
+    public boolean hasShader() {
+        return shader != null;
+    }
+
     /** Invalidate cache segments for the given tile indices. */
     public void invalidateTiles(final com.badlogic.gdx.utils.IntArray indices) {
         if (cacheEnabled) {
@@ -64,7 +69,7 @@ public final class SpriteBatchMapRenderer implements MapRenderer, Disposable {
     public void render(final MapRenderData map, final CameraProvider camera) {
         spriteBatch.setProjectionMatrix(camera.getCamera().combined);
         if (cacheEnabled) {
-            tileCache.ensureCache(resourceLoader, map, resolver, camera);
+            tileCache.ensureCache(resourceLoader, map, resolver, camera, shader != null);
         }
         if (shader != null) {
             spriteBatch.setShader(shader);

--- a/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
@@ -144,10 +144,12 @@ public final class TileRenderer implements EntityRenderer<RenderTile>, Disposabl
                         }
                         String upper = type.toUpperCase(java.util.Locale.ROOT);
                         int rotationIndex = 0;
+                        boolean hasShader = shader != null;
                         if ("GRASS".equals(upper) || "DIRT".equals(upper)) {
                             rotationAngle = TileRotationUtil.rotationFor(tile.getX(), tile.getY());
                             rotationIndex = (int) (rotationAngle / RIGHT_ANGLE);
-                            spriteBatch.setColor(1f, 1f, 1f, rotationIndex / INDEX_SCALE);
+                            float alpha = hasShader ? rotationIndex / INDEX_SCALE : 1f;
+                            spriteBatch.setColor(1f, 1f, 1f, alpha);
                             spriteBatch.draw(
                                     region,
                                     worldCoords.x,
@@ -162,7 +164,8 @@ public final class TileRenderer implements EntityRenderer<RenderTile>, Disposabl
                             );
                             spriteBatch.setColor(com.badlogic.gdx.graphics.Color.WHITE);
                         } else {
-                            spriteBatch.setColor(1f, 1f, 1f, rotationIndex / INDEX_SCALE);
+                            float alpha = hasShader ? rotationIndex / INDEX_SCALE : 1f;
+                            spriteBatch.setColor(1f, 1f, 1f, alpha);
                             spriteBatch.draw(region, worldCoords.x, worldCoords.y);
                             spriteBatch.setColor(com.badlogic.gdx.graphics.Color.WHITE);
                         }

--- a/tests/src/jmh/java/net/lapidist/colony/client/renderers/MapTileCacheBenchmark.java
+++ b/tests/src/jmh/java/net/lapidist/colony/client/renderers/MapTileCacheBenchmark.java
@@ -107,7 +107,7 @@ public class MapTileCacheBenchmark {
     @Benchmark
     public final void rebuildCache() {
         cache.invalidate();
-        cache.ensureCache(loader, data, resolver, camera);
+        cache.ensureCache(loader, data, resolver, camera, true);
     }
 
     @Benchmark
@@ -115,6 +115,6 @@ public class MapTileCacheBenchmark {
         cache.invalidateTiles(updateIndices);
         ((net.lapidist.colony.client.render.SimpleMapRenderData) data)
                 .setVersion(((net.lapidist.colony.client.render.SimpleMapRenderData) data).getVersion() + 1);
-        cache.ensureCache(loader, data, resolver, camera);
+        cache.ensureCache(loader, data, resolver, camera, true);
     }
 }

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/TileRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/TileRendererTest.java
@@ -484,4 +484,38 @@ public class TileRendererTest {
         assertEquals(index1 / INDEX_SCALE, vals.get(0), EPSILON);
         assertEquals(index2 / INDEX_SCALE, vals.get(1), EPSILON);
     }
+
+    @Test
+    public void tilesOpaqueWithoutShader() {
+        SpriteBatch batch = mock(SpriteBatch.class);
+        ResourceLoader loader = mock(ResourceLoader.class);
+        TextureRegion region = mock(TextureRegion.class);
+        TextureRegion overlay = mock(TextureRegion.class);
+        when(loader.findRegion(anyString())).thenReturn(region);
+        when(loader.findRegion(eq("hoveredTile0"))).thenReturn(overlay);
+
+        new BaseDefinitionsMod().init();
+
+        CameraProvider camera = mock(CameraProvider.class);
+        com.badlogic.gdx.graphics.OrthographicCamera cam = new com.badlogic.gdx.graphics.OrthographicCamera();
+        com.badlogic.gdx.utils.viewport.ExtendViewport viewport =
+                new com.badlogic.gdx.utils.viewport.ExtendViewport(1f, 1f, cam);
+        cam.update();
+        when(camera.getViewport()).thenReturn(viewport);
+        when(camera.getCamera()).thenReturn(cam);
+
+        GraphicsSettings graphics = new GraphicsSettings();
+        TileRenderer renderer = new TileRenderer(batch, loader, camera, new DefaultAssetResolver(), null, graphics);
+
+        Array<RenderTile> tiles = new Array<>();
+        tiles.add(RenderTile.builder().x(0).y(0).tileType("GRASS").selected(false).wood(0).stone(0).food(0).build());
+
+        RenderTile[][] grid = new RenderTile[MapState.DEFAULT_WIDTH][MapState.DEFAULT_HEIGHT];
+        grid[0][0] = tiles.first();
+        MapRenderData map = new SimpleMapRenderData(tiles, new Array<RenderBuilding>(), grid);
+
+        renderer.render(map);
+
+        verify(batch).setColor(1f, 1f, 1f, 1f);
+    }
 }


### PR DESCRIPTION
## Summary
- adjust TileRenderer to keep tiles opaque when shader isn't present
- allow MapTileCache to skip rotation alpha when no shader is active
- expose `hasShader` on SpriteBatchMapRenderer and LoadingSpriteMapRenderer
- update tests for new shader handling

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_6855d02f321c83288dd24992bdb4925d