### PR TITLE
fix: ensure map UI uses full viewport

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/MapScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapScreen.java
@@ -46,6 +46,7 @@ public final class MapScreen implements Screen {
     ) {
         this.colony = colonyToSet;
         stage = new Stage(new ScreenViewport());
+        stage.getViewport().update(Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), true);
         world = MapWorldBuilder.build(
                 MapWorldBuilder.builder(
                         state,


### PR DESCRIPTION
## Summary
- revert prior scaling changes
- update viewport size during map screen creation

## Testing
- `./scripts/check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6855dc236bb4832885c3f9573a2bfeee