### PR TITLE
feat: add directional light support

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapWorldBuilder.java
@@ -31,6 +31,7 @@ import net.lapidist.colony.client.systems.MapInitSystem;
 import net.lapidist.colony.client.systems.MapRenderDataSystem;
 import net.lapidist.colony.client.systems.LightOcclusionSystem;
 import net.lapidist.colony.components.entities.CelestialBodyComponent;
+import net.lapidist.colony.components.light.DirectionalLightComponent;
 import net.lapidist.colony.components.state.map.CameraPosition;
 import net.lapidist.colony.components.state.MutableEnvironmentState;
 import net.lapidist.colony.components.state.map.MapState;
@@ -280,13 +281,19 @@ public final class MapWorldBuilder {
         sunComp.setTexture("player0");
         sunComp.setOrbitRadius(radius);
         sunComp.setOrbitOffset(0f);
-        sun.edit().add(sunComp);
+        var sunLight = new DirectionalLightComponent();
+        sunLight.setColor(Color.WHITE);
+        sunLight.setIntensity(1f);
+        sun.edit().add(sunComp).add(sunLight);
 
         var moon = world.createEntity();
         var moonComp = new CelestialBodyComponent();
         moonComp.setTexture("player0");
         moonComp.setOrbitRadius(radius);
         moonComp.setOrbitOffset(HALF_ROTATION);
-        moon.edit().add(moonComp);
+        var moonLight = new DirectionalLightComponent();
+        moonLight.setColor(Color.WHITE);
+        moonLight.setIntensity(0.4f);
+        moon.edit().add(moonComp).add(moonLight);
     }
 }

--- a/core/src/main/java/net/lapidist/colony/components/light/DirectionalLightComponent.java
+++ b/core/src/main/java/net/lapidist/colony/components/light/DirectionalLightComponent.java
@@ -1,0 +1,28 @@
+package net.lapidist.colony.components.light;
+
+import com.artemis.Component;
+import com.badlogic.gdx.graphics.Color;
+
+/** Component describing a dynamic directional light. */
+public final class DirectionalLightComponent extends Component {
+    private Color color = new Color(1f, 1f, 1f, 1f);
+    private float intensity = 1f;
+
+    /** Light color. */
+    public Color getColor() {
+        return color;
+    }
+
+    public void setColor(final Color colorToSet) {
+        this.color = colorToSet;
+    }
+
+    /** Light intensity represented by the alpha channel. */
+    public float getIntensity() {
+        return intensity;
+    }
+
+    public void setIntensity(final float intensityToSet) {
+        this.intensity = intensityToSet;
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/client/systems/DirectionalLightSystemTest.java
+++ b/tests/src/test/java/net/lapidist/colony/client/systems/DirectionalLightSystemTest.java
@@ -1,0 +1,62 @@
+package net.lapidist.colony.client.systems;
+
+import box2dLight.DirectionalLight;
+import box2dLight.RayHandler;
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import com.badlogic.gdx.graphics.Color;
+import net.lapidist.colony.components.entities.CelestialBodyComponent;
+import net.lapidist.colony.components.light.DirectionalLightComponent;
+import net.lapidist.colony.components.state.MutableEnvironmentState;
+import net.lapidist.colony.client.systems.LightingSystem;
+import net.lapidist.colony.client.systems.ClearScreenSystem;
+import net.lapidist.colony.tests.GdxTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/** Tests directional light management within {@link LightingSystem}. */
+@RunWith(GdxTestRunner.class)
+public class DirectionalLightSystemTest {
+
+    @Test
+    public void createsAndRemovesDirectionalLights() {
+        ClearScreenSystem clear = new ClearScreenSystem(new Color());
+        LightingSystem.LightFactory factory = new LightingSystem.LightFactory() {
+            @Override
+            public box2dLight.PointLight create(final RayHandler h, final net.lapidist.colony.components.light.PointLightComponent c) {
+                return null;
+            }
+
+            @Override
+            public DirectionalLight createDirectional(final RayHandler h, final DirectionalLightComponent c) {
+                return mock(DirectionalLight.class);
+            }
+        };
+        MutableEnvironmentState env = new MutableEnvironmentState();
+        LightingSystem lighting = new LightingSystem(clear, factory, env);
+        World world = new World(new WorldConfigurationBuilder().with(clear, lighting).build());
+        RayHandler handler = mock(RayHandler.class);
+        lighting.setRayHandler(handler);
+
+        var e = world.createEntity();
+        DirectionalLightComponent light = new DirectionalLightComponent();
+        CelestialBodyComponent body = new CelestialBodyComponent();
+        body.setOrbitRadius(0f);
+        body.setOrbitOffset(0f);
+        e.edit().add(light).add(body);
+
+        world.setDelta(0f);
+        world.process();
+        assertEquals(1, lighting.getDirectionalLightCount());
+
+        e.deleteFromWorld();
+        world.process();
+        assertEquals(0, lighting.getDirectionalLightCount());
+
+        world.dispose();
+        handler.dispose();
+    }
+}

--- a/tests/src/test/java/net/lapidist/colony/client/systems/package-info.java
+++ b/tests/src/test/java/net/lapidist/colony/client/systems/package-info.java
@@ -1,0 +1,2 @@
+/** Tests for client systems. */
+package net.lapidist.colony.client.systems;

--- a/tests/src/test/java/net/lapidist/colony/tests/client/systems/LightingSystemDynamicTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/systems/LightingSystemDynamicTest.java
@@ -1,6 +1,7 @@
 package net.lapidist.colony.tests.client.systems;
 
 import box2dLight.RayHandler;
+import box2dLight.DirectionalLight;
 import com.artemis.World;
 import com.artemis.WorldConfigurationBuilder;
 import com.badlogic.gdx.graphics.Color;
@@ -26,7 +27,17 @@ public class LightingSystemDynamicTest {
     @Test
     public void createsAndRemovesLights() {
         ClearScreenSystem clear = new ClearScreenSystem(new Color());
-        LightingSystem.LightFactory factory = (h, c) -> mock(box2dLight.PointLight.class);
+        LightingSystem.LightFactory factory = new LightingSystem.LightFactory() {
+            @Override
+            public box2dLight.PointLight create(final RayHandler h, final PointLightComponent c) {
+                return mock(box2dLight.PointLight.class);
+            }
+
+            @Override
+            public DirectionalLight createDirectional(final RayHandler h, final net.lapidist.colony.components.light.DirectionalLightComponent c) {
+                return null;
+            }
+        };
         MutableEnvironmentState env = new MutableEnvironmentState();
         LightingSystem lighting = new LightingSystem(clear, factory, env);
         World world = new World(new WorldConfigurationBuilder()


### PR DESCRIPTION
## Summary
- add DirectionalLightComponent
- create directional lights via LightingSystem
- spawn sun and moon lights in MapWorldBuilder
- test directional light creation and cleanup

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`


------
https://chatgpt.com/codex/tasks/task_e_68568955bd8883288b0b58584df20c1e