### PR TITLE
feat: add RGB specular mapping support

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/BuildingRenderer.java
@@ -96,7 +96,10 @@ public final class BuildingRenderer implements EntityRenderer<RenderBuilding> {
                         shader.setUniformi("u_normal", 1);
                     }
                     if (spec != null && graphicsSettings.isSpecularMapsEnabled()) {
-                        spec.getTexture().bind(2);
+                        com.badlogic.gdx.Gdx.gl.glActiveTexture(
+                                com.badlogic.gdx.graphics.GL20.GL_TEXTURE0 + 2
+                        );
+                        spec.getTexture().bind();
                         shader.setUniformi("u_specular", 2);
                     }
                     Integer power = specularPowers.get(type.toUpperCase(java.util.Locale.ROOT));

--- a/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
+++ b/client/src/main/java/net/lapidist/colony/client/renderers/TileRenderer.java
@@ -128,7 +128,10 @@ public final class TileRenderer implements EntityRenderer<RenderTile> {
                                 shader.setUniformi("u_normal", 1);
                             }
                             if (spec != null && graphicsSettings.isSpecularMapsEnabled()) {
-                                spec.getTexture().bind(2);
+                                com.badlogic.gdx.Gdx.gl.glActiveTexture(
+                                        com.badlogic.gdx.graphics.GL20.GL_TEXTURE0 + 2
+                                );
+                                spec.getTexture().bind();
                                 shader.setUniformi("u_specular", 2);
                             }
                             Integer power = specularPowers.get(type.toUpperCase(java.util.Locale.ROOT));

--- a/client/src/main/resources/assets/shaders/normal.frag
+++ b/client/src/main/resources/assets/shaders/normal.frag
@@ -29,7 +29,7 @@ void main() {
     float diff = max(dot(normal, lightDir), 0.0);
     vec3 halfDir = normalize(lightDir + viewDir);
     float specIntensity = pow(max(dot(normal, halfDir), 0.0), u_specularPower);
-    float specMap = texture2D(u_specular, rCoords).r;
-    vec3 color = diffuse.rgb * diff + vec3(specIntensity * specMap);
+    vec3 reflectColor = texture2D(u_specular, rCoords).rgb;
+    vec3 color = diffuse.rgb * diff + reflectColor * specIntensity;
     gl_FragColor = vec4(color, diffuse.a) * v_color;
 }

--- a/docs/asset_pipeline.md
+++ b/docs/asset_pipeline.md
@@ -7,6 +7,10 @@ The normal mapping shader reads a `specularPower` value from atlas regions to
 control the Blinn–Phong exponent. Add a line like `specularPower: 32` under a
 region entry to override the default of `8`.
 
+Specular textures now store reflection color in the RGB channels. When present,
+these maps are bound in RGB mode and multiplied with the computed specular
+highlight. They should therefore be saved without an alpha channel.
+
 Run `./gradlew tests:copyAssets` whenever the atlas is updated so the test module
 has the latest resources.
 

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/BuildingRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/BuildingRendererTest.java
@@ -189,6 +189,44 @@ public class BuildingRendererTest {
     }
 
     @Test
+    public void bindsSpecularTextureWhenEnabled() {
+        SpriteBatch batch = mock(SpriteBatch.class);
+        ShaderProgram shader = mock(ShaderProgram.class);
+        when(batch.getShader()).thenReturn(shader);
+        ResourceLoader loader = mock(ResourceLoader.class);
+        TextureRegion region = mock(TextureRegion.class);
+        TextureRegion spec = mock(TextureRegion.class);
+        Texture specTex = mock(Texture.class);
+        when(spec.getTexture()).thenReturn(specTex);
+        when(loader.findRegion(anyString())).thenReturn(region);
+        when(loader.findSpecularRegion(anyString())).thenReturn(spec);
+
+        CameraProvider camera = mock(CameraProvider.class);
+        OrthographicCamera cam = new OrthographicCamera();
+        ExtendViewport viewport = new ExtendViewport(VIEW_SIZE, VIEW_SIZE, cam);
+        viewport.update(VIEW_SIZE, VIEW_SIZE, true);
+        cam.update();
+        when(camera.getCamera()).thenReturn(cam);
+        when(camera.getViewport()).thenReturn(viewport);
+
+        GraphicsSettings graphics = new GraphicsSettings();
+        graphics.setSpecularMapsEnabled(true);
+        BuildingRenderer renderer = new BuildingRenderer(batch, loader, camera, new DefaultAssetResolver(), graphics);
+
+        Array<RenderBuilding> buildings = new Array<>();
+        RenderBuilding building = RenderBuilding.builder().x(0).y(0).buildingType("house").build();
+        buildings.add(building);
+
+        MapRenderData map = new SimpleMapRenderData(new Array<RenderTile>(), buildings,
+                new RenderTile[MapState.DEFAULT_WIDTH][MapState.DEFAULT_HEIGHT]);
+
+        renderer.render(map);
+
+        verify(specTex).bind();
+        verify(shader).setUniformi("u_specular", 2);
+    }
+
+    @Test
     public void setsSpecularPowerUniform() {
         SpriteBatch batch = mock(SpriteBatch.class);
         ShaderProgram shader = mock(ShaderProgram.class);

--- a/tests/src/test/java/net/lapidist/colony/tests/client/renderers/TileRendererTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/client/renderers/TileRendererTest.java
@@ -327,6 +327,55 @@ public class TileRendererTest {
     }
 
     @Test
+    public void bindsSpecularTextureWhenEnabled() {
+        SpriteBatch batch = mock(SpriteBatch.class);
+        ShaderProgram shader = mock(ShaderProgram.class);
+        when(batch.getShader()).thenReturn(shader);
+        ResourceLoader loader = mock(ResourceLoader.class);
+        TextureRegion region = mock(TextureRegion.class);
+        TextureRegion overlay = mock(TextureRegion.class);
+        TextureRegion spec = mock(TextureRegion.class);
+        Texture specTex = mock(Texture.class);
+        when(spec.getTexture()).thenReturn(specTex);
+        when(loader.findRegion(anyString())).thenReturn(region);
+        when(loader.findRegion(eq("hoveredTile0"))).thenReturn(overlay);
+        when(loader.findSpecularRegion(anyString())).thenReturn(spec);
+
+        CameraProvider camera = mock(CameraProvider.class);
+        com.badlogic.gdx.graphics.OrthographicCamera cam = new com.badlogic.gdx.graphics.OrthographicCamera();
+        com.badlogic.gdx.utils.viewport.ExtendViewport viewport =
+                new com.badlogic.gdx.utils.viewport.ExtendViewport(1f, 1f, cam);
+        cam.update();
+        when(camera.getViewport()).thenReturn(viewport);
+        when(camera.getCamera()).thenReturn(cam);
+
+        GraphicsSettings graphics = new GraphicsSettings();
+        graphics.setSpecularMapsEnabled(true);
+        TileRenderer renderer = new TileRenderer(batch, loader, camera, new DefaultAssetResolver(), null, graphics);
+
+        Array<RenderTile> tiles = new Array<>();
+        RenderTile tile = RenderTile.builder()
+                .x(0)
+                .y(0)
+                .tileType("GRASS")
+                .selected(false)
+                .wood(0)
+                .stone(0)
+                .food(0)
+                .build();
+        tiles.add(tile);
+
+        RenderTile[][] grid = new RenderTile[MapState.DEFAULT_WIDTH][MapState.DEFAULT_HEIGHT];
+        grid[0][0] = tile;
+        MapRenderData map = new SimpleMapRenderData(tiles, new Array<RenderBuilding>(), grid);
+
+        renderer.render(map);
+
+        verify(specTex).bind();
+        verify(shader).setUniformi("u_specular", 2);
+    }
+
+    @Test
     public void setsSpecularPowerUniform() {
         SpriteBatch batch = mock(SpriteBatch.class);
         ShaderProgram shader = mock(ShaderProgram.class);


### PR DESCRIPTION
## Summary
- sample RGB values from the specular map in `normal.frag`
- bind specular textures on a dedicated unit and set the uniform
- document RGB specular maps
- test uniform updates for specular textures

## Testing
- `./gradlew tests:copyAssets`
- `./gradlew spotlessApply`
- `./gradlew clean test`

------
https://chatgpt.com/codex/tasks/task_e_68569345b764832895b9ba4e8f1414f5