### PR TITLE
fix: apply ui scale consistently in map

### DIFF
--- a/client/src/main/java/net/lapidist/colony/client/screens/MapScreen.java
+++ b/client/src/main/java/net/lapidist/colony/client/screens/MapScreen.java
@@ -39,6 +39,7 @@ public final class MapScreen implements Screen {
         ScreenViewport viewport = (ScreenViewport) stage.getViewport();
         viewport.setUnitsPerPixel(1f / scale);
         viewport.update(Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), true);
+        stage.getRoot().setScale(scale);
     }
 
     public MapScreen(final Colony colonyToSet, final MapState state, final GameClient client) {

--- a/tests/src/test/java/net/lapidist/colony/tests/screens/MapScreenTest.java
+++ b/tests/src/test/java/net/lapidist/colony/tests/screens/MapScreenTest.java
@@ -131,6 +131,8 @@ public class MapScreenTest {
             Stage stage = extractStage(screen);
             ScreenViewport vp = (ScreenViewport) stage.getViewport();
             assertEquals(1f / settings.getUiScale(), vp.getUnitsPerPixel(), 0f);
+            assertEquals(settings.getUiScale(), stage.getRoot().getScaleX(), 0f);
+            assertEquals(settings.getUiScale(), stage.getRoot().getScaleY(), 0f);
         }
     }
 


### PR DESCRIPTION
## Summary
- keep Stage root scale synced with UI scale on MapScreen
- test UI scale is applied to viewport and root

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685697054c788328813aee0f5da05524